### PR TITLE
Add required helm kw to api templates

### DIFF
--- a/charts/kubearchive/templates/api_server/api_server.yaml
+++ b/charts/kubearchive/templates/api_server/api_server.yaml
@@ -19,7 +19,7 @@ spec:
             secretName: {{ tpl .Values.apiServer.secret . }}
       containers:
         - name: {{ tpl .Values.apiServer.name . }}
-          image: {{ .Values.apiServer.image }}
+          image: {{ required "An API Server container image is required" .Values.apiServer.image }}
           volumeMounts:
             - name: tls-secret
               readOnly: true
@@ -47,7 +47,7 @@ spec:
             - name: POSTGRES_URL
               value: {{ tpl .Values.database.url . }}
             - name: POSTGRES_PORT
-              value: "{{ .Values.database.service.port }}"
+              value: "{{ required "A Postgres port must be specified" .Values.database.service.port }}"
 {{ include "kubearchive.v1.otel.env" .Values.apiServer | indent 12 }}
 ---
 kind: Service
@@ -59,8 +59,8 @@ spec:
     app: {{ tpl .Values.apiServer.name . }}
   ports:
     - protocol: TCP
-      port: {{ .Values.apiServer.port }}
-      targetPort: {{ .Values.apiServer.port }}
+      port: {{ required "An API Server port must be specified" .Values.apiServer.port }}
+      targetPort: {{ required "An API Server targetPort must be specified" .Values.apiServer.port }}
       name: server
     {{- if .Values.apiServer.debug }}
     - protocol: TCP

--- a/charts/kubearchive/templates/api_server/certificates.yaml
+++ b/charts/kubearchive/templates/api_server/certificates.yaml
@@ -11,7 +11,7 @@ spec:
   renewBefore: 360h  # 15 days
   subject:
     organizations:
-      - {{ .Release.Name }}
+      - {{ required "An organization in the API Server certificate must be specified" .Release.Name }}
   privateKey:
     algorithm: ECDSA
     size: 256


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #91 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

This PR is the first of several that we should create if we agree to go on with the usage of the [required](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-required-function) helm keyword.

The main goal is to prevent introducing typos in the templated variables of the templates in the charts.

The required should be introduced in non-mandatory fields (AFAIK, the only field that files an error with `helm lint --strict` if it's not provided is `.metadata.name`) that don't use `tpl` function. This way we will prevent having empty values after `helm template` by mistake.

With the usage of `tpl` the `required` function is not needed because if the variable to be templated not exist, it files an error.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
