### PR TITLE
Operator creates invalid cel expressions in KubeArchiveConfig.

### DIFF
--- a/charts/kubearchive/templates/test/kac.yaml
+++ b/charts/kubearchive/templates/test/kac.yaml
@@ -9,5 +9,5 @@ spec:
     - selector:
         apiVersion: v1
         kind: Event
-      archiveWhen: .status != 'Completed'
-      deleteWhen: .status == 'Completed'
+      archiveWhen: status.state != 'Completed'
+      deleteWhen: status.state == 'Completed'

--- a/docs/modules/ROOT/pages/configuration/kubearchiveconfig.adoc
+++ b/docs/modules/ROOT/pages/configuration/kubearchiveconfig.adoc
@@ -15,8 +15,8 @@ spec:
     - selector:
         apiVersion: v1
         kind: Event
-      archiveWhen: .status != 'Completed'
-      deleteWhen: .status == 'Completed'
+      archiveWhen: status.state != 'Completed'
+      deleteWhen: status.state == 'Completed'
 ----
 The configuration of `ApiServerSource` is done using the `selector` keys of the KubeArchiveConfig custom
 resource. The format of the `selectors` key can be found in the `ApiServerSource`

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -87,8 +87,8 @@ spec:
     - selector:
         apiVersion: v1
         kind: Event
-      archiveWhen: .status != 'Completed'
-      deleteWhen: .status == 'Completed'
+      archiveWhen: status.state != 'Completed'
+      deleteWhen: status.state == 'Completed'
 `, namespaceName)
 
 	// create the test namespace and KubeArchiveConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Resolves #285

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
