### PR TITLE
Run helm to generate templated files for yamllint.

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -23,6 +23,13 @@ jobs:
       - run: echo "Branch ${{ github.ref }} of repository ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Install helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: latest
+        id: install
+      - name: Run helm and template locally
+        run: helm template charts/kubearchive/ --output-dir charts/generated
       - name: Run yamllint
         uses: karancode/yamllint-github-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work
 
 # Python environment for yamllint
 venv/
+
+# Helm generated files
+charts/generated/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 extends: default
+ignore:
+  - charts/kubearchive
 rules:
   line-length: disable
   truthy: disable

--- a/charts/kubearchive/templates/api_server/api_server.yaml
+++ b/charts/kubearchive/templates/api_server/api_server.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -14,7 +13,7 @@ spec:
     metadata:
       labels: *labels
     spec:
-      serviceAccountName: {{ .Values.apiServer.serviceAccount }}
+      serviceAccountName: {{ .Values.apiServer.name }}
       volumes:
         - name: tls-secret
           secret:

--- a/charts/kubearchive/templates/api_server_source.yaml
+++ b/charts/kubearchive/templates/api_server_source.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 {{- range .Values.kubearchive.watchNamespaces }}
 ---
 apiVersion: sources.knative.dev/v1

--- a/charts/kubearchive/templates/namespace.yaml
+++ b/charts/kubearchive/templates/namespace.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 ---
 apiVersion: v1
 kind: Namespace

--- a/charts/kubearchive/templates/role.yaml
+++ b/charts/kubearchive/templates/role.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 {{- range .Values.kubearchive.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubearchive/templates/role_binding.yaml
+++ b/charts/kubearchive/templates/role_binding.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 {{- range .Values.kubearchive.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubearchive/templates/service_account.yaml
+++ b/charts/kubearchive/templates/service_account.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/kubearchive/templates/sink/sink.yaml
+++ b/charts/kubearchive/templates/sink/sink.yaml
@@ -1,4 +1,3 @@
-# yamllint disable-file
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Replaces https://github.com/kubearchive/kubearchive/pull/69.