### PR TITLE
Install helm chart in kubearchive namespace

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ Install these tools:
 
 1. Use Helm to install KubeArchive:
    ```bash
-   helm install kubearchive charts/kubearchive -n default \
+   helm install kubearchive charts/kubearchive --create-namespace -n kubearchive \
        --set-string apiServer.image=$(ko build github.com/kubearchive/kubearchive/cmd/api) \
        --set-string sink.image=$(ko build github.com/kubearchive/kubearchive/cmd/sink)
    ```
@@ -57,7 +57,7 @@ Install these tools:
    
 1. List the deployed helm chart
    ```bash
-   helm list -n default  
+   helm list -n kubearchive  
    ```
 
 ## Update KubeArchive
@@ -65,7 +65,7 @@ Install these tools:
 After you make changes to the code use Helm to redeploy KubeArchive:
 
 ```bash
-helm upgrade kubearchive charts/kubearchive -n default \
+helm upgrade kubearchive charts/kubearchive -n kubearchive \
     --set-string apiServer.image=$(ko build github.com/kubearchive/kubearchive/cmd/api) \
     --set-string sink.image=$(ko build github.com/kubearchive/kubearchive/cmd/sink)
 ```
@@ -73,7 +73,7 @@ helm upgrade kubearchive charts/kubearchive -n default \
 ## Uninstall KubeArchive
 
 ```bash
-helm uninstall -n default kubearchive
+helm uninstall -n kubearchive kubearchive
 ```
 
 ## Generate activity on the KubeArchive sink

--- a/charts/kubearchive/templates/api_server/api_server.yaml
+++ b/charts/kubearchive/templates/api_server/api_server.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.apiServer.name }}
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   replicas: 1
   selector:
@@ -36,7 +35,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ .Values.apiServer.name }}
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   selector:
     app: {{ .Values.apiServer.name }}

--- a/charts/kubearchive/templates/api_server/service_account.yaml
+++ b/charts/kubearchive/templates/api_server/service_account.yaml
@@ -3,10 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.apiServer.name }}
-  namespace: {{ .Values.kubearchive.namespace }}
 ---
+# Service account that must only be used for development purposes
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.apiServer.testSA }}
-  namespace: {{ .Values.kubearchive.namespace }}

--- a/charts/kubearchive/templates/certificates.yaml
+++ b/charts/kubearchive/templates/certificates.yaml
@@ -4,7 +4,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kubearchive-ca-issuer
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   selfSigned: {}
 
@@ -13,7 +12,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kubearchive-ca-certificate
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   isCA: true
   commonName: kubearchive-ca-certificate
@@ -31,7 +29,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: kubearchive-cert-issuer
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   ca:
     secretName: kubearchive-ca-secret
@@ -41,7 +38,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "{{ .Values.apiServer.name }}-certificate"
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   isCA: false
   commonName: {{ .Values.apiServer.name }}

--- a/charts/kubearchive/templates/namespace.yaml
+++ b/charts/kubearchive/templates/namespace.yaml
@@ -1,8 +1,3 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.kubearchive.namespace }}
 {{- range .Values.kubearchive.watchNamespaces }}
 {{- if .create }}
 ---

--- a/charts/kubearchive/templates/operator/auth_proxy_service.yaml
+++ b/charts/kubearchive/templates/operator/auth_proxy_service.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/created-by: {{ .Values.kubearchive.namespace }}-operator
     app.kubernetes.io/part-of: {{ .Values.kubearchive.namespace }}-operator
   name: {{ .Values.kubearchive.namespace }}-operator-metrics-service
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   ports:
     - name: https

--- a/charts/kubearchive/templates/operator/leader_election_role.yaml
+++ b/charts/kubearchive/templates/operator/leader_election_role.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/created-by: {{ .Values.kubearchive.namespace }}-operator
     app.kubernetes.io/part-of: {{ .Values.kubearchive.namespace }}-operator
   name: {{ .Values.kubearchive.namespace }}-operator-leader-election
-  namespace: {{ .Values.kubearchive.namespace }}
 rules:
   - apiGroups:
       - ""

--- a/charts/kubearchive/templates/operator/leader_election_role_binding.yaml
+++ b/charts/kubearchive/templates/operator/leader_election_role_binding.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.kubearchive.namespace }}-operator
     app.kubernetes.io/managed-by: kustomize
   name: {{ .Values.kubearchive.namespace }}-operator-leader-election
-  namespace: {{ .Values.kubearchive.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kubearchive/templates/operator/monitor.yaml
+++ b/charts/kubearchive/templates/operator/monitor.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.kubearchive.namespace }}-operator
     app.kubernetes.io/managed-by: kustomize
   name: {{ .Values.kubearchive.namespace }}-operator-metrics-monitor
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   endpoints:
     - path: /metrics

--- a/charts/kubearchive/templates/operator/operator.yaml
+++ b/charts/kubearchive/templates/operator/operator.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.kubearchive.namespace }}-operator
     control-plane: controller-manager
   name: {{ .Values.kubearchive.namespace }}-operator
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/kubearchive/templates/operator/service_account.yaml
+++ b/charts/kubearchive/templates/operator/service_account.yaml
@@ -9,4 +9,3 @@ metadata:
     app.kubernetes.io/created-by: {{ .Values.kubearchive.namespace }}-operator
     app.kubernetes.io/part-of: {{ .Values.kubearchive.namespace }}-operator
   name: {{ .Values.kubearchive.namespace }}-operator
-  namespace: {{ .Values.kubearchive.namespace }}

--- a/charts/kubearchive/templates/service_account.yaml
+++ b/charts/kubearchive/templates/service_account.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.kubearchive.serviceAccount }}
-  namespace: {{ .Values.kubearchive.namespace }}
 {{- range .Values.kubearchive.watchNamespaces }}
 ---
 apiVersion: v1

--- a/charts/kubearchive/templates/sink/service_account.yaml
+++ b/charts/kubearchive/templates/sink/service_account.yaml
@@ -3,4 +3,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.sink.name }}
-  namespace: {{ .Values.kubearchive.namespace }}

--- a/charts/kubearchive/templates/sink/sink.yaml
+++ b/charts/kubearchive/templates/sink/sink.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.sink.name }}
-  namespace: {{ .Values.kubearchive.namespace }}
 spec:
   replicas: {{ .Values.sink.replicas }}
   selector:


### PR DESCRIPTION
Create kubearchive namespace outside of the templates with the `--create-namespace` option.

Remove the namespace of the kubearchive resources as they are going to be installed in the namespace indicated with `-n` option that now is `kubearchive`