### PR TITLE
Cache discovery endpoint calls

### DIFF
--- a/cmd/api/discovery/apiresources.go
+++ b/cmd/api/discovery/apiresources.go
@@ -1,23 +1,37 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/kubearchive/kubearchive/cmd/api/abort"
+	"github.com/kubearchive/kubearchive/pkg/cache"
 )
+
+// Arbitrary time for cache, probably enough to not overload the Kubernetes API
+var cacheExpirationTime = 10 * time.Minute
 
 // GetAPIResource set apiResource attribute in the context based on the path parameters group version and resourceType
 //
 // This function relied on the DiscoveryClient's ServerResourcesForGroupVersion function. However it does not accept a context
 // so we had to implement the same call to be able to pass the context so telemetry traces are tied together
 // @rh-hemartin opened a ticket to allow for a context on that function, see https://github.com/kubernetes/client-go/issues/1370
-func GetAPIResource(client rest.Interface) gin.HandlerFunc {
+// The client-go discovery package offers cache implementations however our cache implementation is simpler.
+func GetAPIResource(client rest.Interface, cache *cache.Cache) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		resourceName := c.Param("resourceType")
+		kind := cache.Get(resourceName)
+		if kind != nil {
+			c.Set("apiResourceKind", kind)
+			return
+		}
+
 		discoveryURL := getDiscoveryURL(c.Param("group"), c.Param("version"))
 		result := client.Get().AbsPath(discoveryURL).Do(c.Request.Context())
 
@@ -35,10 +49,10 @@ func GetAPIResource(client rest.Interface) gin.HandlerFunc {
 			return
 		}
 
-		resourceName := c.Param("resourceType")
 		for _, resource := range resources.APIResources {
 			if resource.Name == resourceName {
-				c.Set("apiResource", resource)
+				cache.Set(resourceName, resource.Kind, cacheExpirationTime)
+				c.Set("apiResourceKind", resource.Kind)
 				return
 			}
 		}
@@ -46,6 +60,15 @@ func GetAPIResource(client rest.Interface) gin.HandlerFunc {
 			fmt.Sprintf("Unable to find the API resource %s in the Kubernetes cluster", resourceName),
 			http.StatusBadRequest)
 	}
+}
+
+func GetAPIResourceKind(context *gin.Context) (string, error) {
+	kind := context.GetString("apiResourceKind")
+	if kind == "" {
+		return "", errors.New("API resource not found")
+	}
+
+	return kind, nil
 }
 
 func getDiscoveryURL(group, version string) string {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -55,7 +55,6 @@ func getKubernetesClient() *kubernetes.Clientset {
 }
 
 func NewServer(k8sClient kubernetes.Interface, controller routers.Controller, cache *cache.Cache, cacheExpirations *routers.CacheExpirations) *Server {
-
 	router := gin.Default()
 	router.Use(otelgin.Middleware("")) // Empty string so the library sets the proper server
 
@@ -68,7 +67,7 @@ func NewServer(k8sClient kubernetes.Interface, controller routers.Controller, ca
 		group.Use(auth.RBACAuthorization(k8sClient.AuthorizationV1().SubjectAccessReviews(), cache, cacheExpirations.Authorized, cacheExpirations.Unauthorized))
 		// TODO - Probably want to use cache for the discovery client
 		// See https://pkg.go.dev/k8s.io/client-go/discovery/cached/disk#NewCachedDiscoveryClientForConfig
-		group.Use(discovery.GetAPIResource(k8sClient.Discovery().RESTClient()))
+		group.Use(discovery.GetAPIResource(k8sClient.Discovery().RESTClient(), cache))
 	}
 
 	router.GET("/livez", controller.Livez)

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -4,18 +4,15 @@
 package routers
 
 import (
-	"errors"
-	"fmt"
+	"net/http"
 	"os"
 	"time"
 
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/abort"
+	"github.com/kubearchive/kubearchive/cmd/api/discovery"
 	"github.com/kubearchive/kubearchive/pkg/database"
 	"github.com/kubearchive/kubearchive/pkg/observability"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -46,7 +43,7 @@ func (c *Controller) GetAllResources(context *gin.Context) {
 	group := context.Param("group")
 	version := context.Param("version")
 
-	kind, err := getAPIResourceKind(context)
+	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
@@ -66,7 +63,7 @@ func (c *Controller) GetNamespacedResources(context *gin.Context) {
 	version := context.Param("version")
 	namespace := context.Param("namespace")
 
-	kind, err := getAPIResourceKind(context)
+	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
@@ -84,7 +81,7 @@ func (c *Controller) GetNamespacedResources(context *gin.Context) {
 func (c *Controller) GetAllCoreResources(context *gin.Context) {
 	version := context.Param("version")
 
-	kind, err := getAPIResourceKind(context)
+	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
@@ -103,7 +100,7 @@ func (c *Controller) GetNamespacedCoreResources(context *gin.Context) {
 	version := context.Param("version")
 	namespace := context.Param("namespace")
 
-	kind, err := getAPIResourceKind(context)
+	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
@@ -120,7 +117,6 @@ func (c *Controller) GetNamespacedCoreResources(context *gin.Context) {
 
 // Livez returns current server configuration as we don't have a clear deadlock indicator
 func (c *Controller) Livez(context *gin.Context) {
-
 	observabilityConfig := os.Getenv(observability.OtelStartEnvVar)
 	if observabilityConfig == "" {
 		observabilityConfig = "disabled"
@@ -144,18 +140,6 @@ func (c *Controller) Readyz(context *gin.Context) {
 		return
 	}
 	context.JSON(http.StatusOK, gin.H{"message": "ready"})
-}
-
-func getAPIResourceKind(context *gin.Context) (string, error) {
-	resource, ok := context.Get("apiResource")
-	if !ok {
-		return "", errors.New("API resource not found")
-	}
-	apiResource, ok := resource.(metav1.APIResource)
-	if !ok {
-		return "", fmt.Errorf("unexpected API resource type, in context: %T", resource)
-	}
-	return apiResource.Kind, nil
 }
 
 // NewList creates a new List struct with apiVersion "v1",

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kubearchive/kubearchive/pkg/database"
@@ -22,29 +21,15 @@ import (
 var testResources = fake.CreateTestResources()
 var nonCoreResources = testResources[:1]
 var coreResources = testResources[1:2]
-var testCoreAPIResource = metav1.APIResource{
-	Kind:         "Pod",
-	Name:         "pods",
-	Version:      "v1",
-	SingularName: "pod",
-	Namespaced:   true,
-}
-var testNonCoreAPIResource = metav1.APIResource{
-	Kind:         "Crontab",
-	Name:         "crontabs",
-	Group:        "stable.example.com",
-	Version:      "v1",
-	SingularName: "crontab",
-	Namespaced:   true}
 
 func setupRouter(db database.DBInterface, core bool) *gin.Engine {
 	router := gin.Default()
 	ctrl := Controller{Database: db}
 	router.Use(func(c *gin.Context) {
 		if core {
-			c.Set("apiResource", testCoreAPIResource)
+			c.Set("apiResourceKind", "Pod")
 		} else {
-			c.Set("apiResource", testNonCoreAPIResource)
+			c.Set("apiResourceKind", "Crontab")
 		}
 	})
 	router.GET("/apis/:group/:version/:resourceType", ctrl.GetAllResources)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #195 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* Changed `apiResource` to `apiResourceKind` and store just the string, there is no need to pass around the object and then reserializing it just to get the `Kind`.
* Moved `getApiResourceKind` to the `discovery` package so its closer to its counterpart (that sets the context property).

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
