### PR TITLE
Add pagination support

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/auth"
 	"github.com/kubearchive/kubearchive/cmd/api/discovery"
+	"github.com/kubearchive/kubearchive/cmd/api/pagination"
 	"github.com/kubearchive/kubearchive/cmd/api/routers"
 	"github.com/kubearchive/kubearchive/pkg/cache"
 	"github.com/kubearchive/kubearchive/pkg/database"
@@ -71,6 +72,7 @@ func NewServer(k8sClient kubernetes.Interface, controller routers.Controller, ca
 		// TODO - Probably want to use cache for the discovery client
 		// See https://pkg.go.dev/k8s.io/client-go/discovery/cached/disk#NewCachedDiscoveryClientForConfig
 		group.Use(discovery.GetAPIResource(k8sClient.Discovery().RESTClient(), cache))
+		group.Use(pagination.Middleware())
 	}
 
 	router.GET("/livez", controller.Livez)

--- a/cmd/api/pagination/pagination.go
+++ b/cmd/api/pagination/pagination.go
@@ -1,0 +1,117 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pagination
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/kubearchive/kubearchive/cmd/api/abort"
+)
+
+const (
+	limitKey        = "limit"
+	continueKey     = "continue"
+	continueDateKey = "continueDate"
+	continueUUIDKey = "continueUUID"
+	defaultLimit    = "100"
+	maxAllowedLimit = 1000
+)
+
+// GetValuesFromContext is a helper function for routes to retrieve the
+// information needed. This is kept here so its close to the function
+// that sets these values in the context (Middleware)
+func GetValuesFromContext(context *gin.Context) (string, string, string) {
+	return context.GetString(limitKey), context.GetString(continueUUIDKey), context.GetString(continueDateKey)
+}
+
+func CreateToken(uuid, date string) string {
+	// The date is returned as a quoted string, so remove the quotes
+	date = strings.TrimPrefix(date, "\"")
+	date = strings.TrimSuffix(date, "\"")
+	tokenString := fmt.Sprintf("%s %s", uuid, date)
+	return base64.StdEncoding.EncodeToString([]byte(tokenString))
+}
+
+// Middleware validates the `limit` and `continue` query parameters
+// and populates `limit` and `continueValue` in the context with their
+// respective values so they are retrieved by the endpoints that need it
+func Middleware() gin.HandlerFunc {
+	return func(context *gin.Context) {
+		limitString := context.Query(limitKey)
+		continueToken := context.Query(continueKey)
+
+		var limit string
+		if limitString == "" {
+			// If not specified, we set a limit so users don't retrieve
+			// large collections by mistake. Those collections could
+			// make us crash if they are too large
+			limit = defaultLimit
+		} else {
+			var err error
+			limitInteger, err := strconv.Atoi(limitString)
+			if err != nil {
+				abort.Abort(context, fmt.Sprintf("limit '%s' could not be converted to integer", limitString), http.StatusBadRequest)
+				return
+			}
+
+			if limitInteger > maxAllowedLimit {
+				abort.Abort(context, fmt.Sprintf("limit '%s' exceeds the maximum allowed '%d'", limitString, maxAllowedLimit), http.StatusBadRequest)
+				return
+			}
+
+			// We reserialize to avoid SQL injection. There is the possibility the
+			// value is a valid integer, but in SQL does something else.
+			limit = strconv.Itoa(limitInteger)
+		}
+
+		var continueDate string
+		var continueUUID string
+		if continueToken != "" {
+			continueBytes, err := base64.StdEncoding.DecodeString(continueToken)
+			if err != nil {
+				abort.Abort(context, "could not decode the continuation token", http.StatusBadRequest)
+				return
+			}
+
+			continueParts := strings.Split(string(continueBytes), " ")
+			if len(continueParts) != 2 {
+				abort.Abort(context, "expected two elements on the continue token, received a different amount", http.StatusBadRequest)
+				return
+			}
+
+			continueUUID = continueParts[0]
+			err = uuid.Validate(continueUUID)
+			if err != nil {
+				abort.Abort(context, "first element of the continue token is not a valid UUID", http.StatusBadRequest)
+				return
+			}
+
+			continueDate = continueParts[1]
+			continueTimestamp, err := time.Parse(time.RFC3339, continueDate)
+			if err != nil {
+				log.Printf("Error: %s", err)
+				abort.Abort(context, fmt.Sprintf("continuation token decoded value '%s' is not valid. It should match '%s'", continueDate, time.RFC3339), http.StatusBadRequest)
+				return
+			}
+
+			// We reserialize to avoid SQL injection. There is the possibility the
+			// value is a valid date, but in SQL does something else.
+			continueDate = continueTimestamp.Format(time.RFC3339)
+		}
+
+		// Pass the values using the context, these should be retrieved
+		// using `GetValuesFromContext`
+		context.Set(limitKey, limit)
+		context.Set(continueDateKey, continueDate)
+		context.Set(continueUUIDKey, continueUUID)
+	}
+}

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -53,7 +53,7 @@ func TestGetAllResources(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&resources); err != nil {
 		t.Fail()
 	}
