### PR TITLE
Fix POSTGRES_URL env value in helm chart templates

### DIFF
--- a/charts/kubearchive/templates/_helpers.tpl
+++ b/charts/kubearchive/templates/_helpers.tpl
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0
 {{- define "kubearchive.v1.database.env" -}}
 {{- $enabled := .Values.database.enabled -}}
 {{- if $enabled -}}
-POSTGRES_URL: {{ .Values.database.url | b64enc | quote }}
+POSTGRES_URL: {{ tpl .Values.database.url . | b64enc | quote }}
 POSTGRES_DB: {{ .Values.database.postgresData.dbName | b64enc | quote }}
 POSTGRES_USER: {{ .Values.database.postgresData.dbUser | b64enc | quote }}
 POSTGRES_PASSWORD: {{ .Values.database.postgresData.dbPassword | b64enc | quote }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Fixes
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Fixes #", use "Related to #"

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Resolves #388

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
