### PR TITLE
Enable 'go mod tidy' for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "osvVulnerabilityAlerts": true,
-  "semanticCommits": "disabled"
+  "semanticCommits": "disabled",
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #201 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* The configuration read was from the `main` branch, which did not contain the `goModTidy` option. I had to use the parameter `configurationFile` to make the changes on this branch matter. I removed it after testing because we don't need to specify it.
* This was tested at https://github.com/kubearchive/kubearchive/pull/245 by running manually the Renovate workflow from a branch with these changes.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
