### PR TITLE
fix(KAR-26): add gitleaks scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,18 +3,16 @@
 ---
 name: gitleaks
 run-name: Running gitleaks check
-on:
-  push:
-    branches-ignore:
-      - main
-  pull_request:
-    branches:
-      - main
+# According to the GitHub documentation on Action secrets:
+# "They are not passed to workflows that are triggered by a pull request from a fork."
+# So we can't use pull_requests here since gitleaks needs GITLEAKS_LICENSE.
+on: [push]
 permissions:
   contents: read
   pull-requests: read
 jobs:
   scan:
+    # From https://github.com/gitleaks/gitleaks
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
@@ -25,14 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Testing secrets
-        shell: bash
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
         env:
-          TEST_ENV: ${{ secrets.KUBEARCHIVE_TEST }}
-        run: echo "Testing secrets ${TEST_ENV} (this should display as three stars)"
-#      - name: Run gitleaks
-#        uses: gitleaks/gitleaks-action@v2
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Job triggered by ${{ github.actor }}."
+      - run: echo "Testing secret access ${{ secrets.KUBEARCHIVE_TEST }}."
       - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
       - name: Check out repository code
@@ -29,4 +30,5 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Job triggered by ${{ github.actor }}."
-      - run: echo "Testing secret access ${{ secrets.KUBEARCHIVE_TEST }}."
+      - run: echo "Testing secret access KUBEARCHIVE_TEST ${{ secrets.KUBEARCHIVE_TEST }}."
       - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
       - name: Check out repository code
@@ -31,4 +31,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Testing secrets
         shell: bash
         env:
-          GITLEAKS_LICENSE: ${{ secrets.KUBEARCHIVE_TEST }}
-        run: echo "Testing secrets $KUBEARCHIVE_TEST (this should display as three stars)"
+          TEST_ENV: ${{ secrets.KUBEARCHIVE_TEST }}
+        run: echo "Testing secrets ${TEST_ENV} (this should display as three stars)"
 #      - name: Run gitleaks
 #        uses: gitleaks/gitleaks-action@v2
 #        env:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,11 +8,8 @@ run-name: Running gitleaks check
 # According to the GitHub documentation on Action secrets:
 # "They are not passed to workflows that are triggered by a pull request from a fork."
 # So we can't use pull_requests here since gitleaks needs GITLEAKS_LICENSE.
-# According to the GitHub documentation on pull_request_target,
-# that workflow can access secrets even when it is triggered from a fork.
 on:
-  pull_request_target:
-    types: [opened, edited]
+  push:
   schedule:
     - cron: "15 8 * * 1"  # Run once every Monday at ~8:15AM UTC
 permissions:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,32 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+name: gitleaks
+run-name: Running gitleaks check
+on:
+  push:
+    branches-ignore:
+      - 'main'
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  scan:
+    name: "gitleaks"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Job triggered by ${{ github.actor }}."
+      - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,18 +1,26 @@
 # Copyright KubeArchive Authors
 # SPDX-License-Identifier: Apache-2.0
+#
+# GitLeaks: https://github.com/gitleaks/gitleaks
 ---
 name: gitleaks
 run-name: Running gitleaks check
 # According to the GitHub documentation on Action secrets:
 # "They are not passed to workflows that are triggered by a pull request from a fork."
 # So we can't use pull_requests here since gitleaks needs GITLEAKS_LICENSE.
-on: [push]
+# According to the GitHub documentation on pull_request_target,
+# that workflow can access secrets even when it is triggered from a fork.
+on:
+  pull_request_target:
+    types: [opened, edited]
+  schedule:
+    - cron: "15 8 * * 1"  # Run once every Monday at ~8:15AM UTC
 permissions:
   contents: read
   pull-requests: read
 jobs:
   scan:
-    # From https://github.com/gitleaks/gitleaks
+    # From: https://github.com/marketplace/actions/gitleaks
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
@@ -28,3 +36,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_NOTIFY_USER_LIST: "@beerparty"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,7 +6,7 @@ run-name: Running gitleaks check
 on:
   push:
     branches-ignore:
-      - 'main'
+      - main
   pull_request:
     branches:
       - main
@@ -15,7 +15,7 @@ permissions:
   pull-requests: read
 jobs:
   scan:
-    name: "gitleaks"
+    name: gitleaks
     runs-on: ubuntu-latest
     steps:
       - run: echo "Job triggered by ${{ github.actor }}."
@@ -29,4 +29,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,15 +19,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Job triggered by ${{ github.actor }}."
-      - run: echo "Testing secret access KUBEARCHIVE_TEST ${{ secrets.KUBEARCHIVE_TEST }}."
       - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
       - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      - name: Testing secrets
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_LICENSE: ${{ secrets.KUBEARCHIVE_TEST }}
+        run: echo "Testing secrets $KUBEARCHIVE_TEST (this should display as three stars)"
+#      - name: Run gitleaks
+#        uses: gitleaks/gitleaks-action@v2
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -4,38 +4,41 @@
 name: static_code_analysis
 run-name: Running static code analysis
 on:
-    pull_request:
-        branches:
-            - main
+  push:
+    branches-ignore:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
 permissions:
-    contents: read
-    pull-requests: read
+  contents: read
+  pull-requests: read
 jobs:
-    yamllint:
-        name: "YAML lint"
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo "Job triggered by ${{ github.actor }}."
-            - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
-            - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
-            - name: Check out repository code
-              uses: actions/checkout@v4
-            - name: Run yamllint
-              uses: karancode/yamllint-github-action@master
-              with:
-                  yamllint_strict: false
-                  yamllint_comment: false
-    goftm:
-        name: "Golang format test"
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo "Job triggered by ${{ github.actor }}."
-            - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
-            - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
-            - name: Check out repository code
-              uses: actions/checkout@v4
-            - name: Check Golang formatting (gofmt)
-              uses: Jerome1337/gofmt-action@v1.0.5
-              with:
-                  gofmt-path: '.'
-                  gofmt-flags: '-l -d'
+  yamllint:
+    name: "YAML lint"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Job triggered by ${{ github.actor }}."
+      - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Run yamllint
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_strict: false
+          yamllint_comment: false
+  goftm:
+    name: "Golang format test"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Job triggered by ${{ github.actor }}."
+      - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Check Golang formatting (gofmt)
+        uses: Jerome1337/gofmt-action@v1.0.5
+        with:
+          gofmt-path: '.'
+          gofmt-flags: '-l -d'


### PR DESCRIPTION
We hope to have upstream contributions from developers outside Red Hat. While I will add instructions for setting up open source gitleaks checking to the contributing guide, we need extra protection. So, I added a schedule to ensure that gitleaks runs against the repository regularly. For now, once a week should be sufficient. We can alter the schedule once the pace of development increases.

Signed-off-by: cbeer <cbeer@redhat.com>