### PR TITLE
update renovate configuration

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "15 8 * * 1"  # Run weekly at 8:15 UTC on Monday
+    - cron: "15 8 * * *"  # Run daily at 8:15 UTC
 
 jobs:
   renovate:

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "osvVulnerabilityAlerts": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "osvVulnerabilityAlerts": true
+  "osvVulnerabilityAlerts": true,
+  "semanticCommits": "disabled"
 }


### PR DESCRIPTION
- renovate will check osv.dev for security vulnerabilities 
- renovate will run daily at 8:15 UTC instead of weekly on Monday at 8:15 UTC. By default, renovate will only create 2 PRs at most per run so we will not be overwhelmed with renovate PRs
- renovate will not use sematic commit names in PRs and commits since we're not using them

Resolves #120 
Resolves #131 