### PR TITLE
add linters to golangci-lint

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -28,17 +28,3 @@ jobs:
         with:
           yamllint_strict: false
           yamllint_comment: false
-  goftm:
-    name: "Golang format test"
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Job triggered by ${{ github.actor }}."
-      - run: echo "Running on a ${{ runner.os }} server hosted by GitHub."
-      - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: Check Golang formatting (gofmt)
-        uses: Jerome1337/gofmt-action@v1.0.5
-        with:
-          gofmt-path: '.'
-          gofmt-flags: '-l -d'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,4 +5,11 @@ run:
   timeout: 10m
 linters:
   enable:
+    - bodyclose
+    - containedctx
+    - fatcontext
+    - gofmt
     - gosec
+    - nilerr
+    - usestdlibvars
+    - wastedassign

--- a/cmd/api/auth/authn_test.go
+++ b/cmd/api/auth/authn_test.go
@@ -97,7 +97,7 @@ func TestAuthentication(t *testing.T) {
 			ftr := &fakeTokenReview{authenticated: tc.authenticated}
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
-			c.Request, _ = http.NewRequest("GET", "/", nil)
+			c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
 			c.Request.Header.Add("Authorization", "Bearer faketoken")
 			Authentication(ftr)(c)
 			assert.Equal(t, tc.expected, res.Code)

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -25,7 +25,7 @@ func TestOtelMiddlewareConfigured(t *testing.T) {
 	server := NewServer(k8sClient)
 	// Get the context for a new response recorder for inspection and set it to the router engine
 	c := gin.CreateTestContextOnly(httptest.NewRecorder(), server.router)
-	c.Request, _ = http.NewRequest("GET", "/", nil)
+	c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
 	server.router.HandleContext(c)
 	// Get the handler names from the context
 	names := c.HandlerNames()
@@ -48,7 +48,7 @@ func TestAuthMiddlewareConfigured(t *testing.T) {
 	server := NewServer(k8sClient)
 	// Make a correct request with an invalid token
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer token")
 	server.router.ServeHTTP(res, req)
 	// Assert unauthenticated request

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -24,7 +24,7 @@ func TestGetAllResources(t *testing.T) {
 	router := setupRouter()
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/apis/stable.example.com/v1/crontabs", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/crontabs", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -34,13 +34,16 @@ func main() {
 			return otelhttp.NewHandler(next, "receive")
 		}),
 	)
+	if err != nil {
+		logger.Fatalf("failed to create HTTP client: %s\n", err.Error())
+	}
 	eventClient, err := cloudevents.NewClient(httpClient, ceClient.WithObservabilityService(ceOtelObs.NewOTelObservabilityService()))
 	if err != nil {
-		logger.Fatalf("failed to create CloudEvents HTTP client: %s", err.Error())
+		logger.Fatalf("failed to create CloudEvents HTTP client: %s\n", err.Error())
 	}
 
 	err = eventClient.StartReceiver(context.Background(), receive)
 	if err != nil {
-		logger.Fatalf("failed to start receiving CloudEvents: %s", err.Error())
+		logger.Fatalf("failed to start receiving CloudEvents: %s\n", err.Error())
 	}
 }


### PR DESCRIPTION
bodyclose       - enforce that http response bodies get closed
containedctx  - enforce that contexts do not get placed as fields in a struct
fatcontext       - enforce that contexts do not get nested in loops
gofmt               - enforce the golang code style
nilerr                - enforce that an error is not returned as nil if the code checks the there error is not actually nil
usestdlibvars  - detect values that can be replaced with vars/consts from go standard library
wastedassign - detect vars that are reassigned and the new value is never used

Also fix code so that it passes all of the lint checks