### PR TITLE
sink lets database add created_at and update updated_at timestamps in resource table

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/kubearchive/kubearchive/pkg/models"
 	_ "github.com/lib/pq"
@@ -18,7 +17,7 @@ const (
 	resourceTableName        = "resource"
 	resourcesQuery           = "SELECT data FROM %s WHERE kind=$1 AND api_version=$2"
 	namespacedResourcesQuery = "SELECT data FROM %s WHERE kind=$1 AND api_version=$2 AND namespace=$3"
-	writeResource            = `INSERT INTO %s (uuid, api_version, cluster, cluster_uid, kind, name, namespace, resource_version, created_ts, updated_ts, cluster_deleted_ts, data) Values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) ON CONFLICT(uuid) DO UPDATE SET name=$6, namespace=$7, resource_version=$8, updated_ts=$10, cluster_deleted_ts=$11, data=$12`
+	writeResource            = `INSERT INTO %s (uuid, api_version, cluster, cluster_uid, kind, name, namespace, resource_version, cluster_deleted_ts, data) Values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT(uuid) DO UPDATE SET name=$6, namespace=$7, resource_version=$8, cluster_deleted_ts=$9, data=$10`
 )
 
 type DBInterface interface {
@@ -103,8 +102,6 @@ func (db *Database) WriteResource(ctx context.Context, k8sObj *unstructured.Unst
 		k8sObj.GetName(),
 		k8sObj.GetNamespace(),
 		k8sObj.GetResourceVersion(),
-		models.FormatTimestamp(k8sObj.GetCreationTimestamp().Time),
-		models.FormatTimestamp(time.Now()),
 		models.OptionalTimestamp(k8sObj.GetDeletionTimestamp()),
 		data,
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to #171 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
This PR stops the sink from writing timestamps for `created_at` and `updated_at` so that the database will handle it
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
