### PR TITLE
sink deletes k8s objects when json path returns a value

### DIFF
--- a/charts/kubearchive/templates/sink/sink.yaml
+++ b/charts/kubearchive/templates/sink/sink.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels: *labels
     spec:
+      serviceAccountName: {{ tpl .Values.sink.name . }}
       containers:
         - name: {{ tpl .Values.sink.name . }}
           image: {{ .Values.sink.image }}
@@ -35,6 +36,8 @@ spec:
               value: {{ tpl .Values.database.url . }}
             - name: POSTGRES_PORT
               value: "{{ .Values.database.service.port }}"
+            - name: DELETE_WHEN
+              value: "{{ .Values.sink.deleteWhen }}"
 {{ include "kubearchive.v1.otel.env" .Values.sink | indent 12 }}
 ---
 kind: Service

--- a/charts/kubearchive/values.yaml
+++ b/charts/kubearchive/values.yaml
@@ -48,6 +48,8 @@ sink:
   replicas: 1
   # If true, OpenTelemetry instrumentation will be enabled for the sink
   observability: false
+  # a json path that if it returns a value, will cause the sink to delete the resource
+  deleteWhen: ".status.completionTime"
 
 operator:
   # NOTE - Helm does not resolve the `ko` path. The path needs to be set on the `helm install` command.

--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -183,7 +183,7 @@ func (r *KubeArchiveConfigReconciler) desiredRole(ctx context.Context, kaconfig 
 			rules = append(rules, rbacv1.PolicyRule{
 				APIGroups: []string{apiGroup},
 				Resources: []string{strings.ToLower(gvr.Resource.Resource)},
-				Verbs:     []string{"get", "list", "watch"}})
+				Verbs:     []string{"delete", "get", "list", "watch"}})
 		} else {
 			log.Error(err, "Failed to get GVR for "+resource.APIVersion)
 		}
@@ -244,11 +244,18 @@ func (r *KubeArchiveConfigReconciler) desiredRoleBinding(kaconfig *kubearchivev1
 			Kind:     "Role",
 			Name:     kaconfig.Name,
 		},
-		Subjects: []rbacv1.Subject{{
-			Kind:      "ServiceAccount",
-			Name:      kaconfig.Name,
-			Namespace: kaconfig.Namespace,
-		}},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      kaconfig.Name,
+				Namespace: kaconfig.Namespace,
+			},
+			{
+				Kind:      "ServiceAccount",
+				Name:      "kubearchive-sink",
+				Namespace: "kubearchive",
+			},
+		},
 	}
 
 	if err := ctrl.SetControllerReference(kaconfig, binding, r.Scheme); err != nil {

--- a/cmd/sink/client.go
+++ b/cmd/sink/client.go
@@ -1,0 +1,25 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// returns a dynamic.DynamicClient. This is different than the kubernetes.ClientSet used in the api server and allows the
+// sink to build a GroupVersionResource for a resource on the cluster so that the sink can delete objects of that
+// resource's type
+func GetKubernetesClient() (*dynamic.DynamicClient, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving in-cluster k8s client config: %s", err)
+	}
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Error instantiating k8s from host %s: %s", config.Host, err)
+	}
+	return client, nil
+}

