### PR TITLE
Fix envvar for cache expiration

### DIFF
--- a/charts/kubearchive/templates/api_server/api_server.yaml
+++ b/charts/kubearchive/templates/api_server/api_server.yaml
@@ -45,9 +45,9 @@ spec:
             - name: POSTGRES_PORT
               value: "{{ required "A Postgres port must be specified" .Values.database.service.port }}"
             {{- include "kubearchive.v1.otel.env" . | nindent 12 }}
-            - name: CACHE_EXPIRATION_AUTHENTICATED
+            - name: CACHE_EXPIRATION_AUTHORIZED
               value: "{{ .Values.apiServer.cache.expirationAuthenticated }}"
-            - name: CACHE_EXPIRATION_UNAUTHENTICATED
+            - name: CACHE_EXPIRATION_UNAUTHORIZED
               value: "{{ .Values.apiServer.cache.expirationUnauthenticated }}"
 ---
 kind: Service

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -85,17 +85,17 @@ func main() {
 		log.Printf("Could not start opentelemetry: %s", err)
 	}
 
-	db, err := database.NewDatabase()
-	if err != nil {
-		log.Fatalf("Could not connect to database: %s", err)
-	}
-	controller := routers.Controller{Database: db}
-
 	cacheExpirations, err := getCacheExpirations()
 	if err != nil {
 		log.Fatal(err)
 	}
 	cache := cache.New()
+
+	db, err := database.NewDatabase()
+	if err != nil {
+		log.Fatalf("Could not connect to database: %s", err)
+	}
+	controller := routers.Controller{Database: db}
 
 	server := NewServer(getKubernetesClient(), controller, cache, cacheExpirations)
 	err = server.router.RunTLS("localhost:8081", "/etc/kubearchive/ssl/tls.crt", "/etc/kubearchive/ssl/tls.key")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Solves a bug introduced in #340 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* The first test that makes sure that every deployment was OK was too fast, as well as the `rollout status` that happens on the `hack/quick-install.sh` script. This is why this could pass CI.
* I put the cache environment variables get operator before the database, so it crashes before it starts with the retries that connect to the database. I think the retries to the database make the Deployment seem OK, then crash when it connected and got to the cache configuration.
* Also introduced a check for the retry on the integration test, because the general error was not being checked.
* I think these problems will be mitigated by #305

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
