### PR TITLE
Get the real plural name from the CRD, rather than blindly appending 's'.

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -115,6 +115,7 @@ func main() {
 	if err = (&controller.KubeArchiveConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeArchiveConfig")
 		os.Exit(1)

--- a/docs/modules/ROOT/pages/configuration/kubearchiveconfig.adoc
+++ b/docs/modules/ROOT/pages/configuration/kubearchiveconfig.adoc
@@ -13,7 +13,7 @@ metadata:
 spec:
   resources:
     - apiVersion: v1
-      kind: Events
+      kind: Event
 ----
 The configuration of `ApiServerSource` is done using the `resources` key of the KubeArchiveConfig custom
 resource. The format of the `resources` key can be found in the `ApiServerSource`


### PR DESCRIPTION
Resolves https://github.com/kubearchive/kubearchive/issues/136.