-	assert.Equal(t, NewList(nonCoreResources), resources)
+	assert.Equal(t, NewList(nonCoreResources, ""), resources)
 }
 
 func TestGetNamespacedResources(t *testing.T) {
@@ -68,7 +68,7 @@ func TestGetNamespacedResources(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&resources); err != nil {
 		t.Fail()
 	}
-	assert.Equal(t, NewList(nonCoreResources), resources)
+	assert.Equal(t, NewList(nonCoreResources, ""), resources)
 }
 
 func TestGetNamespacedResourcesByName(t *testing.T) {
@@ -98,7 +98,7 @@ func TestGetResourcesEmpty(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&resources); err != nil {
 		t.Fail()
 	}
-	assert.Equal(t, NewList(nil), resources)
+	assert.Equal(t, NewList(nil, ""), resources)
 }
 
 func TestGetAllCoreResources(t *testing.T) {
@@ -113,7 +113,7 @@ func TestGetAllCoreResources(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&resources); err != nil {
 		t.Fail()
 	}
-	assert.Equal(t, NewList(coreResources), resources)
+	assert.Equal(t, NewList(coreResources, ""), resources)
 }
 
 func TestGetCoreNamespacedResources(t *testing.T) {
@@ -128,7 +128,7 @@ func TestGetCoreNamespacedResources(t *testing.T) {
 	if err := json.NewDecoder(res.Body).Decode(&resources); err != nil {
 		t.Fail()
 	}
-	assert.Equal(t, NewList(coreResources), resources)
+	assert.Equal(t, NewList(coreResources, ""), resources)
 }
 
 func TestGetCoreNamespacedResourcesByName(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/cel-go v0.21.0
+	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
@@ -86,7 +87,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240827171923-fa2c70bbbfe5 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/integrations/database/postgresql/kubearchive.sql
+++ b/integrations/database/postgresql/kubearchive.sql
@@ -119,6 +119,11 @@ CREATE INDEX idx_json_labels ON public.resource USING gin ((((data -> 'metadata'
 
 CREATE INDEX idx_json_owners ON public.resource USING gin ((((data -> 'metadata'::text) -> 'ownerReferences'::text)) jsonb_path_ops);
 
+--
+-- Name: idx_json_creation_timestamp; Type: INDEX; Schema: public; Owner: kubearchive
+--
+
+CREATE INDEX idx_creation_timestamp ON public.resource USING gin ((((data -> 'metadata'::text) -> 'creationTimestamp'::text)) jsonb_path_ops);
 
 --
 -- Name: log_url_uuid_idx; Type: INDEX; Schema: public; Owner: kubearchive

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +29,7 @@ const (
 	testPodResource     = `{"kind": "Pod", "apiVersion": "v1", "spec": {"volumes": [{"name": "otel-config", "configMap": {"name": "otel-collector-config", "items": [{"key": "otelcol.yaml", "path": "otelcol.yaml"}], "optional": true, "defaultMode": 420}}, {"name": "kube-api-access-njsk9", "projected": {"sources": [{"serviceAccountToken": {"path": "token", "expirationSeconds": 3607}}, {"configMap": {"name": "kube-root-ca.crt", "items": [{"key": "ca.crt", "path": "ca.crt"}]}}, {"downwardAPI": {"items": [{"path": "namespace", "fieldRef": {"fieldPath": "metadata.namespace", "apiVersion": "v1"}}]}}, {"configMap": {"name": "openshift-service-ca.crt", "items": [{"key": "service-ca.crt", "path": "service-ca.crt"}]}}], "defaultMode": 420}}], "nodeName": "ip-10-30-218-170.ec2.internal", "priority": 0, "dnsPolicy": "ClusterFirst", "containers": [{"args": ["--config=/etc/otel/otelcol.yaml"], "name": "test-pod", "image": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib@sha256:1720f9ce46441e0bb6e4b9ac448c476a950db0767fe774bb73877ecd46017dd7", "ports": [{"protocol": "TCP", "containerPort": 4317}, {"protocol": "TCP", "containerPort": 8889}], "resources": {"limits": {"cpu": "1", "memory": "2Gi"}, "requests": {"cpu": "200m", "memory": "100Mi"}}, "volumeMounts": [{"name": "otel-config", "subPath": "otelcol.yaml", "readOnly": true, "mountPath": "/etc/otel/otelcol.yaml"}, {"name": "kube-api-access-njsk9", "readOnly": true, "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"}], "livenessProbe": {"httpGet": {"path": "/", "port": 13133, "scheme": "HTTP"}, "periodSeconds": 10, "timeoutSeconds": 30, "failureThreshold": 30, "successThreshold": 1, "initialDelaySeconds": 1800}, "readinessProbe": {"httpGet": {"path": "/", "port": 13133, "scheme": "HTTP"}, "periodSeconds": 10, "timeoutSeconds": 30, "failureThreshold": 300, "successThreshold": 1, "initialDelaySeconds": 300}, "imagePullPolicy": "IfNotPresent", "securityContext": {"runAsUser": 1000930000, "capabilities": {"drop": ["ALL"]}, "runAsNonRoot": true, "allowPrivilegeEscalation": false}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File"}], "tolerations": [{"key": "node.kubernetes.io/not-ready", "effect": "NoExecute", "operator": "Exists", "tolerationSeconds": 300}, {"key": "node.kubernetes.io/unreachable", "effect": "NoExecute", "operator": "Exists", "tolerationSeconds": 300}, {"key": "node.kubernetes.io/memory-pressure", "effect": "NoSchedule", "operator": "Exists"}], "restartPolicy": "Always", "schedulerName": "default-scheduler", "serviceAccount": "default", "securityContext": {"fsGroup": 1000930000, "seLinuxOptions": {"level": "s0:c31,c0"}, "seccompProfile": {"type": "RuntimeDefault"}}, "imagePullSecrets": [{"name": "cpaas-container-registries"}, {"name": "default-dockercfg-rhb7z"}], "preemptionPolicy": "PreemptLowerPriority", "enableServiceLinks": true, "serviceAccountName": "default", "terminationGracePeriodSeconds": 30}, "status": {"phase": "Running", "podIP": "10.131.2.206", "hostIP": "10.30.218.170", "podIPs": [{"ip": "10.131.2.206"}], "qosClass": "Burstable", "startTime": "2024-04-05T09:57:32Z", "conditions": [{"type": "Initialized", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T09:57:32Z"}, {"type": "Ready", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T10:02:42Z"}, {"type": "ContainersReady", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T10:02:42Z"}, {"type": "PodScheduled", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T09:57:32Z"}], "containerStatuses": [{"name": "otel-collector", "image": "image-registry.openshift-image-registry.svc:5000/cpaas-ci-widget-o6uljbey/opentelemetry-collector-contrib:0.64.1", "ready": true, "state": {"running": {"startedAt": "2024-04-05T09:57:34Z"}}, "imageID": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib@sha256:1720f9ce46441e0bb6e4b9ac448c476a950db0767fe774bb73877ecd46017dd7", "started": true, "lastState": {}, "containerID": "cri-o://b6622cb6edcf8a9319771fd21c94d1796bc0d3a3f9b06c4cb44f154cadc0b06f", "restartCount": 0}]}, "metadata": {"uid": "42422d92-1a72-418d-97cf-97019c2d56e8", "name": "test-pod", "labels": {"app": "otelcollector", "otel-infra": "otel-pod", "pod-template-hash": "85fc74bc47"}, "namespace": "cpaas-ci", "annotations": {"openshift.io/scc": "restricted-v2", "k8s.v1.cni.cncf.io/network-status": "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.131.2.206\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]", "seccomp.security.alpha.kubernetes.io/pod": "runtime/default", "alpha.image.policy.openshift.io/resolve-names": "*"}, "generateName": "otelcollector-85fc74bc47-", "ownerReferences": [{"uid": "852e6139-ad94-44e1-a813-f70b7ab1c033", "kind": "ReplicaSet", "name": "test-pod", "apiVersion": "apps/v1", "controller": true, "blockOwnerDeletion": true}], "resourceVersion": "1883964183", "creationTimestamp": "2024-04-05T09:57:32Z"} }`
 )
 
+var columns = []string{"created_at", "uuid,", "data"}
 var tests = []struct {
 	name     string
 	database *Database
@@ -73,27 +76,28 @@ func TestQueryResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			expectedQuery := regexp.QuoteMeta(tt.database.info.GetResourcesSQL())
 			for _, ttt := range subtests {
-				db, mock := NewMock()
-				tt.database.db = db
-				var rows *sqlmock.Rows
-				if ttt.data {
-					rows = sqlmock.NewRows([]string{"data"}).AddRow(json.RawMessage(testCronJobResource))
-				} else {
-					rows = sqlmock.NewRows([]string{"data"})
-				}
-				mock.ExpectQuery(expectedQuery).WithArgs(kind, cronJobApiVersion).WillReturnRows(rows)
+				t.Run(ttt.name, func(t *testing.T) {
+					db, mock := NewMock()
+					tt.database.db = db
 
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-				defer cancel()
+					rows := sqlmock.NewRows(columns)
+					if ttt.data {
+						rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testCronJobResource))
+					}
+					mock.ExpectQuery(expectedQuery).WithArgs(kind, cronJobApiVersion).WillReturnRows(rows)
 
-				resources, err := tt.database.QueryResources(ctx, kind, group, version)
-				if ttt.numResources == 0 {
-					assert.Nil(t, resources)
-				} else {
-					assert.NotNil(t, resources)
-				}
-				assert.Equal(t, ttt.numResources, len(resources))
-				assert.NoError(t, err)
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+					defer cancel()
+
+					resources, _, _, err := tt.database.QueryResources(ctx, kind, group, version, "", "", "")
+					assert.NoError(t, err)
+					if ttt.numResources == 0 {
+						assert.Nil(t, resources)
+					} else {
+						assert.NotNil(t, resources)
+					}
+					assert.Equal(t, ttt.numResources, len(resources))
+				})
 			}
 		})
 	}
@@ -107,18 +111,16 @@ func TestQueryNamespacedResources(t *testing.T) {
 				db, mock := NewMock()
 				tt.database.db = db
 
-				var rows *sqlmock.Rows
+				rows := sqlmock.NewRows(columns)
 				if ttt.data {
-					rows = sqlmock.NewRows([]string{"data"}).AddRow(json.RawMessage(testCronJobResource))
-				} else {
-					rows = sqlmock.NewRows([]string{"data"})
+					rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testCronJobResource))
 				}
 				mock.ExpectQuery(expectedQuery).WithArgs(kind, cronJobApiVersion, namespace).WillReturnRows(rows)
 
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 				defer cancel()
 
-				resources, err := tt.database.QueryNamespacedResources(ctx, kind, group, version, namespace)
+				resources, _, _, err := tt.database.QueryNamespacedResources(ctx, kind, group, version, namespace, "", "", "")
 				if ttt.numResources == 0 {
 					assert.Nil(t, resources)
 				} else {
@@ -139,13 +141,10 @@ func TestQueryNamespacedResourceByName(t *testing.T) {
 				db, mock := NewMock()
 				tt.database.db = db
 
-				var rows *sqlmock.Rows
+				rows := sqlmock.NewRows(columns)
 				if ttt.data {
-					rows = sqlmock.NewRows([]string{"data"}).AddRow(json.RawMessage(testCronJobResource))
-				} else {
-					rows = sqlmock.NewRows([]string{"data"})
+					rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testCronJobResource))
 				}
-
 				mock.ExpectQuery(expectedQuery).WithArgs(kind, cronJobApiVersion, namespace, cronJobName).WillReturnRows(rows)
 
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -169,8 +168,9 @@ func TestQueryNamespacedResourceByNameMoreThanOne(t *testing.T) {
 			expectedQuery := regexp.QuoteMeta(tt.database.info.GetNamespacedResourceByNameSQL())
 			db, mock := NewMock()
 			tt.database.db = db
-			row := json.RawMessage(testCronJobResource)
-			rows := sqlmock.NewRows([]string{"data"}).AddRow(row).AddRow(row)
+
+			row := []driver.Value{"2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testCronJobResource)}
+			rows := sqlmock.NewRows(columns).AddRow(row...).AddRow(row...)
 			mock.ExpectQuery(expectedQuery).WithArgs(kind, cronJobApiVersion, namespace, cronJobName).WillReturnRows(rows)
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -178,7 +178,7 @@ func TestQueryNamespacedResourceByNameMoreThanOne(t *testing.T) {
 
 			resource, err := tt.database.QueryNamespacedResourceByName(ctx, kind, group, version, namespace, cronJobName)
 			assert.Nil(t, resource)
-			assert.Errorf(t, err, "More than one resource found")
+			assert.EqualError(t, err, "More than one resource found")
 		})
 	}
 }
