### PR TITLE
Fix helm chart to include tokenreview permissions

### DIFF
--- a/DEVELOPER_RESOURCES.md
+++ b/DEVELOPER_RESOURCES.md
@@ -51,4 +51,6 @@ performance and behavior.
 Additional software that KubeArchive uses.
 
 * [Helm - Package Managment for Kubernetes](https://helm.sh/)
+* [Kind - Local Kubernetes Cluster](https://kind.sigs.k8s.io/)
+* [Podman Desktop - Includes Kind](https://podman-desktop.io/)
 

--- a/charts/kubearchive/templates/api_server/role.yaml
+++ b/charts/kubearchive/templates/api_server/role.yaml
@@ -6,7 +6,9 @@ metadata:
 rules:
   - apiGroups:
       - authorization.k8s.io
+      - authentication.k8s.io
     resources:
       - subjectaccessreviews
+      - tokenreviews
     verbs:
       - create

--- a/charts/kubearchive/templates/api_server/role_binding.yaml
+++ b/charts/kubearchive/templates/api_server/role_binding.yaml
@@ -11,3 +11,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ .Values.apiServer.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.apiServer.testSA }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.apiServer.testSA }}
+    namespace: {{ .Values.kubearchive.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/charts/kubearchive/templates/api_server/service_account.yaml
+++ b/charts/kubearchive/templates/api_server/service_account.yaml
@@ -4,3 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.apiServer.name }}
   namespace: {{ .Values.kubearchive.namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.apiServer.testSA }}
+  namespace: {{ .Values.kubearchive.namespace }}

--- a/charts/kubearchive/values.yaml
+++ b/charts/kubearchive/values.yaml
@@ -61,6 +61,7 @@ apiServer:
   debug: false
   # If true, OpenTelemetry instrumention will be enabled for the api server
   observability: false
+  testSA: "kubearchive-test-sa"
 
 # values used to create a sink
 sink:


### PR DESCRIPTION
* Include permissions for the `kubearchive-api-server` service account to create TokenReview objects.
* Include a new service account called `kubearchive-privileged-user` with view permissions
* Update `DEVELOPMENT.md`
