### PR TITLE
Introduce telemetry modes

### DIFF
--- a/charts/kubearchive/templates/_helpers.tpl
+++ b/charts/kubearchive/templates/_helpers.tpl
@@ -14,8 +14,8 @@ SPDX-License-Identifier: Apache-2.0
     {{- $endpoint = tpl "http://otel-collector.{{ .Release.Namespace }}.svc.cluster.local:4318" . -}}
 {{- end -}}
 
-- name: KUBEARCHIVE_OTEL_ENABLED
-  value: '{{ ternary "false" "true" (eq $endpoint "") }}'
+- name: KUBEARCHIVE_OTEL_MODE
+  value: '{{ ternary "disabled" "enabled" (eq $endpoint "") }}'
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   value: "{{ $endpoint }}"
 {{- end -}}

--- a/docs/modules/ROOT/pages/configuration/enable-observability.adoc
+++ b/docs/modules/ROOT/pages/configuration/enable-observability.adoc
@@ -4,8 +4,13 @@ KubeArchive is instrumented to emit observability data, specifically metrics and
 traces. This can be enabled and configured with two environment
 variables present on all of the KubeArchive components:
 
-* `KUBEARCHIVE_OTEL_ENABLED`: one of "true" or "false". Defaults to "false". It
-   controls if observability data is sent to `OTEL_EXPORTER_OTLP_ENDPOINT`.
+* `KUBEARCHIVE_OTEL_MODE`: one of "enabled", "delegated" or "disabled". Defaults to
+an "disabled". It controls when observability data is sent to `OTEL_EXPORTER_OTLP_ENDPOINT`:
+** "disabled": do not send traces or metrics.
+** "enabled": always send traces and metrics. Useful for observability in development.
+** "delegated": always send metrics but send traces only when the incoming request sent its traces (see
+link:https://www.w3.org/TR/trace-context-2/#sampled-flag[W3 Trace Context `sampled` flag]).
+Useful for observability in production.
 * `OTEL_EXPORTER_OTLP_ENDPOINT`: an OTLP compatible endpoint where traces are
     sent. By default it is set to an empty string.
 
@@ -26,8 +31,8 @@ spec:
       containers:
         - name: kubearchive-api-server
           env:
-            - name: KUBEARCHIVE_OTEL_ENABLED
-              value: "true"
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: "delegated"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-collector.observability.svc.cluster.local:4318"
 ----
@@ -45,8 +50,8 @@ spec:
       containers:
         - name: kubearchive-sink
           env:
-            - name: KUBEARCHIVE_OTEL_ENABLED
-              value: "true"
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: "delegated"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-collector.observability.svc.cluster.local:4318"
 ----
@@ -64,8 +69,8 @@ spec:
       containers:
         - name: manager
           env:
-            - name: KUBEARCHIVE_OTEL_ENABLED
-              value: "true"
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: "delegated"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://traces-collector.observability.svc.cluster.local:4318"
 ----


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #233 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Now KubeArchive supports different telemetry modes of operation using `KUBEARCHIVE_OTEL_MODE`. This variable replaced `KUBEARCHIVE_OTEL_ENABLED`.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
