### PR TITLE
Sink archives and deletes objects based on CEL expressions

### DIFF
--- a/charts/kubearchive/templates/sink/sink.yaml
+++ b/charts/kubearchive/templates/sink/sink.yaml
@@ -13,9 +13,17 @@ spec:
       labels: *labels
     spec:
       serviceAccountName: {{ tpl .Values.sink.name . }}
+      volumes:
+        - name: sink-filters
+          configMap:
+            name: sink-filters
       containers:
         - name: {{ tpl .Values.sink.name . }}
           image: {{ .Values.sink.image }}
+          volumeMounts:
+            - mountPath: "{{ .Values.sink.mountPath }}"
+              name: "sink-filters"
+              readOnly: true
           env:
             - name: POSTGRES_DB
               valueFrom:
@@ -36,8 +44,8 @@ spec:
               value: {{ tpl .Values.database.url . }}
             - name: POSTGRES_PORT
               value: "{{ .Values.database.service.port }}"
-            - name: DELETE_WHEN
-              value: "{{ .Values.sink.deleteWhen }}"
+            - name: MOUNT_PATH
+              value: "{{ .Values.sink.mountPath }}"
 {{ include "kubearchive.v1.otel.env" .Values.sink | indent 12 }}
 ---
 kind: Service

--- a/charts/kubearchive/values.yaml
+++ b/charts/kubearchive/values.yaml
@@ -48,8 +48,8 @@ sink:
   replicas: 1
   # If true, OpenTelemetry instrumentation will be enabled for the sink
   observability: false
-  # a json path that if it returns a value, will cause the sink to delete the resource
-  deleteWhen: ".status.completionTime"
+  # the path that the sink will mount the KubeArchive ConfigMap
+  mountPath: "/data/sink-filters"
 
 operator:
   # NOTE - Helm does not resolve the `ko` path. The path needs to be set on the `helm install` command.
@@ -62,7 +62,7 @@ operator:
 database:
   # Controls if the database is deployed or not. The secret with the credentials
   # is deployed always, as the sink and the api-server need to connect somewhere.
-  # Provde the proper `url` and credentials if you provide your database
+  # Provide the proper `url` and credentials if you provide your database
   # TODO: set 'enabled' to 'false' when we start distributing the chart for production installation
   enabled: true
 