@@ -191,18 +191,16 @@ func TestCoreQueryResources(t *testing.T) {
 				db, mock := NewMock()
 				tt.database.db = db
 
-				var rows *sqlmock.Rows
+				rows := sqlmock.NewRows(columns)
 				if ttt.data {
-					rows = sqlmock.NewRows([]string{"data"}).AddRow(json.RawMessage(testPodResource))
-				} else {
-					rows = sqlmock.NewRows([]string{"data"})
+					rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource))
 				}
 				mock.ExpectQuery(expectedQuery).WithArgs(kind, podApiVersion).WillReturnRows(rows)
 
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 				defer cancel()
 
-				resources, err := tt.database.QueryCoreResources(ctx, kind, version)
+				resources, _, _, err := tt.database.QueryCoreResources(ctx, kind, version, "", "", "")
 				if ttt.numResources == 0 {
 					assert.Nil(t, resources)
 				} else {
@@ -223,19 +221,16 @@ func TestQueryNamespacedCoreResources(t *testing.T) {
 				db, mock := NewMock()
 				tt.database.db = db
 
-				var rows *sqlmock.Rows
+				rows := sqlmock.NewRows(columns)
 				if ttt.data {
-					rows = sqlmock.NewRows([]string{"data"}).AddRow(json.RawMessage(testPodResource))
-				} else {
-					rows = sqlmock.NewRows([]string{"data"})
+					rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource))
 				}
