### PR TITLE
sink only attempts to delete a k8s object once

### DIFF
--- a/cmd/sink/events/type.go
+++ b/cmd/sink/events/type.go
@@ -1,0 +1,16 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+const DeleteTypeEventSuffix = ".delete"
+
+func IsDeleteType(event cloudevents.Event) bool {
+	return strings.HasSuffix(event.Type(), DeleteTypeEventSuffix)
+}

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -13,6 +13,7 @@ import (
 	ceOtelObs "github.com/cloudevents/sdk-go/observability/opentelemetry/v2/client"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	ceClient "github.com/cloudevents/sdk-go/v2/client"
+	"github.com/kubearchive/kubearchive/cmd/sink/events"
 	jsonpath "github.com/kubearchive/kubearchive/cmd/sink/jsonPath"
 	"github.com/kubearchive/kubearchive/pkg/database"
 	"github.com/kubearchive/kubearchive/pkg/models"
@@ -104,6 +105,10 @@ func (sink *Sink) Receive(ctx context.Context, event cloudevents.Event) {
 	}
 	sink.Logger.Printf("successfully wrote cloudevent %s to the database\n", event.ID())
 	sink.Logger.Printf("checking if resource from cloudevent %s needs to be deleted\n", event.ID())
+	if events.IsDeleteType(event) {
+		sink.Logger.Printf("resource from cloudevent %s is already deleted\n", event.ID())
+		return
+	}
 	mustDelete, err := jsonpath.PathExists(sink.DeleteWhen, k8sObj.UnstructuredContent())
 	if err != nil {
 		sink.Logger.Printf(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #232 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The sink will stops processing `delete` type cloudevents after its payload is written into the database. Deletion criteria does not need to be checked since the object in the payload of the cloudevent has already been deleted
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