--- a/cmd/sink/expr/cel.go
+++ b/cmd/sink/expr/cel.go
@@ -1,0 +1,211 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package expr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	celext "github.com/google/cel-go/ext"
+	"github.com/kubearchive/kubearchive/cmd/operator/api/v1alpha1"
+	"github.com/kubearchive/kubearchive/pkg/files"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const globalKey = "_global"
+
+type Filters struct {
+	archive map[string]cel.Program
+	delete  map[string]cel.Program
+}
+
+// Returns a Filters struct with an empty archive and delete slice
+func EmptyFilters() *Filters {
+	return &Filters{
+		archive: make(map[string]cel.Program),
+		delete:  make(map[string]cel.Program),
+	}
+}
+
+// Creates a Filters struct from the path to a directory where a ConfigMap was mounted. If path is empty string or path
+// does not exist, it returns a Filters struct with empty archive and delete slices. It will attempt to create all the
+// cel programs that it can from the ConfigMap. Any errors that are encountered are wrapped together and returned. Even
+// if this function returns an error, the Filters struct returned can still be used and will not be nil.
+func NewFilters(path string) (*Filters, error) {
+	var errList []error
+	filters := &Filters{
+		archive: make(map[string]cel.Program),
+		delete:  make(map[string]cel.Program),
+	}
+	exists, err := files.PathExists(path)
+	if err != nil {
+		return filters, fmt.Errorf("cannot determine if ConfigMap is mounted at path %s: %s", path, err)
+	}
+	if path == "" || !exists {
+		return filters, fmt.Errorf("cannot create Filters. ConfigMap is not mounted at path %s", path)
+	}
+	filterFiles, err := files.DirectoryFiles(path)
+	if err != nil {
+		return filters, fmt.Errorf(
+			"cannot create Filters. Could not read files created from ConfigMap mounted at path %s: %s",
+			path,
+			err,
+		)
+	}
+	for namespace, filePath := range filterFiles {
+		resourcesBytes, err := os.ReadFile(filePath)
+		if err != nil {
+			errList = append(errList, err)
+			continue
+		}
+		resources := []v1alpha1.KubeArchiveConfigResource{}
+		err = yaml.Unmarshal(resourcesBytes, &resources)
+		if err != nil {
+			errList = append(errList, err)
+			continue
+		}
+		for _, resource := range resources {
+			namespaceGvk := NamespaceGroupVersionKind(namespace, resource)
+			archiveExpr, err := CreateCelExpr(resource.ArchiveWhen)
+			if err != nil {
+				errList = append(errList, err)
+			} else {
+				filters.archive[namespaceGvk] = *archiveExpr
+			}
+			deleteExpr, err := CreateCelExpr(resource.DeleteWhen)
+			if err != nil {
+				errList = append(errList, err)
+			} else {
+				filters.delete[namespaceGvk] = *deleteExpr
+			}
+		}
+	}
+
+	return filters, errors.Join(errList...)
+
+}
+
+// Returns whether obj needs to be archived. Obj needs to be archived if any of the cel programs in archive return true
+// or if obj needs to be deleted. If obj is nil, it returns false
+func (f *Filters) MustArchive(ctx context.Context, obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	mustArchive := f.MustDelete(ctx, obj)
+	if mustArchive {
+		return mustArchive
+	}
+	globalGvk := GlobalGroupVersionKind(obj)
+	namespaceGvk := NamespaceGroupVersionKindFromObject(obj)
+	program, exists := f.archive[globalGvk]
+	if exists {
+		mustArchive = executeCel(ctx, program, obj)
+	}
+	if mustArchive {
+		return mustArchive
+	}
+	program, exists = f.archive[namespaceGvk]
+	if exists {
+		mustArchive = executeCel(ctx, program, obj)
+	}
+	return mustArchive
+}
+
+// Returns whether obj needs to be deleted. Obj needs to be deleted if the cel program in delete that matches the
+// NamespaceGroupVersionKind of obj or the cel program for the GlobalGroupVersionKind in delete for obj returns true. If
+// obj is nil, it returns false
+func (f *Filters) MustDelete(ctx context.Context, obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	mustDelete := false
+	globalGvk := GlobalGroupVersionKind(obj)
+	namespaceGvk := NamespaceGroupVersionKindFromObject(obj)
+	program, exists := f.delete[globalGvk]
+	if exists {
+		mustDelete = executeCel(ctx, program, obj)
+	}
+	if mustDelete {
+		return mustDelete
+	}
+	program, exists = f.delete[namespaceGvk]
+	if exists {
+		mustDelete = executeCel(ctx, program, obj)
+	}
+	return mustDelete
+}
+
+// Returns a string that is the form <globalKey>:GroupVersionKind
+func GlobalGroupVersionKind(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ":"
+	}
+	return fmt.Sprintf("%s:%s", globalKey, obj.GetObjectKind().GroupVersionKind())
+}
+
+// Returns a string that is the form <namespace>:GroupVersionKind
+func NamespaceGroupVersionKindFromObject(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ":"
+	}
+	return fmt.Sprintf("%s:%s", obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind())
+}
+
+// Returns a string that is the form <namespace>:GroupVersionKind
+func NamespaceGroupVersionKind(namespace string, resource v1alpha1.KubeArchiveConfigResource) string {
+	gvk := schema.FromAPIVersionAndKind(resource.Selector.APIVersion, resource.Selector.Kind)
+	return fmt.Sprintf("%s:%s", namespace, gvk)
+}
+
+func CreateCelExpr(expr string) (*cel.Program, error) {
+	mapStrDyn := decls.NewMapType(decls.String, decls.Dyn)
+	env, err := cel.NewEnv(
+		celext.Strings(),
+		celext.Encoders(),
+		celext.Sets(),
+		celext.Lists(),
+		celext.Math(),
+		cel.Declarations(
+			decls.NewVar("metadata", mapStrDyn),
+			decls.NewVar("spec", mapStrDyn),
+			decls.NewVar("status", mapStrDyn),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	parsed, issues := env.Parse(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	checked, issues := env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	program, err := env.Program(checked)
+	if err != nil {
+		return nil, err
+	}
+	return &program, err
+}
+
+// executes the cel program with obj as the input. If the program returns and error or if the program returns a value
+// that cannot be converted to bool, false is returned. Otherwise the value returned by the cel program is returned
+func executeCel(ctx context.Context, program cel.Program, obj *unstructured.Unstructured) bool {
+	val, _, err := program.ContextEval(ctx, obj.Object)
+	if err != nil {
+		return false
+	}
+	boolVal, ok := val.Value().(bool)
+	if !ok {
+		return false
+	}
+	return boolVal
+}

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -13,7 +13,7 @@ import (
 	ceOtelObs "github.com/cloudevents/sdk-go/observability/opentelemetry/v2/client"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	ceClient "github.com/cloudevents/sdk-go/v2/client"
-	jsonpath "github.com/kubearchive/kubearchive/cmd/sink/jsonPath"
+	"github.com/kubearchive/kubearchive/cmd/sink/expr"
 	"github.com/kubearchive/kubearchive/pkg/database"
 	"github.com/kubearchive/kubearchive/pkg/models"
 	kaObservability "github.com/kubearchive/kubearchive/pkg/observability"
@@ -25,24 +25,28 @@ import (
 )
 
 const (
-	DeleteWhenEnvVar = "DELETE_WHEN"
+	mountPathEnvVar = "MOUNT_PATH"
 )
 
 type Sink struct {
 	Db          database.DBInterface
-	DeleteWhen  string
 	EventClient ceClient.Client
+	Filters     *expr.Filters
 	K8sClient   *dynamic.DynamicClient
 	Logger      *log.Logger
 }
 
-func NewSink(db database.DBInterface, logger *log.Logger) *Sink {
+func NewSink(db database.DBInterface, logger *log.Logger, filters *expr.Filters) *Sink {
 	if logger == nil {
 		logger = log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds|log.LUTC)
-		logger.Println("sink was provided a nil logger, falling back to defualt logger")
+		logger.Println("sink was provided a nil logger, falling back to default logger")
 	}
 	if db == nil {
 		logger.Fatalln("cannot start sink when db connection is nil")
+	}
+	if filters == nil {
+		logger.Println("sink was provided nil filters. Archive and delete operations will not happen until new filters are provided")
+		filters = expr.EmptyFilters()
 	}
 
 	httpClient, err := cloudevents.NewHTTP(
@@ -59,12 +63,6 @@ func NewSink(db database.DBInterface, logger *log.Logger) *Sink {
 		logger.Fatalf("failed to create CloudEvents HTTP client: %s\n", err.Error())
 	}
 
-	deleteWhen := os.Getenv(DeleteWhenEnvVar)
-	deleteWhen, err = jsonpath.RelaxedJSONPathExpression(deleteWhen)
-	if err != nil {
-		logger.Fatalf("Provided JSON Path %s could not be parsed: %s\n", deleteWhen, err)
-	}
-
 	k8sClient, err := GetKubernetesClient()
 	if err != nil {
 		logger.Fatalln("Could not start a kubernetes client:", err)
@@ -72,8 +70,8 @@ func NewSink(db database.DBInterface, logger *log.Logger) *Sink {
 
 	return &Sink{
 		Db:          db,
-		DeleteWhen:  deleteWhen,
 		EventClient: eventClient,
+		Filters:     filters,
 		K8sClient:   k8sClient,
 		Logger:      logger,
 	}
@@ -87,38 +85,48 @@ func (sink *Sink) Receive(ctx context.Context, event cloudevents.Event) {
 		sink.Logger.Printf("cloudevent %s is malformed and will not be processed: %s\n", event.ID(), err)
 		return
 	}
-	sink.Logger.Printf("cloudevent %s contains all required fields. Attempting to write it to the database\n", event.ID())
+	sink.Logger.Printf(
+		"cloudevent %s contains all required fields. Checking its object %s needs to be archived\n",
+		event.ID(),
+		k8sObj.GetUID(),
+	)
+	if !sink.Filters.MustArchive(ctx, k8sObj) {
+		sink.Logger.Printf("object %s from cloudevent %s does not need to be archived\n", k8sObj.GetUID(), event.ID())
+		return
+	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-	sink.Logger.Printf("writing resource from cloudevent %s into the database\n", event.ID())
+	sink.Logger.Printf("writing object %s from cloudevent %s into the database\n", k8sObj.GetUID(), event.ID())
 	err = sink.Db.WriteResource(ctx, k8sObj, event.Data())
 	defer cancel()
 	if err != nil {
-		sink.Logger.Printf("failed to write cloudevent %s to the database: %s\n", event.ID(), err)
-		return
-	}
-	sink.Logger.Printf("successfully wrote cloudevent %s to the database\n", event.ID())
-	sink.Logger.Printf("checking if resource from cloudevent %s needs to be deleted\n", event.ID())
-	mustDelete, err := jsonpath.PathExists(sink.DeleteWhen, k8sObj.UnstructuredContent())
-	if err != nil {
 		sink.Logger.Printf(
-			"encountered error while evaluating JSON Path %s on cloudevent %s: %s\n",
-			sink.DeleteWhen,
+			"failed to write object %s from cloudevent %s to the database: %s\n",
+			k8sObj.GetUID(),
 			event.ID(),
 			err,
 		)
+		return
 	}
-	if mustDelete {
+	sink.Logger.Printf("successfully wrote object %s cloudevent %s to the database\n", k8sObj.GetUID(), event.ID())
+	sink.Logger.Printf("checking if object %s from cloudevent %s needs to be deleted\n", k8sObj.GetUID(), event.ID())
+	if sink.Filters.MustDelete(ctx, k8sObj) {
 		sink.Logger.Println("attempting to delete kubernetes object:", k8sObj.GetUID())
 		kind := k8sObj.GetObjectKind().GroupVersionKind()
 		resource, _ := meta.UnsafeGuessKindToResource(kind) // we only need the plural resource
 		k8sCtx, k8sCancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer k8sCancel()
-		err = sink.K8sClient.Resource(resource).Namespace(k8sObj.GetNamespace()).Delete(k8sCtx, k8sObj.GetName(), metav1.DeleteOptions{})
+		err = sink.K8sClient.Resource(resource).Namespace(k8sObj.GetNamespace()).Delete(
+			k8sCtx,
+			k8sObj.GetName(),
+			metav1.DeleteOptions{},
+		)
 		if err != nil {
-			sink.Logger.Printf("could not delete resource %s: %s\n", k8sObj.GetUID(), err)
+			sink.Logger.Printf("could not delete object %s: %s\n", k8sObj.GetUID(), err)
 			return
 		}
 		sink.Logger.Println("successfully deleted kubernetes object:", k8sObj.GetUID())
+	} else {
+		sink.Logger.Printf("object %s from cloudevent %s does not need to be deleted\n", k8sObj.GetUID(), event.ID())
 	}
 }
 
@@ -132,7 +140,14 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Could not connect to the database: %s\n", err)
 	}
-	sink := NewSink(db, logger)
+	filters, err := expr.NewFilters(os.Getenv(mountPathEnvVar))
+	if err != nil {
+		log.Printf(
+			"Not all filters could be created from the ConfigMap. Some archive and delete operations will not execute until the errors are resolved: %s\n",
+			err,
+		)
+	}
+	sink := NewSink(db, logger, filters)
 	err = sink.EventClient.StartReceiver(context.Background(), sink.Receive)
 	if err != nil {
 		logger.Fatalf("failed to start receiving CloudEvents: %s\n", err.Error())

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.15.2
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/gin-gonic/gin v1.10.0
+	github.com/google/cel-go v0.20.1
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.19.1
 	github.com/onsi/gomega v1.34.0
@@ -33,6 +34,7 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/bytedance/sonic v1.11.9 // indirect
@@ -97,6 +99,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	go.opencensus.io v0.24.0 // indirect
@@ -106,7 +109,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
+	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8V
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -190,6 +192,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/cel-go v0.20.1 h1:nDx9r8S3L4pE61eDdt8igGj8rf5kjYR3ILxWIpWNi84=
+github.com/google/cel-go v0.20.1/go.mod h1:kWcIzTsPX0zmQ+H3TirHstLLf9ep5QTsZBN9u4dOYLg=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -360,6 +364,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/sqs/goreturns v0.0.0-20181028201513-538ac6014518/go.mod h1:CKI4AZ4XmGV240rTHfO0hfE83S6/a3/Q1siZJ/vXf7A=
+github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
+github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -368,6 +374,7 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -443,8 +450,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
+golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/files/read.go
+++ b/pkg/files/read.go
@@ -1,0 +1,41 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package files
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Determines if path exists in the file system. Returns true if the path exists. Returns false if the path does not
+// exist. Returns error if a file system error other than os.ErrNotExist occurs
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+// Returns map representing all non directory files in path. The key is the file name and value is the path to the file.
+// It does not search for files in sub directories
+func DirectoryFiles(path string) (map[string]string, error) {
+	dirFiles := make(map[string]string)
+	dir, err := os.ReadDir(path)
+	if err != nil {
+		return dirFiles, err
+	}
+	for _, file := range dir {
+		if file.IsDir() || strings.HasPrefix(file.Name(), "..") {
+			continue
+		}
+		dirFiles[file.Name()] = fmt.Sprintf("%s/%s", path, file.Name())
+	}
+	return dirFiles, nil
+}


### PR DESCRIPTION
Sink archives and deletes resources on the cluster depending on if they
cause a cel expression to return to true. The cel expressions that are run
depend on the namespace and apiVersion of the k8s object

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Resolves #238

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
- Sink creates cel expressions from the `sink-filters` ConfigMap that is managed by the operator
- Sink mounts the ConfigMap so that every key-value pair in the ConfigMap's data becomes a file that will be updated if the ConfigMap changes
- Sink can handle invalid cel expressions. If one or more cel expressions are not valid the sink will log the error and skip the expression
- The sink can handle the mounted ConfigMap files being unreadable with out crashing
- The sink can handle the ConfigMap not being mounted without crashing

WIP:
- Updating the cel expressions when the ConfigMap changes

**Important**: If you test this change, you will see the following error in the sink logs

```bash
ERROR: <input>:1:9: found no matching overload for '_==_' applied to '(map(string, dyn), string)'
| .status == 'Completed'
| ........^
```

This is a bug in the operator code. I created #285 to fix it. This error does not impact the operation of the sink

To test:

- install KubeArchive following instructions in DEVELOPMENT.md including initializing the database
- run `kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml`
- run `kubectl create ns demo-tekton`
- run

```bash
kc apply -f - << EOF
---
apiVersion: kubearchive.kubearchive.org/v1alpha1
kind: KubeArchiveConfig
metadata:
  name: kubearchive
  namespace: demo-tekton
spec:
  resources:
    - selector:
        apiVersion: tekton.dev/v1beta1
        kind: PipelineRun
      archive-when: .status.startTime != ''
      delete-when: .status.completionTime != ''
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: demo-tekton
  namespace: demo-tekton
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: pipelineruns-reader
rules:
- apiGroups: ["tekton.dev"]
  resources: ["pipelineruns"]
  verbs: ["get", "list"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: read-pipelineruns
subjects:
- kind: ServiceAccount
  name: demo-tekton
  namespace: demo-tekton
  apiGroup: ""
roleRef:
  kind: ClusterRole
  name: pipelineruns-reader
  apiGroup: rbac.authorization.k8s.io
EOF
```

- run `kubectl get -n kubearchive pods` and copy the name of the `kubearchive-sink` pod
- run `kubectl delete pod -n kubearchive <kubearchive-sink pod> (this is needed because the sink won't create new filters when the ConfigMap updates
- in a separate terminal run `kubectl logs -n kubearchive -l app=kubearchive-sink -f
- in the first terminal run `kubectl apply -f https://raw.githubusercontent.com/skoved/kubearchive/first-demo/tekton.yaml`
- run `kubectl apply -f https://raw.githubusercontent.com/skoved/kubearchive/first-demo/tekton.yaml`

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
