### PR TITLE
Sink now applies global filters as well

### DIFF
--- a/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook.go
+++ b/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook.go
@@ -64,19 +64,19 @@ func (kac *KubeArchiveConfig) validateCELExpressions() (admission.Warnings, erro
 	errList := make([]error, 0)
 	for _, resource := range kac.Spec.Resources {
 		if resource.ArchiveWhen != "" {
-			_, err := cel.CreateCelExprOr(resource.ArchiveWhen)
+			_, err := cel.CompileOrCELExpression(resource.ArchiveWhen)
 			if err != nil {
 				errList = append(errList, err)
 			}
 		}
 		if resource.DeleteWhen != "" {
-			_, err := cel.CreateCelExprOr(resource.DeleteWhen)
+			_, err := cel.CompileOrCELExpression(resource.DeleteWhen)
 			if err != nil {
 				errList = append(errList, err)
 			}
 		}
 		if resource.ArchiveOnDelete != "" {
-			_, err := cel.CreateCelExprOr(resource.ArchiveOnDelete)
+			_, err := cel.CompileOrCELExpression(resource.ArchiveOnDelete)
 			if err != nil {
 				errList = append(errList, err)
 			}

--- a/cmd/sink/filters/testdata/cm.yaml
+++ b/cmd/sink/filters/testdata/cm.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sink-filters
+data:
+  kubearchive: |
+    - selector:
+        apiversion: batch/v1
+        kind: CronJob
+        labelselector: null
+      archivewhen: "true"
+      deletewhen: ""
+      archiveondelete: ""
+    - selector:
+        apiversion: batch/v1
+        kind: Job
+        labelselector: null
+      archivewhen: has(status.startTime)
+      deletewhen: has(status.completionTime)
+      archiveondelete: ""
+    - selector:
+        apiversion: v1
+        kind: Pod
+        labelselector: null
+      archivewhen: "has(metadata.labels) && 'global-filter' in metadata.labels"
+      deletewhen: ""
+      archiveondelete: ""
+  pods-archive: |
+    - selector:
+        apiversion: v1
+        kind: Pod
+        labelselector: null
+      archivewhen: "has(metadata.labels) && 'local-filter' in metadata.labels"
+      deletewhen: ""
+      archiveondelete: ""
+  pods-noarchive: |
+    []

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -223,6 +223,7 @@ func main() {
 		slog.Error("Could not get a kubernetes client", "error", err)
 		os.Exit(1)
 	}
+
 	filters := filters.NewFilters(clientset)
 	stopUpdating, err := filters.Update()
 	if err != nil {

--- a/pkg/cel/cel.go
+++ b/pkg/cel/cel.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// CreateCelExprOr attempts to compile cel expression strings into a cel.Program. If exprs contains more than one cel
+// CompileOrCELExpression attempts to compile cel expression strings into a cel.Program. If exprs contains more than one cel
 // expression string, it will surround each cell expression in parentheses and or them together.
-func CreateCelExprOr(exprs ...string) (*cel.Program, error) {
+func CompileOrCELExpression(exprs ...string) (*cel.Program, error) {
 	exprs = FormatCelExprs(exprs...)
 	expr := strings.Join(exprs, " || ")
 	return CompileCELExpr(expr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #526 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* My original intention was to refactor the code so global and local are treated in the same way and then do "namespace filters" + "global filters". However I found this approach in which we keep treating global filters in the same way. I will probably open an issue to refactor it. I think making this work has more priority than refactoring.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
