### PR TITLE
create service account for kubearchive-sink

### DIFF
--- a/charts/kubearchive/templates/role.yaml
+++ b/charts/kubearchive/templates/role.yaml
@@ -21,4 +21,26 @@ rules:
       - {{ . }}
     {{- end }}
   {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.sink.name }}
+  namespace: {{ .name }}
+rules:
+  {{- range .role.rules }}
+  - apiGroups:
+    {{- range .apiGroups }}
+      {{- /* quote values in apiGroups so that if empty string is one of the values, helm doesn't remove it */}}
+      - {{ . | quote }}
+    {{- end }}
+    resources:
+    {{- range .resources }}
+      - {{ . }}
+    {{- end }}
+    verbs:
+      - get
+      - list
+      - delete
+  {{- end }}
 {{- end }}

--- a/charts/kubearchive/templates/role_binding.yaml
+++ b/charts/kubearchive/templates/role_binding.yaml
@@ -13,4 +13,18 @@ subjects:
   - kind: ServiceAccount
     name: {{ $.Values.kubearchive.serviceAccount }}
     namespace: {{ .name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.sink.name }}
+  namespace: {{ .name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $.Values.sink.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.sink.name }}
+    namespace: {{ $.Values.kubearchive.namespace }}
 {{- end }}

--- a/charts/kubearchive/templates/sink/service_account.yaml
+++ b/charts/kubearchive/templates/sink/service_account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.sink.name }}
+  namespace: {{ .Values.kubearchive.namespace }}


### PR DESCRIPTION
create a service account for kubearchive-sink. Also create a role and a role and role binding so that the kubearchive-sink service account has permissions to get, list, and delete resources that kubearchive has been configured to archive.

closes #61 