### PR TITLE
sink can archive objects when they are deleted

### DIFF
--- a/cmd/sink/filters/filters.go
+++ b/cmd/sink/filters/filters.go
@@ -31,25 +31,28 @@ var ErrNoGlobal = errors.New("no global expressions exist")
 
 type Filters struct {
 	*sync.RWMutex
-	archive map[NamespaceGroupVersionKind]cel.Program
-	delete  map[NamespaceGroupVersionKind]cel.Program
-	path    string
+	archive         map[NamespaceGroupVersionKind]cel.Program
+	delete          map[NamespaceGroupVersionKind]cel.Program
+	archiveOnDelete map[NamespaceGroupVersionKind]cel.Program
+	path            string
 }
 
-// EmptyFilters returns a Filters struct with an empty archive and delete slice.
+// EmptyFilters returns a Filters struct with an empty archive, delete, and archiveOnDelete slices.
 func EmptyFilters() *Filters {
 	return &Filters{
-		RWMutex: &sync.RWMutex{},
-		archive: make(map[NamespaceGroupVersionKind]cel.Program),
-		delete:  make(map[NamespaceGroupVersionKind]cel.Program),
-		path:    os.Getenv(mountPathEnvVar),
+		RWMutex:         &sync.RWMutex{},
+		archive:         make(map[NamespaceGroupVersionKind]cel.Program),
+		delete:          make(map[NamespaceGroupVersionKind]cel.Program),
+		archiveOnDelete: make(map[NamespaceGroupVersionKind]cel.Program),
+		path:            os.Getenv(mountPathEnvVar),
 	}
 }
 
 // NewFilters creates a Filters struct from the path to a directory where a ConfigMap was mounted. If path is empty
-// string or path does not exist, it returns a Filters struct with empty archive and delete slices. It will attempt to
-// create all the cel programs that it can from the ConfigMap. Any errors that are encountered are wrapped together and
-// returned. Even if this function returns an error, the Filters struct returned can still be used and will not be nil.
+// string or path does not exist, it returns a Filters struct with empty archive, delete, and archiveOnDelete slices. It
+// will attempt to create all the cel programs that it can from the ConfigMap. Any errors that are encountered are
+// wrapped together and returned. Even if this function returns an error, the Filters struct returned can still be used
+// and will not be nil.
 func NewFilters() (*Filters, error) {
 	var errList []error
 	filters := EmptyFilters()
@@ -68,49 +71,56 @@ func NewFilters() (*Filters, error) {
 			err,
 		)
 	}
-	globalArchive, globalDelete, err := getGlobalCelExprs(filterFiles)
+	globalArchive, globalDelete, globalArchiveOnDelete, err := getGlobalCelExprs(filterFiles)
 	// We don't need to report an error if no global filters were provided
 	if err != nil && !errors.Is(err, ErrNoGlobal) {
 		errList = append(errList, err)
 	}
-	errList = append(errList, filters.changeGlobalFilters(filterFiles, globalArchive, globalDelete))
+	errList = append(errList, filters.changeGlobalFilters(filterFiles, globalArchive, globalDelete, globalArchiveOnDelete))
 
 	return filters, errors.Join(errList...)
 }
 
