### PR TITLE
Sink looks for global filters under the key kubearchive instead of _global

### DIFF
--- a/cmd/sink/filters/filters.go
+++ b/cmd/sink/filters/filters.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	globalKey       = "_global"
+	globalKey       = "kubearchive"
 	mountPathEnvVar = "MOUNT_PATH"
 )
 


### PR DESCRIPTION
The operator places the global filters in the ConfigMap under the key kubearchive not _global

resolves #524 

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
