### PR TITLE
fix bug in integrations/database/postgresql/install.sh

### DIFF
--- a/integrations/database/postgresql/install.sh
+++ b/integrations/database/postgresql/install.sh
@@ -16,7 +16,11 @@ kubectl rollout status deployment --namespace=cnpg-system --timeout=90s
 # Create the postgres database server.
 kubectl create ns ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n ${NAMESPACE} apply -f .
-kubectl -n ${NAMESPACE} wait pod/kubearchive-1 --for=create --timeout=60s
+echo "Waiting for kubernetes to create the postgres database pod."
+while OUTPUT=$(kubectl -n ${NAMESPACE} get pods kubearchive-1 2>&1); [[ $OUTPUT == Error* ]]; do
+    sleep 0.5
+done
+echo "Postgresql database pod started."
 kubectl -n ${NAMESPACE} wait pod/kubearchive-1 --for=condition=ready --timeout=90s
 
 # Create the kubearchive database


### PR DESCRIPTION
Get rid of `error: unrecognized condition: "create"` when the script is run as part of hack/quick-install.sh while still waiting for kubearchive-1 pod to start.

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #485 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
`--for=create` is the incorrect syntax, it should be `--for=condition=create` however, this command fails if the pod was not started. For me it can take a couple of seconds so instead I used a while loop to wait until the pod is created.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
