### PR TITLE
otel instrumentation only starts when environment variable is set

### DIFF
--- a/charts/kubearchive/templates/_helpers.tpl
+++ b/charts/kubearchive/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Copyright KubeArchive Authors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Create environment variables for OpenTelemetry if .observability is set to true. Otherwise set KUBEARCHIVE_OTEL_ENABLED=false.
+This tells the OpenTelemtry instrumentation if it should start or not.
+*/}}
+{{- define "kubearchive.v1.otel.env" -}}
+{{- if .observability -}}
+- name: KUBEARCHIVE_OTEL_ENABLED
+  value: "true"
+{{- else -}}
+- name: KUBEARCHIVE_OTEL_ENABLED
+  value: "false"
+{{- end -}}
+{{- end -}}

--- a/charts/kubearchive/templates/api_server.yaml
+++ b/charts/kubearchive/templates/api_server.yaml
@@ -22,6 +22,8 @@ spec:
           command: ["./go/bin/dlv"]
           args: ["--listen=:40000", "--headless=true", "--api-version=2", "--log", "exec", "/ko-app/api"]
           {{- end}}
+          env:
+{{ include "kubearchive.v1.otel.env" .Values.apiServer | indent 12 }}
 ---
 kind: Service
 apiVersion: v1

--- a/charts/kubearchive/values.yaml
+++ b/charts/kubearchive/values.yaml
@@ -59,6 +59,8 @@ apiServer:
   # KO_DEFAULTBASEIMAGE=gcr.io/k8s-skaffold/skaffold-debug-support/go:latest ko build --disable-optimizations \
   # github.com/kubearchive/kubearchive/cmd/api
   debug: false
+  # If true, OpenTelemetry instrumention will be enabled for the api server
+  observability: false
 
 # values used to create a sink
 sink:


### PR DESCRIPTION
OpenTelemetry instrumentation will only start if the environment variable `KUBEARCHIVE_OTEL_ENABLED=true`.

closes #36 