-
 				mock.ExpectQuery(expectedQuery).WithArgs(kind, podApiVersion, namespace).WillReturnRows(rows)
 
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 				defer cancel()
 
-				resources, err := tt.database.QueryNamespacedCoreResources(ctx, kind, version, namespace)
+				resources, _, _, err := tt.database.QueryNamespacedCoreResources(ctx, kind, version, namespace, "", "", "")
 				if ttt.numResources == 0 {
 					assert.Nil(t, resources)
 				} else {
@@ -255,13 +250,10 @@ func TestQueryNamespacedCoreResourceByName(t *testing.T) {
 				db, mock := NewMock()
 				tt.database.db = db
 
-				var rows *sqlmock.Rows
+				rows := sqlmock.NewRows(columns)
 				if ttt.data {
-					rows = sqlmock.NewRows([]string{"data"}).AddRow(json.RawMessage(testPodResource))
-				} else {
-					rows = sqlmock.NewRows([]string{"data"})
+					rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource))
 				}
-
 				mock.ExpectQuery(expectedQuery).WithArgs(kind, version, namespace, podName).WillReturnRows(rows)
 
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -285,16 +277,17 @@ func TestQueryNamespacedCoreResourceByNameMoreThanOne(t *testing.T) {
 			expectedQuery := regexp.QuoteMeta(tt.database.info.GetNamespacedResourceByNameSQL())
 			db, mock := NewMock()
 			tt.database.db = db
-			row := json.RawMessage(testCronJobResource)
-			rows := sqlmock.NewRows([]string{"data"}).AddRow(row).AddRow(row)
+
+			row := []driver.Value{"2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource)}
+			rows := sqlmock.NewRows(columns).AddRow(row...).AddRow(row...)
 			mock.ExpectQuery(expectedQuery).WithArgs(kind, version, namespace, podName).WillReturnRows(rows)
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 
-			resource, err := tt.database.QueryNamespacedCoreResourceByName(ctx, kind, version, namespace, cronJobName)
+			resource, err := tt.database.QueryNamespacedCoreResourceByName(ctx, kind, version, namespace, podName)
 			assert.Nil(t, resource)
-			assert.Errorf(t, err, "More than one resource found")
+			assert.EqualError(t, err, "More than one resource found")
 		})
 	}
 }

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -46,14 +46,14 @@ func (f *Database) TestConnection(env map[string]string) error {
 	return f.err
 }
 
