### PR TITLE
Change API Gin metrics package

### DIFF
--- a/cmd/api/auth/authn_test.go
+++ b/cmd/api/auth/authn_test.go
@@ -67,7 +67,7 @@ func TestInvalidAuthHeader(t *testing.T) {
 			ftr := &fakeTokenReview{authenticated: false}
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
-			c.Request, _ = http.NewRequest(http.MethodGet, "", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			c.Request.Header = tc.header
 
 			Authentication(ftr, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
@@ -105,7 +105,7 @@ func TestAuthentication(t *testing.T) {
 			ftr := &fakeTokenReview{authenticated: tc.authenticated}
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
-			c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			c.Request.Header.Add("Authorization", "Bearer faketoken")
 
 			Authentication(ftr, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
@@ -151,7 +151,7 @@ func TestAuthenticationCache(t *testing.T) {
 			}
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
-			c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			c.Request.Header.Add("Authorization", "Bearer faketoken")
 
 			Authentication(ftr, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
@@ -186,7 +186,7 @@ func TestDifferentAuthenticationExpirations(t *testing.T) {
 			cache := cache.New()
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
-			c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			c.Request.Header.Add("Authorization", "Bearer faketoken")
 
 			Authentication(ftr, cache, 10*time.Minute, -10*time.Minute)(c)

--- a/cmd/api/auth/authz_test.go
+++ b/cmd/api/auth/authz_test.go
@@ -121,7 +121,7 @@ func TestAuthZMiddleware(t *testing.T) {
 				gin.Param{Key: "namespace", Value: tc.namespace},
 				gin.Param{Key: "name", Value: tc.resourceName},
 			}
-			c.Request, _ = http.NewRequest(http.MethodGet, "", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			RBACAuthorization(fsar, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
 			assert.Equal(t, tc.expected, res.Code)
 			ra := fsar.sar.Spec.ResourceAttributes
@@ -168,7 +168,7 @@ func TestAuthorizationCache(t *testing.T) {
 				gin.Param{Key: "version", Value: version},
 				gin.Param{Key: "resourceType", Value: resource},
 			}
-			c.Request, _ = http.NewRequest(http.MethodGet, "", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 
 			RBACAuthorization(fsar, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
 			assert.Equal(t, !tc.allowed, cache.Get(sarSpec.String()))
@@ -207,7 +207,7 @@ func TestDifferentAuthorizationExpirations(t *testing.T) {
 				gin.Param{Key: "version", Value: version},
 				gin.Param{Key: "resourceType", Value: resource},
 			}
-			c.Request, _ = http.NewRequest(http.MethodGet, "", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 
 			RBACAuthorization(fsar, cache, 10*time.Minute, -10*time.Minute)(c)
 

--- a/cmd/api/discovery/apiresources_test.go
+++ b/cmd/api/discovery/apiresources_test.go
@@ -116,7 +116,7 @@ func TestGetAPIResource(t *testing.T) {
 
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
-			c.Request, _ = http.NewRequest(http.MethodGet, "/", nil)
+			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			c.AddParam("group", tc.group)
 			c.AddParam("version", tc.version)
 			c.AddParam("resourceType", tc.resource)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Cyprinus12138/otelgin"
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/auth"
 	"github.com/kubearchive/kubearchive/cmd/api/discovery"
@@ -19,7 +20,6 @@ import (
 	"github.com/kubearchive/kubearchive/pkg/database"
 	"github.com/kubearchive/kubearchive/pkg/middleware"
 	"github.com/kubearchive/kubearchive/pkg/observability"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -72,7 +72,7 @@ func TestMiddlewareConfigured(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			c := gin.CreateTestContextOnly(httptest.NewRecorder(), server.router)
-			c.Request, _ = http.NewRequest(http.MethodGet, testCase.path, nil)
+			c.Request = httptest.NewRequest(http.MethodGet, testCase.path, nil)
 			server.router.HandleContext(c)
 
 			handlers := c.HandlerNames()
@@ -100,7 +100,7 @@ func TestUnauthQuery(t *testing.T) {
 	server := fakeServer(nil, memCache)
 	// Make a correct request with an invalid token
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/v1/jobs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/jobs", nil)
 	req.Header.Set("Authorization", "Bearer token")
 	server.router.ServeHTTP(res, req)
 	// Assert unauthenticated request

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -45,7 +45,7 @@ func TestGetAllResources(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase(testResources), false)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/crontabs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/crontabs", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -60,7 +60,7 @@ func TestGetNamespacedResources(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase(testResources), false)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespace/test/crontabs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespace/test/crontabs", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -76,7 +76,7 @@ func TestGetNamespacedResourcesByName(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase(testResources), false)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespace/test/crontabs/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespace/test/crontabs/test", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -91,7 +91,7 @@ func TestGetResourcesEmpty(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase([]*unstructured.Unstructured{}), false)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespace/test/crontabs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespace/test/crontabs", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -106,7 +106,7 @@ func TestGetAllCoreResources(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase(testResources), true)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -121,7 +121,7 @@ func TestGetCoreNamespacedResources(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase(testResources), true)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespace/test/pods", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespace/test/pods", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -136,7 +136,7 @@ func TestGetCoreNamespacedResourcesByName(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabase(testResources), true)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/v1/namespace/test/pods/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespace/test/pods/test", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusOK, res.Code)
@@ -151,7 +151,7 @@ func TestDBError(t *testing.T) {
 	router := setupRouter(fake.NewFakeDatabaseWithError(errors.New("test error")), true)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusInternalServerError, res.Code)
@@ -167,7 +167,7 @@ func TestNoAPIResourceInContextError(t *testing.T) {
 	router.GET("/api/:version/:resourceType", ctrl.GetAllCoreResources)
 
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
 	router.ServeHTTP(res, req)
 
 	assert.Equal(t, http.StatusInternalServerError, res.Code)
@@ -182,7 +182,7 @@ func TestLivez(t *testing.T) {
 		CacheConfiguration: CacheExpirations{Authorized: 60, Unauthorized: 5}}
 	router.GET("/livez", ctrl.Livez)
 	res := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/livez", nil)
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
 	router.ServeHTTP(res, req)
 
 	expected, _ := json.Marshal(gin.H{
@@ -225,7 +225,7 @@ func TestReadyz(t *testing.T) {
 		}
 		router.GET("/readyz", ctrl.Readyz)
 		res := httptest.NewRecorder()
-		req, _ := http.NewRequest(http.MethodGet, "/readyz", nil)
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 		router.ServeHTTP(res, req)
 
 		assert.Equal(t, testCase.expected, res.Code)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.23.2
 
 require (
+	github.com/Cyprinus12138/otelgin v1.0.2
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/XSAM/otelsql v0.35.0
@@ -21,7 +22,6 @@ require (
 	github.com/onsi/gomega v1.34.2
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.56.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.56.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.56.0
@@ -134,6 +134,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/contrib/propagators/b3 v1.31.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Cyprinus12138/otelgin v1.0.2 h1:ey7hK/WOL1tED7mS8RNcoL1cu/eDPWC5GrUNMTaNwCY=
+github.com/Cyprinus12138/otelgin v1.0.2/go.mod h1:2awev+K126GKnxin/XulKzV+/6nlW++xMHhPPTY2zX0=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
@@ -464,8 +466,6 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
-go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.56.0 h1:0nTRpaCaILLdooXAQnfktlL6Zw1ECKEW9DZGH2byi2c=
-go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.56.0/go.mod h1:A7aFlp4WSLmeOnFRZwf2dMU+40THPc+rsr6KOwZLOcg=
 go.opentelemetry.io/contrib/instrumentation/host v0.56.0 h1:bLJ0U2SVly7aCVAv4pSJ62I0yy3GHPMbK+74AXSwC40=
 go.opentelemetry.io/contrib/instrumentation/host v0.56.0/go.mod h1:7XvO8DvjdcoYDOQs/1n3AuadI/30eE2R+H/pQQuZVN0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 h1:UP6IpuHFkUgOQL9FFQFrZ+5LiwhhYRbi7VZSIx6Nj5s=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Related to #527 527

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* The current instrumentation package for gin does not provide metrics, I'm changing it to one that does.
* The current instrumentation used is deprecated and has no maintainer: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6190

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
