### PR TITLE
renovate will automerge PRs if CI checks pass

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "15 8 * * *"  # Run daily at 8:15 UTC
+    - cron: "15 * * * *"  # Run hourly at 15 minutes past the hour
 
 jobs:
   setup:
@@ -39,7 +39,7 @@ jobs:
           # username needed for Github auth (Github app name + "[bot]")
           RENOVATE_USERNAME: "kubearchive-renovate[bot]"
           # git commit author. Format is: Github app name <id+RENOVATE_USERNAME@users.noreply.github.com>
-          # id can be retreived from https://api.github.com/users/kubearchive-renovate[bot]
+          # id can be retrieved from https://api.github.com/users/kubearchive-renovate[bot]
           RENOVATE_GIT_AUTHOR: "kubearchive-renovate <171263778+kubearchive-renovate[bot]@users.noreply.github.com>"
           # renovate will create signed commits
           RENOVATE_PLATFORM_COMMIT: "true"

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,7 @@
   "semanticCommits": "disabled",
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
+  "automerge": true,
+  "prHourlyLimit": 1
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #597 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
- I had to move the rule requiring 2 approvals on PRs into its own ruleset, so that `kubearchive-renovate` can automerge its own PRs without being able to bypass the CI checks.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