-// getGlobalCelExprs returns a two maps that both have GroupVersionKind strings as keys and cel expression strings as
-// values. The first map is archive cel expressions and the second map is delete cel expressions. If no global file
-// exists, it returns ErrNoGlobal. Otherwise it will return any error it encounters trying to read the global file or
-// trying to yaml.Unmarshal the global file into a []KubeArchiveConfigResources.
-func getGlobalCelExprs(filterFiles map[string]string) (map[string]string, map[string]string, error) {
+// getGlobalCelExprs returns three maps that have GroupVersionKind strings as keys and cel expression strings as values.
+// The first map is archive cel expressions, the second map is delete cel expressions, and the third map is archive on
+// delete cel expression. If no global file exists, it returns ErrNoGlobal. Otherwise it will return any error it
+// encounters trying to read the global file or trying to yaml.Unmarshal the global file into a
+// []KubeArchiveConfigResources.
+func getGlobalCelExprs(filterFiles map[string]string) (map[string]string, map[string]string, map[string]string, error) {
 	archiveExprs := make(map[string]string)
 	deleteExprs := make(map[string]string)
+	archiveOnDelete := make(map[string]string)
 	globalFile, exists := filterFiles[globalKey]
 	if !exists {
-		return archiveExprs, deleteExprs, ErrNoGlobal
+		return archiveExprs, deleteExprs, archiveOnDelete, ErrNoGlobal
 	}
 	resources, err := kubearchiveapi.LoadFromFile(globalFile)
 	if err != nil {
-		return archiveExprs, deleteExprs, err
+		return archiveExprs, deleteExprs, archiveOnDelete, err
 	}
 	for _, resource := range resources {
 		gvk := schema.FromAPIVersionAndKind(resource.Selector.APIVersion, resource.Selector.Kind)
 		archiveExprs[gvk.String()] = resource.ArchiveWhen
 		deleteExprs[gvk.String()] = resource.DeleteWhen
+		archiveOnDelete[gvk.String()] = resource.ArchiveOnDelete
 	}
-	return archiveExprs, deleteExprs, nil
+	return archiveExprs, deleteExprs, archiveOnDelete, nil
 }
 
 // changeGlobalFilters must be called when global filters for f have changed. This includes when f is first created.
-func (f *Filters) changeGlobalFilters(filterFiles, globalArchive, globalDelete map[string]string) error {
+func (f *Filters) changeGlobalFilters(
+	filterFiles, globalArchive, globalDelete, globalArchiveOnDelete map[string]string,
+) error {
 	errList := []error{}
 	delete(filterFiles, globalKey)
 	archiveMap := make(map[NamespaceGroupVersionKind]cel.Program)
 	deleteMap := make(map[NamespaceGroupVersionKind]cel.Program)
+	archiveOnDeleteMap := make(map[NamespaceGroupVersionKind]cel.Program)
 	for namespace, filePath := range filterFiles {
-		nsArchive, nsDelete, err := f.createFilters(namespace, filePath, globalArchive, globalDelete)
+		nsArchive, nsDelete, nsArchiveOnDelete, err := f.createFilters(namespace, filePath, globalArchive, globalDelete, globalArchiveOnDelete)
 		maps.Copy(archiveMap, nsArchive)
 		maps.Copy(deleteMap, nsDelete)
+		maps.Copy(archiveOnDeleteMap, nsArchiveOnDelete)
 		if err != nil {
 			errList = append(errList, err)
 		}
@@ -123,71 +133,101 @@ func (f *Filters) changeGlobalFilters(filterFiles, globalArchive, globalDelete m
 	return err
 }
 
-// createNamespaceFilters creates archive and delete filters for namespace from the KubeArchiveConfigResource stored in file. It
-// tries to create all the filters it can even if it encounters errors. Any errors encountered are wrapped together and
-// returned. createNamespaceFilters should only be called when no filters have been created for namespace. That case is
-// handled by updateNamespaceFilters.
-func (f *Filters) createNamespaceFilters(namespace, file string, globalArchive, globalDelete map[string]string) error {
-	namespaceArchive, namespaceDelete, err := f.createFilters(namespace, file, globalArchive, globalDelete)
+// createNamespaceFilters creates archive, delete, and archiveOnDelete filters for namespace from the
+// KubeArchiveConfigResource stored in file. It tries to create all the filters it can even if it encounters errors. Any
+// errors encountered are wrapped together and returned. createNamespaceFilters should only be called when no filters
+// have been created for namespace. That case is handled by updateNamespaceFilters.
+func (f *Filters) createNamespaceFilters(
+	namespace, file string,
+	globalArchive, globalDelete, globalArchiveOnDelete map[string]string,
+) error {
+	namespaceArchive, namespaceDelete, namespaceArchiveOnDelete, err := f.createFilters(
+		namespace, file, globalArchive, globalDelete, globalArchiveOnDelete,
+	)
 	f.Lock()
 	defer f.Unlock()
-	f.insertFilters(namespaceArchive, namespaceDelete)
+	f.insertFilters(namespaceArchive, namespaceDelete, namespaceArchiveOnDelete)
 	return err
 }
 
-// createFilters returns two maps representing all of the filters for namespace from created by compiling cel
-// expressions from file with matching cel expressions based on GroupVersionKind from globalArchive and globalDelete.
-// The first returned map represents the filters for archiving and the second returned map represents the filters for
-// deleting. createFilters wraps all errors it encounters while creating filters and returns the wrapped error. Even if
-// the returned error is not nil, the maps returned can still be used.
+// createFilters returns three maps representing all of the filters for namespace created by compiling cel expressions
+// from file with matching cel expressions based on GroupVersionKind from globalArchive, globalDelete, and
+// globalArchiveOnDelete. The first returned map represents the filters for archiving, the second returned map
+// represents the filters for deleting, and the third map represents the filters for archiving on delete. createFilters
+// wraps all errors it encounters while creating filters and returns the wrapped error. Even if the returned error is
+// not nil, the maps returned can still be used.
 func (f *Filters) createFilters(
-	namespace string,
-	file string,
-	globalArchive, globalDelete map[string]string,
-) (map[NamespaceGroupVersionKind]cel.Program, map[NamespaceGroupVersionKind]cel.Program, error) {
+	namespace, file string,
+	globalArchive, globalDelete, globalArchiveOnDelete map[string]string,
+) (
+	map[NamespaceGroupVersionKind]cel.Program,
+	map[NamespaceGroupVersionKind]cel.Program,
+	map[NamespaceGroupVersionKind]cel.Program,
+	error,
+) {
 	archiveMap := make(map[NamespaceGroupVersionKind]cel.Program)
 	deleteMap := make(map[NamespaceGroupVersionKind]cel.Program)
+	archiveOnDeleteMap := make(map[NamespaceGroupVersionKind]cel.Program)
 	resources, err := kubearchiveapi.LoadFromFile(file)
 	if err != nil {
-		return archiveMap, deleteMap, err
+		return archiveMap, deleteMap, archiveOnDeleteMap, err
 	}
 	var errList []error
 	for _, resource := range resources {
 		gvk := schema.FromAPIVersionAndKind(resource.Selector.APIVersion, resource.Selector.Kind)
 		namespaceGvk := NamespaceGVKFromNamespaceAndGvk(namespace, gvk)
-		archiveExpr, err := ocel.CreateCelExprOr(resource.ArchiveWhen, globalArchive[gvk.String()])
-		if err != nil {
-			errList = append(errList, err)
-		} else {
-			archiveMap[namespaceGvk] = *archiveExpr
+		if resource.ArchiveWhen != "" {
+			archiveExpr, err := ocel.CreateCelExprOr(resource.ArchiveWhen, globalArchive[gvk.String()])
+			if err != nil {
+				errList = append(errList, err)
+			} else {
+				archiveMap[namespaceGvk] = *archiveExpr
+			}
 		}
-		deleteExpr, err := ocel.CreateCelExprOr(resource.DeleteWhen, globalDelete[gvk.String()])
-		if err != nil {
-			errList = append(errList, err)
-		} else {
-			deleteMap[namespaceGvk] = *deleteExpr
+		if resource.DeleteWhen != "" {
+			deleteExpr, err := ocel.CreateCelExprOr(resource.DeleteWhen, globalDelete[gvk.String()])
+			if err != nil {
+				errList = append(errList, err)
+			} else {
+				deleteMap[namespaceGvk] = *deleteExpr
+			}
+		}
+		if resource.ArchiveOnDelete != "" {
+			archiveOnDeleteExpr, err := ocel.CreateCelExprOr(resource.ArchiveOnDelete, globalArchiveOnDelete[gvk.String()])
+			if err != nil {
+				errList = append(errList, err)
+			} else {
+				archiveOnDeleteMap[namespaceGvk] = *archiveOnDeleteExpr
+			}
 		}
 	}
-	return archiveMap, deleteMap, errors.Join(errList...)
+	return archiveMap, deleteMap, archiveOnDeleteMap, errors.Join(errList...)
 }
 
 // updateNamespaceFilters updates the cel filters for namespace, from file. It differs from createNamespaceFilters by
 // deleting all filters for namespace before inserting the new ones.
-func (f *Filters) updateNamespaceFilters(namespace, file string, globalArchive, globalDelete map[string]string) error {
-	namespaceArchive, namespaceDelete, err := f.createFilters(namespace, file, globalArchive, globalDelete)
+func (f *Filters) updateNamespaceFilters(
+	namespace, file string,
+	globalArchive, globalDelete, globalArchiveOnDelete map[string]string,
+) error {
+	namespaceArchive, namespaceDelete, namespaceArchiveOnDelete, err := f.createFilters(namespace, file, globalArchive, globalDelete, globalArchiveOnDelete)
 	matcher := NamespaceMatcherFromNamespace(namespace)
 	f.Lock()
 	defer f.Unlock()
 	f.deleteFiltersWithMatcher(matcher)
-	f.insertFilters(namespaceArchive, namespaceDelete)
+	f.insertFilters(namespaceArchive, namespaceDelete, namespaceArchiveOnDelete)
 	return err
 }
 
-// insertFilters copies filters from insertArchive into archive and copies insertDelete into delete. insertFilters
-// does not call Lock() or Unlock() so this must be done by the method that calls it.
-func (f *Filters) insertFilters(insertArchive, insertDelete map[NamespaceGroupVersionKind]cel.Program) {
+// insertFilters copies filters from insertArchive into archive, copies insertDelete into delete, and copies
+// insertArchiveOnDelete into archiveOnDelete. insertFilters does not call Lock() or Unlock() so this must be done by
+// the method that calls it.
+func (f *Filters) insertFilters(
+	insertArchive, insertDelete, insertArchiveOnDelete map[NamespaceGroupVersionKind]cel.Program,
+) {
 	maps.Copy(f.archive, insertArchive)
 	maps.Copy(f.delete, insertDelete)
+	maps.Copy(f.archiveOnDelete, insertArchiveOnDelete)
 }
 
 // deleteNamespaceFilters deletes all filters for namespace.
@@ -203,9 +243,10 @@ func (f *Filters) deleteNamespaceFilters(namespace string) {
 func (f *Filters) deleteFiltersWithMatcher(matcher NamespaceMatcher) {
 	maps.DeleteFunc(f.archive, matcher)
 	maps.DeleteFunc(f.delete, matcher)
+	maps.DeleteFunc(f.archiveOnDelete, matcher)
 }
 
-// Update updates the archive and delete filters when a ConfigMap file changes.
+// Update updates the archive, delete, and archiveOnDelete filters when a ConfigMap file changes.
 func (f *Filters) Update(watcher *fsnotify.Watcher) {
 	logger := log.New(os.Stderr, "", log.LstdFlags|log.Lmicroseconds|log.LUTC)
 	for {
@@ -238,14 +279,14 @@ func (f *Filters) handleFsEvent(logger *log.Logger, event fsnotify.Event) {
 			logger.Printf("Could not get all files in directory %s: %s\n", dir, err)
 			break
 		}
-		globalArchive, globalDelete, err := getGlobalCelExprs(filePaths)
+		globalArchive, globalDelete, globalArchiveOnDelete, err := getGlobalCelExprs(filePaths)
 		if err != nil && !errors.Is(err, ErrNoGlobal) {
 			logger.Println("Could not read global filters:", err)
 			break
 		}
 		if fileName == globalKey {
 			logger.Println("Creating global filters")
-			err = f.changeGlobalFilters(filePaths, globalArchive, globalDelete)
+			err = f.changeGlobalFilters(filePaths, globalArchive, globalDelete, globalArchiveOnDelete)
 			if err != nil {
 				logger.Println("Problem creating global filters:", err)
 			}
@@ -254,9 +295,9 @@ func (f *Filters) handleFsEvent(logger *log.Logger, event fsnotify.Event) {
 		}
 		logger.Println("Creating filters for namespace:", fileName)
 		if event.Has(fsnotify.Write) {
-			err = f.updateNamespaceFilters(fileName, event.Name, globalArchive, globalDelete)
+			err = f.updateNamespaceFilters(fileName, event.Name, globalArchive, globalDelete, globalArchiveOnDelete)
 		} else {
-			err = f.createNamespaceFilters(fileName, event.Name, globalArchive, globalDelete)
+			err = f.createNamespaceFilters(fileName, event.Name, globalArchive, globalDelete, globalArchiveOnDelete)
 		}
 		if err != nil {
 			logger.Printf("Problem creating filters for namespace %s: %s\n", fileName, err)
@@ -279,7 +320,8 @@ func (f *Filters) handleFsEvent(logger *log.Logger, event fsnotify.Event) {
 			}
 			globalArchive := make(map[string]string)
 			globalDelete := make(map[string]string)
-			err = f.changeGlobalFilters(filePaths, globalArchive, globalDelete)
+			globalArchiveOnDelete := make(map[string]string)
+			err = f.changeGlobalFilters(filePaths, globalArchive, globalDelete, globalArchiveOnDelete)
 			if err != nil {
 				logger.Println("Problem removing global filters:", err)
 				break
@@ -329,6 +371,19 @@ func (f *Filters) mustDelete(ctx context.Context, obj *unstructured.Unstructured
 	}
 	ngvk := NamespaceGVKFromObject(obj)
 	program, exists := f.delete[ngvk]
+	return exists && ocel.ExecuteCel(ctx, program, obj)
+}
+
+// MustArchiveOnDelete returns whether obj needs to be archived if it was already deleted. Obj need to be archived if
+// any of the cel programs in archiveOnDelete return true. If obj is nil, it returns false.
+func (f *Filters) MustArchiveOnDelete(ctx context.Context, obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	f.RLock()
+	defer f.RUnlock()
+	ngvk := NamespaceGVKFromObject(obj)
+	program, exists := f.archiveOnDelete[ngvk]
 	return exists && ocel.ExecuteCel(ctx, program, obj)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #337 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The sink now checks if the received cloudevent's type is 'delete'. If it is, the sink checks if the object contained in the cloudevent meets the criteria for archiveOnDelete. If the object meets that criteria, the object is written to the database. If the object does not meet the criteria, the sink ignores the message. If the cloudevent's type is not 'delete', the sink handles the cloudevent normally.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
