### PR TITLE
First approach adding splunk testing environment

### DIFF
--- a/charts/kubearchive/templates/logging_systems/splunk.yaml
+++ b/charts/kubearchive/templates/logging_systems/splunk.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: splunk
+  namespace: kubearchive
+  labels:
+    app: splunk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: splunk
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        app: splunk
+    spec:
+      containers:
+        - name: splunk
+          image: splunk/splunk:latest
+          env:
+            - name: SPLUNK_START_ARGS
+              value: "--accept-license"
+            - name: SPLUNK_PASSWORD
+              value: "Admin123!"
+          ports:
+            - name: splunk-api
+              containerPort: 8089
+              protocol: TCP
+            - name: splunk-web
+              containerPort: 8000
+              protocol: TCP
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: splunk
+  namespace: kubearchive
+spec:
+  selector:
+    app: splunk
+  ports:
+    - protocol: TCP
+      port: 8089
+      targetPort: 8089
+      name: api
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+      name: web
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: random-logger
+  namespace: kubearchive
+spec:
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+  containers:
+    - name: splunk-uf
+      image: splunk/universalforwarder:latest
+      env:
+        - name: SPLUNK_START_ARGS
+          value: --accept-license
+        - name: SPLUNK_USER
+          value: root
+        - name: SPLUNK_GROUP
+          value: root
+        - name: SPLUNK_PASSWORD
+          value: "Admin123!"
+        - name: SPLUNK_CMD
+          value: add monitor /var/log/
+        - name: SPLUNK_STANDALONE_URL
+          value: splunk.kubearchive.svc.cluster.local:8089
+      volumeMounts:
+        - name: shared-data
+          mountPath: /var/log
+    - name: random-logger
+      image: chentex/random-logger:latest
+      volumeMounts:
+        - name: shared-data
+          mountPath: /app/logs/
+  volumes:
+    - name: shared-data
+      emptyDir: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Related to #189 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

I didn't manage to get Splunk working for a test environment.

This is something to share the progress I made as of now.

After some investigation and the lack of experience with Splunk architecture this is what I found:

### Splunk components:

* Forwarder - in charge of collecting the logs and forwarding them to the Indexer. I tried to deploy one as a sidecar
using the [universal-forwarder docker image](https://hub.docker.com/r/splunk/universalforwarder) and a [random-logger docker image](https://hub.docker.com/r/chentex/random-logger) based on [this example](https://splunk.github.io/docker-splunk/EXAMPLES.html#create-sidecar-root-forwarder) of the documentation. I think this element is similar to fluentd.
* Indexer - process the logs received and store them in the different indexes. There isn't an indexer in this PR.
* Server - provides a GUI and a search engine to allow the user to retrieve the logs. This is deployed in this PR with the [splunk docker image](https://hub.docker.com/r/splunk/splunk) and it's working:
** `kubectl apply -f charts/kubearchive/templates/logging_systems/splunk.yaml`
** `kubectl port-forward -n kubearchive svc/splunk 8000:8000`
** Access localhost:8000 with the credentials: admin/Admin123!
** Go to the search application, you can see some internal logs with `index="_*"`

### Splunk deployments:

I tried to make some sense of the [Splunk for docker](https://docs.splunk.com/Documentation/Splunk/9.3.0/Installation/DeployandrunSplunkEnterpriseinsideDockercontainers) to deploy the simplest thing in kubernetes, but I am missing some parts that I'm not sure how to fill. I based this
trial on [this example I found](https://medium.com/@swarupdonepudi/setup-splunk-on-kubernetes-94716dab0e9) but
there isn't a lot of information about it.

There is also [this open-source Kubernetes operator](https://splunk.github.io/splunk-operator/) that is meant to deploy Splunk in a cluster but it seemed a little more cumbersome to start with.

I am also not sure of how the licenses come into play. I am aware that [free licenses](https://docs.splunk.com/Documentation/Splunk/9.2.2/Admin/MoreaboutSplunkFree) are available for a limited functionality but not sure of how to configure them.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
