### PR TITLE
sink does not try to delete k8s objects twice

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,15 +42,29 @@ Install these tools:
     export KO_DOCKER_REPO="kind.local"
     ```
 
-1. Install knative-eventing core and cert-manager and wait for them to be ready:
+1. Install knative-eventing core and cert-manager, wait for them to be ready, and enable new-apiserversource-filters:
     ```bash
     export CERT_MANAGER_VERSION=v1.9.1
-    export KNATIVE_EVENTING_VERSION=v1.14.3
+    export KNATIVE_EVENTING_VERSION=v1.15.0
 
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
     kubectl apply -f https://github.com/knative/eventing/releases/download/knative-${KNATIVE_EVENTING_VERSION}/eventing-core.yaml
     kubectl rollout status deployment --namespace=cert-manager --timeout=30s
     kubectl rollout status deployment --namespace=knative-eventing --timeout=30s
+
+    kubectl apply -f - << EOF
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-features
+      namespace: knative-eventing
+      labels:
+        eventing.knative.dev/release: devel
+        knative.dev/config-propagation: original
+        knative.dev/config-category: eventing
+    data:
+      new-apiserversource-filters: enabled
+    EOF
     ```
 
 1. Generate operator code:

--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -15,6 +15,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
@@ -388,6 +389,11 @@ func (r *KubeArchiveConfigReconciler) desiredA14e(kaconfig *kubearchivev1alpha1.
 						Name:       k9eSinkName,
 						Namespace:  k9eNs,
 					},
+				},
+			},
+			Filters: []eventingv1.SubscriptionsAPIFilter{
+				{
+					CESQL: "type NOT LIKE '%delete'", // a14e SHOULD NOT send delete cloudevents
 				},
 			},
 		},

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -108,17 +108,28 @@ func (sink *Sink) Receive(ctx context.Context, event cloudevents.Event) {
 		)
 	}
 	if mustDelete {
-		sink.Logger.Println("attempting to delete kubernetes object:", k8sObj.GetUID())
+		sink.Logger.Println("requesting to delete kubernetes object:", k8sObj.GetUID())
 		kind := k8sObj.GetObjectKind().GroupVersionKind()
 		resource, _ := meta.UnsafeGuessKindToResource(kind) // we only need the plural resource
 		k8sCtx, k8sCancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer k8sCancel()
 		err = sink.K8sClient.Resource(resource).Namespace(k8sObj.GetNamespace()).Delete(k8sCtx, k8sObj.GetName(), metav1.DeleteOptions{})
 		if err != nil {
-			sink.Logger.Printf("could not delete resource %s: %s\n", k8sObj.GetUID(), err)
+			sink.Logger.Printf("failed to request resource %s be deleted: %s\n", k8sObj.GetUID(), err)
 			return
 		}
-		sink.Logger.Println("successfully deleted kubernetes object:", k8sObj.GetUID())
+		sink.Logger.Printf("successfully requested kubernetes object %s be deleted\n", k8sObj.GetUID())
+		deleteTs := metav1.Now()
+		k8sObj.SetDeletionTimestamp(&deleteTs)
+		sink.Logger.Println("updating cluster_deleted_ts for kubernetes object:", k8sObj.GetUID())
+		updateCtx, updateCancel := context.WithTimeout(context.Background(), time.Second*5)
+		err = sink.Db.WriteResource(updateCtx, k8sObj, event.Data())
+		defer updateCancel()
+		if err != nil {
+			sink.Logger.Println("failed to update cluster_deleted_ts for kubernetes object:", k8sObj.GetUID())
+			return
+		}
+		sink.Logger.Println("updated cluster_deleted_ts for kubernetes object:", k8sObj.GetUID())
 	}
 }
 

--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -4,12 +4,26 @@ set -o errexit
 set -o xtrace
 
 export CERT_MANAGER_VERSION=v1.9.1
-export KNATIVE_EVENTING_VERSION=v1.14.3
+export KNATIVE_EVENTING_VERSION=v1.15.0
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
 kubectl apply -f https://github.com/knative/eventing/releases/download/knative-${KNATIVE_EVENTING_VERSION}/eventing-core.yaml
 kubectl rollout status deployment --namespace=cert-manager --timeout=30s
 kubectl rollout status deployment --namespace=knative-eventing --timeout=30s
+
+kubectl apply -f - << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+data:
+  new-apiserversource-filters: enabled
+EOF
 
 bash cmd/operator/generate.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #232 

The after the sink deletes a kubernetes object, it will update the entry in the database for that resource with timestamp of when the resource was deleted. Bumped the version of knative-eventing to v1.15.0 so that the operator can apply a filter to all ApiServerSources so that they do not send delete type cloudevents.

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
- knative-eventing version bump `v1.14.3` -> `v1.15.0`
- operator applies a filter to ApiServerSources so they do not send `delete` type cloudevents

To test:
- run `hack/quick-install.sh`
- initialize the database
- run `kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`
- run
  ```bash
  kubectl apply -f - << EOF
  ---
  apiVersion: kubearchive.kubearchive.org/v1alpha1
  kind: KubeArchiveConfig
  metadata:
    name: kubearchive
    namespace: demo-tekton
  spec:
    resources:
      - selector:
          apiVersion: tekton.dev/v1beta1
          kind: PipelineRun
        archive-when: .status != 'Completed'
        delete-when: .status == 'Completed'
  ---
  apiVersion: v1
  kind: ServiceAccount
  metadata:
    name: demo-tekton
    namespace: demo-tekton
  ---
  apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRole
  metadata:
    name: pipelineruns-reader
  rules:
  - apiGroups: ["tekton.dev"]
    resources: ["pipelineruns"]
    verbs: ["get", "list"]
  ---
  apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRoleBinding
  metadata:
    name: read-pipelineruns
  subjects:
  - kind: ServiceAccount
    name: demo-tekton
    namespace: demo-tekton
    apiGroup: ""
  roleRef:
    kind: ClusterRole
    name: pipelineruns-reader
    apiGroup: rbac.authorization.k8s.io
  EOF
  ```
- in a separate terminal run `kubectl logs -n kubearchive -l app=kubearchive-sink -f`
- in the first terminal run `kubectl apply -f https://raw.githubusercontent.com/skoved/kubearchive/first-demo/tekton.yaml`

After 10-20 seconds you will see only one log for deleting the PipelineRun and you will see a log after it for updating it in the database after deleting it
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