-func (f *Database) QueryResources(ctx context.Context, kind, group, version string) ([]*unstructured.Unstructured, error) {
+func (f *Database) QueryResources(ctx context.Context, kind, group, version, limit, continueUUID, continueDate string) ([]*unstructured.Unstructured, string, string, error) {
 	apiVersion := fmt.Sprintf("%s/%s", group, version)
-	return f.filterResoucesByKindAndApiVersion(kind, apiVersion), f.err
+	return f.filterResoucesByKindAndApiVersion(kind, apiVersion), "", "", f.err
 }
 
-func (f *Database) QueryNamespacedResources(ctx context.Context, kind, group, version, namespace string) ([]*unstructured.Unstructured, error) {
+func (f *Database) QueryNamespacedResources(ctx context.Context, kind, group, version, namespace, limit, continueUUID, continueDate string) ([]*unstructured.Unstructured, string, string, error) {
 	apiVersion := fmt.Sprintf("%s/%s", group, version)
-	return f.filterResourcesByKindApiVersionAndNamespace(kind, apiVersion, namespace), f.err
+	return f.filterResourcesByKindApiVersionAndNamespace(kind, apiVersion, namespace), "", "", f.err
 }
 
 func (f *Database) QueryNamespacedResourceByName(ctx context.Context, kind, group, version, namespace, name string) (*unstructured.Unstructured, error) {
@@ -68,12 +68,12 @@ func (f *Database) QueryNamespacedResourceByName(ctx context.Context, kind, grou
 	return resources[0], f.err
 }
 
-func (f *Database) QueryCoreResources(ctx context.Context, kind, version string) ([]*unstructured.Unstructured, error) {
-	return f.filterResoucesByKindAndApiVersion(kind, version), f.err
+func (f *Database) QueryCoreResources(ctx context.Context, kind, version, limit, continueUUID, continueDate string) ([]*unstructured.Unstructured, string, string, error) {
+	return f.filterResoucesByKindAndApiVersion(kind, version), "", "", f.err
 }
 
-func (f *Database) QueryNamespacedCoreResources(ctx context.Context, kind, version, namespace string) ([]*unstructured.Unstructured, error) {
-	return f.filterResourcesByKindApiVersionAndNamespace(kind, version, namespace), f.err
+func (f *Database) QueryNamespacedCoreResources(ctx context.Context, kind, version, namespace, limit, continueUUID, continueDate string) ([]*unstructured.Unstructured, string, string, error) {
+	return f.filterResourcesByKindApiVersionAndNamespace(kind, version, namespace), "", "", f.err
 }
 
 func (f *Database) QueryNamespacedCoreResourceByName(ctx context.Context, kind, version, namespace, name string) (*unstructured.Unstructured, error) {

--- a/pkg/database/fake/database_generated_test.go
+++ b/pkg/database/fake/database_generated_test.go
@@ -77,7 +77,7 @@ func TestQueryResources(t *testing.T) {
 	db := NewFakeDatabase(testResources)
 
 	for _, tt := range tests {
-		filteredResources, err := db.QueryResources(context.TODO(), tt.kind, tt.group, tt.version)
+		filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.group, tt.version, "", "", "")
 		assert.Equal(t, tt.expected, filteredResources)
 		assert.Nil(t, err)
 	}
@@ -142,7 +142,7 @@ func TestQueryNamespacedResources(t *testing.T) {
 
 	db := NewFakeDatabase(testResources)
 	for _, tt := range tests {
-		filteredResources, err := db.QueryNamespacedResources(context.TODO(), tt.kind, tt.group, tt.version, tt.namespace)
+		filteredResources, _, _, err := db.QueryNamespacedResources(context.TODO(), tt.kind, tt.group, tt.version, tt.namespace, "", "", "")
 		assert.Equal(t, tt.expected, filteredResources)
 		assert.Nil(t, err)
 	}
@@ -288,7 +288,7 @@ func TestQueryCoreResources(t *testing.T) {
 	db := NewFakeDatabase(testResources)
 
 	for _, tt := range tests {
-		filteredResources, err := db.QueryCoreResources(context.TODO(), tt.kind, tt.version)
+		filteredResources, _, _, err := db.QueryCoreResources(context.TODO(), tt.kind, tt.version, "", "", "")
 		assert.Equal(t, tt.expected, filteredResources)
 		assert.Nil(t, err)
 	}
@@ -339,7 +339,7 @@ func TestQueryNamespacedCoreResources(t *testing.T) {
 	db := NewFakeDatabase(testResources)
 
 	for _, tt := range tests {
-		filteredResources, err := db.QueryNamespacedCoreResources(context.TODO(), tt.kind, tt.version, tt.namespace)
+		filteredResources, _, _, err := db.QueryNamespacedCoreResources(context.TODO(), tt.kind, tt.version, tt.namespace, "", "", "")
 		assert.Equal(t, tt.expected, filteredResources)
 		assert.Nil(t, err)
 	}

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -30,15 +30,31 @@ func (info MariaDBDatabaseInfo) GetConnectionString() string {
 }
 
 func (info MariaDBDatabaseInfo) GetResourcesSQL() string {
-	return "SELECT data FROM resource WHERE kind=? AND api_version=?"
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? ORDER BY CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid"
+}
+
+func (info MariaDBDatabaseInfo) GetResourcesLimitedSQL() string {
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? ORDER BY CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid LIMIT ?"
+}
+
+func (info MariaDBDatabaseInfo) GetResourcesLimitedContinueSQL() string {
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? AND (CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid) > (?, ?) ORDER BY CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid LIMIT ?"
 }
 
 func (info MariaDBDatabaseInfo) GetNamespacedResourcesSQL() string {
-	return "SELECT data FROM resource WHERE kind=? AND api_version=? AND namespace=?"
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? AND namespace=? ORDER BY CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid"
+}
+
+func (info MariaDBDatabaseInfo) GetNamespacedResourcesLimitedSQL() string {
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? AND namespace=? ORDER BY CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid LIMIT ?"
+}
+
+func (info MariaDBDatabaseInfo) GetNamespacedResourcesLimitedContinueSQL() string {
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? AND namespace=? AND (CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid) > (?, ?) ORDER BY CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid LIMIT ?"
 }
 
 func (info MariaDBDatabaseInfo) GetNamespacedResourceByNameSQL() string {
-	return "SELECT data FROM resource WHERE kind=? AND api_version=? AND namespace=? AND name=?"
+	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? AND namespace=? AND name=?"
 }
 
 func (info MariaDBDatabaseInfo) GetWriteResourceSQL() string {

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -27,21 +27,37 @@ func (info PostgreSQLDatabaseInfo) GetConnectionString() string {
 }
 
 func (info PostgreSQLDatabaseInfo) GetResourcesSQL() string {
-	return "SELECT data FROM resource WHERE kind=$1 AND api_version=$2"
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 ORDER BY ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid)"
+}
+
+func (info PostgreSQLDatabaseInfo) GetResourcesLimitedSQL() string {
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 ORDER BY ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid) LIMIT $3"
+}
+
+func (info PostgreSQLDatabaseInfo) GetResourcesLimitedContinueSQL() string {
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid) > ($3, $4) ORDER BY ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid) LIMIT $5"
 }
 
 func (info PostgreSQLDatabaseInfo) GetNamespacedResourcesSQL() string {
-	return "SELECT data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3"
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 ORDER BY ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid)"
+}
+
+func (info PostgreSQLDatabaseInfo) GetNamespacedResourcesLimitedSQL() string {
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 ORDER BY ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid) LIMIT $4"
+}
+
+func (info PostgreSQLDatabaseInfo) GetNamespacedResourcesLimitedContinueSQL() string {
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid) > ($4, $5) ORDER BY ((data->'metadata'->'creationTimestamp')::text::timestamptz, uuid) LIMIT $6"
+}
+
+func (info PostgreSQLDatabaseInfo) GetNamespacedResourceByNameSQL() string {
+	return "SELECT data->'metadata'->'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND name=$4"
 }
 
 func (info PostgreSQLDatabaseInfo) GetWriteResourceSQL() string {
 	return "INSERT INTO resource (uuid, api_version, kind, name, namespace, resource_version, cluster_deleted_ts, data) " +
 		"VALUES ($1, $2, $3, $4, $5, $6, $7, $8) " +
 		"ON CONFLICT(uuid) DO UPDATE SET name=$4, namespace=$5, resource_version=$6, cluster_deleted_ts=$7, data=$8"
-}
-
-func (info PostgreSQLDatabaseInfo) GetNamespacedResourceByNameSQL() string {
-	return "SELECT data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND name=$4"
 }
 
 type PostgreSQLDatabase struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #226 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Endpoints that retrieve collections of resources support pagination similar to the Kubernetes API.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* I decided to go with ORDER BY because I keep reading (with proof) that LIMIT + OFFSET is slow and its best to do this approach (known as keyset pagination).
* We talked about adding `remainingItems` in the List response. That will be handled in a separate issue (https://github.com/kubearchive/kubearchive/issues/531).

To test:

```
# Normal flow
export KO_DOCKER_REPO="kind.local"
kind create cluster
bash hack/quick-install.sh

# Load data
cat table.sql | kubectl exec -n postgresql -it pods/kubearchive-1 -- psql kubearchive

# Add GET jobs permissions to the default:default ServiceAccount
kubectl create role view-jobs --verb=get --resource=jobs,jobs/status --dry-run=client -o yaml | kubectl apply -f -
kubectl create rolebinding view-jobs --role view-jobs --user system:serviceaccount:default:default --dry-run=client -o yaml | kubectl apply -f -

# Normal flow
kubectl get -n kubearchive secrets kubearchive-api-server-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
kubectl port-forward -n kubearchive svc/kubearchive-api-server 8081:8081 &

```
```
echo "TEST CASE: Curl (should output 1000)"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs" | jq '.items | length'

echo "TEST CASE: Curl with limits (should output 10)"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=10" | jq '.items'
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=10" | jq '.items[].metadata.name'

echo "TEST CASE: Curl with limits, should have a continue token"
export CONTINUE_TOKEN=$(curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=10" | jq -r '.metadata.continue')
echo $CONTINUE_TOKEN

echo "TEST CASE: Curl with continue"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=10&continue=$CONTINUE_TOKEN" | jq '.items | length'
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=10&continue=$CONTINUE_TOKEN" | jq '.items[].metadata.name'

echo "TEST CASE: This should fail because the token does not follow a date format"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=10&continue=$(echo "abc"|base64)"

echo "TEST CASE: This should fail because the limit is not correct"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?limit=ab&continue=$(echo "abc"|base64)"

echo "TEST CASE: This should return 1000 because `continue` on itself is ignored"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs?continue=$CONTINUE_TOKEN" | jq '.items | length'

echo "TEST CASE: The metadata shouldn't contain 'continue' if no limit was specified"
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/apis/batch/v1/namespaces/default/jobs" | jq '.metadata'
```

Download [table.tar.gz](https://github.com/user-attachments/files/17165553/table.tar.gz)  and extract with `tar -xzf table.tar.gz` to get the `table.sql` used in the previous instructions.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
