### PR TITLE
reuse context when setting timeouts

### DIFF
--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -117,7 +117,7 @@ func (sink *Sink) Receive(ctx context.Context, event cloudevents.Event) {
 		sink.Logger.Println("Attempting to delete kubernetes object:", k8sObj.GetUID())
 		kind := k8sObj.GetObjectKind().GroupVersionKind()
 		resource, _ := meta.UnsafeGuessKindToResource(kind) // we only need the plural resource
-		k8sCtx, k8sCancel := context.WithTimeout(context.Background(), time.Second*5)
+		k8sCtx, k8sCancel := context.WithTimeout(ctx, time.Second*5)
 		defer k8sCancel()
 		err = sink.K8sClient.Resource(resource).Namespace(k8sObj.GetNamespace()).Delete(
 			k8sCtx,
@@ -132,7 +132,7 @@ func (sink *Sink) Receive(ctx context.Context, event cloudevents.Event) {
 		deleteTs := metav1.Now()
 		k8sObj.SetDeletionTimestamp(&deleteTs)
 		sink.Logger.Println("Updating cluster_deleted_ts for kubernetes object:", k8sObj.GetUID())
-		updateCtx, updateCancel := context.WithTimeout(context.Background(), time.Second*5)
+		updateCtx, updateCancel := context.WithTimeout(ctx, time.Second*5)
 		err = sink.Db.WriteResource(updateCtx, k8sObj, event.Data())
 		defer updateCancel()
 		if err != nil {


### PR DESCRIPTION
pass ctx to context.WithTimeout so that when the sink creates otel spans, they look right

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Resolves #301 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
