### PR TITLE
Apply naming conventions to api resources in Helm chart

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,7 +106,7 @@ By default, KubeArchive listens to `Event`s in the `test` namespace.
 1. On a new terminal, use `curl` or your browser to perform a query:
     ```bash
     curl --cacert ca.crt localhost:8081/apis/apps/v1/deployments \
-    -H "Authorization: Bearer $(kubectl create token kubearchive-test-sa)" \
+    -H "Authorization: Bearer $(kubectl create token kubearchive-test)" \
    https://localhost:8081/apis/apps/v1/deployments
     ```
 

--- a/charts/kubearchive/templates/api_server/api_server.yaml
+++ b/charts/kubearchive/templates/api_server/api_server.yaml
@@ -2,23 +2,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.apiServer.name }}
+  name: {{ tpl .Values.apiServer.name . }}
 spec:
   replicas: 1
   selector:
     matchLabels: &labels
-      app: {{ .Values.apiServer.name}}
+      app: {{ tpl .Values.apiServer.name . }}
   template:
     metadata:
       labels: *labels
     spec:
-      serviceAccountName: {{ .Values.apiServer.name }}
+      serviceAccountName: {{ tpl .Values.apiServer.name . }}
       volumes:
         - name: tls-secret
           secret:
-            secretName: {{ .Values.apiServer.name }}-tls
+            secretName: {{ tpl .Values.apiServer.secret . }}
       containers:
-        - name: {{ .Values.apiServer.name }}
+        - name: {{ tpl .Values.apiServer.name . }}
           image: {{ .Values.apiServer.image }}
           volumeMounts:
             - name: tls-secret
@@ -34,11 +34,11 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.apiServer.name }}
+  name: {{ tpl .Values.apiServer.name . }}
 spec:
   selector:
-    app: {{ .Values.apiServer.name }}
+    app: {{ tpl .Values.apiServer.name . }}
   ports:
     - protocol: TCP
-      port: 8081
-      targetPort: 8081
+      port: {{ .Values.apiServer.port }}
+      targetPort: {{ .Values.apiServer.port }}

--- a/charts/kubearchive/templates/api_server/certificates.yaml
+++ b/charts/kubearchive/templates/api_server/certificates.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ tpl .Values.apiServer.cert . }}"
+spec:
+  isCA: false
+  commonName: {{ tpl .Values.apiServer.name . }}
+  secretName: "{{ tpl .Values.apiServer.secret . }}"
+  duration: 720h  # 30 days
+  renewBefore: 360h  # 15 days
+  subject:
+    organizations:
+      - {{ .Release.Name }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  usages:
+    - digital signature
+    - key encipherment
+  dnsNames:
+    - localhost
+    - {{ tpl .Values.apiServer.name . }}
+    - "{{ tpl .Values.apiServer.name . }}.{{ .Release.Namespace }}.svc"
+  issuerRef:
+    name: {{ .Release.Name }}
+    kind: Issuer
+    group: cert-manager.io

--- a/charts/kubearchive/templates/api_server/role.yaml
+++ b/charts/kubearchive/templates/api_server/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.apiServer.name }}
+  name: {{ tpl .Values.apiServer.name . }}
 rules:
   - apiGroups:
       - authorization.k8s.io

--- a/charts/kubearchive/templates/api_server/role_binding.yaml
+++ b/charts/kubearchive/templates/api_server/role_binding.yaml
@@ -2,24 +2,24 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.apiServer.name }}
+  name: {{ tpl .Values.apiServer.name . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.apiServer.name }}
-    namespace: {{ .Values.kubearchive.namespace }}
+    name: {{ tpl .Values.apiServer.name . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.apiServer.name }}
+  name: {{ tpl .Values.apiServer.name . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.apiServer.testSA }}
+  name: {{ tpl .Values.apiServer.testSA . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.apiServer.testSA }}
-    namespace: {{ .Values.kubearchive.namespace }}
+    name: {{ tpl .Values.apiServer.testSA . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubearchive/templates/api_server/service_account.yaml
+++ b/charts/kubearchive/templates/api_server/service_account.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.apiServer.name }}
+  name: {{ tpl .Values.apiServer.name . }}
 ---
 # Service account that must only be used for development purposes
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.apiServer.testSA }}
+  name: {{ tpl .Values.apiServer.testSA . }}

--- a/charts/kubearchive/templates/certificates.yaml
+++ b/charts/kubearchive/templates/certificates.yaml
@@ -32,32 +32,3 @@ metadata:
 spec:
   ca:
     secretName: kubearchive-ca-secret
-
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: "{{ .Values.apiServer.name }}-certificate"
-spec:
-  isCA: false
-  commonName: {{ .Values.apiServer.name }}
-  secretName: "{{ .Values.apiServer.name }}-tls"
-  duration: 720h  # 30 days
-  renewBefore: 360h  # 15 days
-  subject:
-    organizations:
-      - kubearchive
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-  usages:
-    - digital signature
-    - key encipherment
-  dnsNames:
-    - localhost
-    - {{ .Values.apiServer.name }}
-    - "{{ .Values.apiServer.name }}.{{ .Values.kubearchive.namespace }}.svc"
-  issuerRef:
-    name: kubearchive-cert-issuer
-    kind: Issuer
-    group: cert-manager.io

--- a/charts/kubearchive/values.yaml
+++ b/charts/kubearchive/values.yaml
@@ -47,9 +47,10 @@ kubearchive:
           - apiVersion: v1
             kind: Event
 
+
 # values used to create the api-server
 apiServer:
-  name: "kubearchive-api-server"
+  name: "{{ .Release.Name }}-api-server"
   # NOTE - Helm does not resolve the `ko` path. The path needs to be set on the `helm install` command.
   # For example:
   # helm install -n default <chart-name> charts/kubearchive \
@@ -61,7 +62,11 @@ apiServer:
   debug: false
   # If true, OpenTelemetry instrumention will be enabled for the api server
   observability: false
-  testSA: "kubearchive-test-sa"
+  # NOTE - This resource must include the certificate suffix to work
+  cert: "{{ tpl .Values.apiServer.name . }}-certificate"
+  secret: "{{ tpl .Values.apiServer.name . }}-tls"
+  port: 8081
+  testSA: "{{ .Release.Name }}-test"
 
 # values used to create a sink
 sink:


### PR DESCRIPTION
Apply the following naming conventions to the Helm chart APIServer resources:

- Remove type of the resource from the resources name that included them
- Use the Helm [built-in objects](https://helm.sh/docs/chart_template_guide/builtin_objects/) `Release.Name` and `Release.Namespace` when needed
- Use `tpl` to build variables upon variables and reduce the repeated variables through the chart.

When this PR is accepted I will create GH issues to address the same changes for:
- sink
- kubearchive general resources
- db
- operator

Closes  #90 