--- a/cmd/sink/jsonPath/jsonPath.go
+++ b/cmd/sink/jsonPath/jsonPath.go
@@ -1,0 +1,74 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+package jsonpath
+
+import (
+	"fmt"
+	"regexp"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// Evaluates the JSON Path, path, against the json, data, using jsonpath from k8s.io/client-go/util and returns a bool
+// representing whether or not the JSON Path exists in data. It expects find only one result. If the evaluation fails,
+// it returns the error
+func PathExists(path string, data map[string]interface{}) (bool, error) {
+	jp := jsonpath.New("Parser")
+	err := jp.Parse(path)
+	if err != nil {
+		return false, err
+	}
+	results, err := jp.FindResults(data)
+	if err != nil {
+		return false, err
+	}
+	if len(results) != 1 || len(results[0]) != 1 {
+		return false, fmt.Errorf("Failed to find a match, expected one result from JSON Path")
+	}
+	return true, nil
+}
+
+// Copied from https://github.com/kubernetes/kubectl/blob/a70106d6a8b4fc24633f7020b9fdc416648e7f22/pkg/cmd/get/customcolumn.go#L38-L67
+// Copyright 2014 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)}$|^\.?([^{}]+)$`)
+
+// relaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
+//   - metadata.name (no leading '.' or curly braces '{...}'
+//   - {metadata.name} (no leading '.')
+//   - .metadata.name (no curly braces '{...}')
+//   - {.metadata.name} (complete expression)
+//
+// And transforms them all into a valid jsonpath expression:
+//
+//	{.metadata.name}
+func RelaxedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -13,22 +13,28 @@ import (
 	ceOtelObs "github.com/cloudevents/sdk-go/observability/opentelemetry/v2/client"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	ceClient "github.com/cloudevents/sdk-go/v2/client"
+	jsonpath "github.com/kubearchive/kubearchive/cmd/sink/jsonPath"
 	"github.com/kubearchive/kubearchive/pkg/database"
 	"github.com/kubearchive/kubearchive/pkg/models"
 	kaObservability "github.com/kubearchive/kubearchive/pkg/observability"
 	_ "github.com/lib/pq"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 )
 
 const (
-	ClusterNameEnvVar = "KUBEARCHIVE_CLUSTER_NAME"
+	DeleteWhenEnvVar = "DELETE_WHEN"
 )
 
 type Sink struct {
 	ClusterName string
 	ClusterUid  string
 	Db          database.DBInterface
+	DeleteWhen  string
 	EventClient ceClient.Client
+	K8sClient   *dynamic.DynamicClient
 	Logger      *log.Logger
 }
 
@@ -55,13 +61,26 @@ func NewSink(db database.DBInterface, logger *log.Logger) *Sink {
 		logger.Fatalf("failed to create CloudEvents HTTP client: %s\n", err.Error())
 	}
 
+	deleteWhen := os.Getenv(DeleteWhenEnvVar)
+	deleteWhen, err = jsonpath.RelaxedJSONPathExpression(deleteWhen)
+	if err != nil {
+		logger.Fatalf("Provided JSON Path %s could not be parsed: %s\n", deleteWhen, err)
+	}
+
+	k8sClient, err := GetKubernetesClient()
+	if err != nil {
+		logger.Fatalln("Could not start a kubernetes client:", err)
+	}
+
 	return &Sink{
 		// TODO: cluster name should be set by the user for multicluster support
 		ClusterName: "",
 		// TODO: clusterUid should be set by the user for multicluster support
 		ClusterUid:  "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		Db:          db,
+		DeleteWhen:  deleteWhen,
 		EventClient: eventClient,
+		K8sClient:   k8sClient,
 		Logger:      logger,
 	}
 }
@@ -84,6 +103,29 @@ func (sink *Sink) Receive(event cloudevents.Event) {
 		return
 	}
 	sink.Logger.Printf("successfully wrote cloudevent %s to the database\n", event.ID())
+	sink.Logger.Printf("checking if resource from cloudevent %s needs to be deleted\n", event.ID())
+	mustDelete, err := jsonpath.PathExists(sink.DeleteWhen, k8sObj.UnstructuredContent())
+	if err != nil {
+		sink.Logger.Printf(
+			"encountered error while evaluating JSON Path %s on cloudevent %s: %s\n",
+			sink.DeleteWhen,
+			event.ID(),
+			err,
+		)
+	}
+	if mustDelete {
+		sink.Logger.Println("attempting to delete kubernetes object:", k8sObj.GetUID())
+		kind := k8sObj.GetObjectKind().GroupVersionKind()
+		resource, _ := meta.UnsafeGuessKindToResource(kind) // we only need the plural resource
+		k8sCtx, k8sCancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer k8sCancel()
+		err = sink.K8sClient.Resource(resource).Namespace(k8sObj.GetNamespace()).Delete(k8sCtx, k8sObj.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			sink.Logger.Printf("could not delete resource %s: %s\n", k8sObj.GetUID(), err)
+			return
+		}
+		sink.Logger.Println("successfully deleted kubernetes object:", k8sObj.GetUID())
+	}
 }
 
 func main() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #191 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The operator grants the sink's ServiceAccount permissions to delete the resource type(s) being watched. When deploying kubearchive, the user can specify a JSON Path that, if it returns a value when applied to a kubernetes object, will cause the sink to delete the kubernetes object from the cluster.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
