### PR TITLE
Fix result ordering

### DIFF
--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -45,7 +45,7 @@ func (c *Controller) GetAllResources(context *gin.Context) {
 	group := context.Param("group")
 	version := context.Param("version")
 	apiVersion := fmt.Sprintf("%s/%s", group, version)
-	limit, uuid, date := pagination.GetValuesFromContext(context)
+	limit, id, date := pagination.GetValuesFromContext(context)
 
 	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
@@ -53,13 +53,13 @@ func (c *Controller) GetAllResources(context *gin.Context) {
 		return
 	}
 
-	resources, lastUUID, lastDate, err := c.Database.QueryResources(context.Request.Context(), kind, apiVersion, limit, uuid, date)
+	resources, lastId, lastDate, err := c.Database.QueryResources(context.Request.Context(), kind, apiVersion, limit, id, date)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	continueToken := pagination.CreateToken(lastUUID, lastDate)
+	continueToken := pagination.CreateToken(lastId, lastDate)
 	context.JSON(http.StatusOK, NewList(resources, continueToken))
 }
 
@@ -68,7 +68,7 @@ func (c *Controller) GetNamespacedResources(context *gin.Context) {
 	version := context.Param("version")
 	apiVersion := fmt.Sprintf("%s/%s", group, version)
 	namespace := context.Param("namespace")
-	limit, uuid, date := pagination.GetValuesFromContext(context)
+	limit, id, date := pagination.GetValuesFromContext(context)
 
 	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
@@ -76,13 +76,13 @@ func (c *Controller) GetNamespacedResources(context *gin.Context) {
 		return
 	}
 
-	resources, lastUUID, lastDate, err := c.Database.QueryNamespacedResources(context.Request.Context(), kind, apiVersion, namespace, limit, uuid, date)
+	resources, lastId, lastDate, err := c.Database.QueryNamespacedResources(context.Request.Context(), kind, apiVersion, namespace, limit, id, date)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	continueToken := pagination.CreateToken(lastUUID, lastDate)
+	continueToken := pagination.CreateToken(lastId, lastDate)
 	context.JSON(http.StatusOK, NewList(resources, continueToken))
 }
 
@@ -110,7 +110,7 @@ func (c *Controller) GetNamespacedResourceByName(context *gin.Context) {
 
 func (c *Controller) GetAllCoreResources(context *gin.Context) {
 	version := context.Param("version")
-	limit, uuid, date := pagination.GetValuesFromContext(context)
+	limit, id, date := pagination.GetValuesFromContext(context)
 
 	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
@@ -118,20 +118,20 @@ func (c *Controller) GetAllCoreResources(context *gin.Context) {
 		return
 	}
 
-	resources, lastUUID, lastDate, err := c.Database.QueryResources(context.Request.Context(), kind, version, limit, uuid, date)
+	resources, lastId, lastDate, err := c.Database.QueryResources(context.Request.Context(), kind, version, limit, id, date)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	continueToken := pagination.CreateToken(lastUUID, lastDate)
+	continueToken := pagination.CreateToken(lastId, lastDate)
 	context.JSON(http.StatusOK, NewList(resources, continueToken))
 }
 
 func (c *Controller) GetNamespacedCoreResources(context *gin.Context) {
 	version := context.Param("version")
 	namespace := context.Param("namespace")
-	limit, uuid, date := pagination.GetValuesFromContext(context)
+	limit, id, date := pagination.GetValuesFromContext(context)
 
 	kind, err := discovery.GetAPIResourceKind(context)
 	if err != nil {
@@ -139,13 +139,13 @@ func (c *Controller) GetNamespacedCoreResources(context *gin.Context) {
 		return
 	}
 
-	resources, lastUUID, lastDate, err := c.Database.QueryNamespacedResources(context.Request.Context(), kind, version, namespace, limit, uuid, date)
+	resources, lastId, lastDate, err := c.Database.QueryNamespacedResources(context.Request.Context(), kind, version, namespace, limit, id, date)
 	if err != nil {
 		abort.Abort(context, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	continueToken := pagination.CreateToken(lastUUID, lastDate)
+	continueToken := pagination.CreateToken(lastId, lastDate)
 	context.JSON(http.StatusOK, NewList(resources, continueToken))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/cel-go v0.21.0
-	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
@@ -91,6 +90,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/integrations/database/postgresql/install.sh
+++ b/integrations/database/postgresql/install.sh
@@ -5,7 +5,7 @@ set -o errexit
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${SCRIPT_DIR}
 
-VERSION="1.24.0"
+VERSION="1.24.1"
 NAMESPACE="postgresql"
 
 # Install cloudnative-pg operator.

--- a/integrations/database/postgresql/kubearchive.sql
+++ b/integrations/database/postgresql/kubearchive.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 17.0 (Debian 17.0-1.pgdg120+1)
--- Dumped by pg_dump version 17.0 (Debian 17.0-1.pgdg120+1)
+-- Dumped from database version 17.0 (Debian 17.0-1.pgdg110+1)
+-- Dumped by pg_dump version 17.0 (Debian 17.0-1.pgdg110+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -66,6 +66,7 @@ SET default_table_access_method = heap;
 --
 
 CREATE TABLE public.log_url (
+    id bigint NOT NULL,
     uuid uuid NOT NULL,
     url text NOT NULL
 );
@@ -74,10 +75,32 @@ CREATE TABLE public.log_url (
 ALTER TABLE public.log_url OWNER TO kubearchive;
 
 --
+-- Name: log_url_id_seq; Type: SEQUENCE; Schema: public; Owner: kubearchive
+--
+
+CREATE SEQUENCE public.log_url_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.log_url_id_seq OWNER TO kubearchive;
+
+--
+-- Name: log_url_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kubearchive
+--
+
+ALTER SEQUENCE public.log_url_id_seq OWNED BY public.log_url.id;
+
+
+--
 -- Name: resource; Type: TABLE; Schema: public; Owner: kubearchive
 --
 
 CREATE TABLE public.resource (
+    id bigint NOT NULL,
     uuid uuid NOT NULL,
     api_version character varying NOT NULL,
     kind character varying NOT NULL,
@@ -94,18 +117,69 @@ CREATE TABLE public.resource (
 ALTER TABLE public.resource OWNER TO kubearchive;
 
 --
+-- Name: resource_id_seq; Type: SEQUENCE; Schema: public; Owner: kubearchive
+--
+
+CREATE SEQUENCE public.resource_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.resource_id_seq OWNER TO kubearchive;
+
+--
+-- Name: resource_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: kubearchive
+--
+
+ALTER SEQUENCE public.resource_id_seq OWNED BY public.resource.id;
+
+
+--
+-- Name: log_url id; Type: DEFAULT; Schema: public; Owner: kubearchive
+--
+
+ALTER TABLE ONLY public.log_url ALTER COLUMN id SET DEFAULT nextval('public.log_url_id_seq'::regclass);
+
+
+--
+-- Name: resource id; Type: DEFAULT; Schema: public; Owner: kubearchive
+--
+
+ALTER TABLE ONLY public.resource ALTER COLUMN id SET DEFAULT nextval('public.resource_id_seq'::regclass);
+
+
+--
+-- Name: log_url log_url_pkey; Type: CONSTRAINT; Schema: public; Owner: kubearchive
+--
+
+ALTER TABLE ONLY public.log_url
+    ADD CONSTRAINT log_url_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: resource resource_pkey; Type: CONSTRAINT; Schema: public; Owner: kubearchive
 --
 
 ALTER TABLE ONLY public.resource
-    ADD CONSTRAINT resource_pkey PRIMARY KEY (uuid);
+    ADD CONSTRAINT resource_pkey PRIMARY KEY (id);
 
 
 --
--- Name: idx_creation_timestamp; Type: INDEX; Schema: public; Owner: kubearchive
+-- Name: resource resource_uuid_key; Type: CONSTRAINT; Schema: public; Owner: kubearchive
 --
 
-CREATE INDEX idx_creation_timestamp ON public.resource USING btree ((((data -> 'metadata'::text) ->> 'creationTimestamp'::text)) DESC);
+ALTER TABLE ONLY public.resource
+    ADD CONSTRAINT resource_uuid_key UNIQUE (uuid);
+
+
+--
+-- Name: idx_creation_timestamp_id; Type: INDEX; Schema: public; Owner: kubearchive
+--
+
+CREATE INDEX idx_creation_timestamp_id ON public.resource USING btree ((((data -> 'metadata'::text) ->> 'creationTimestamp'::text)) DESC, id DESC);
 
 
 --
@@ -158,11 +232,11 @@ CREATE TRIGGER set_timestamp BEFORE UPDATE ON public.resource FOR EACH ROW EXECU
 
 
 --
--- Name: log_url fk_uuid_resource; Type: FK CONSTRAINT; Schema: public; Owner: kubearchive
+-- Name: log_url log_url_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: kubearchive
 --
 
 ALTER TABLE ONLY public.log_url
-    ADD CONSTRAINT fk_uuid_resource FOREIGN KEY (uuid) REFERENCES public.resource(uuid);
+    ADD CONSTRAINT log_url_uuid_fkey FOREIGN KEY (uuid) REFERENCES public.resource(uuid);
 
 
 --

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"database/sql/driver"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -12,7 +11,6 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -82,7 +80,7 @@ func TestQueryResources(t *testing.T) {
 
 					rows := sqlmock.NewRows(columns)
 					if ttt.data {
-						rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource))
+						rows.AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource))
 					}
 					mock.ExpectQuery(expectedQuery).WithArgs(kind, podApiVersion, "100").WillReturnRows(rows)
 
@@ -114,7 +112,7 @@ func TestQueryNamespacedResources(t *testing.T) {
 
 					rows := sqlmock.NewRows(columns)
 					if ttt.data {
-						rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource))
+						rows.AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource))
 					}
 					mock.ExpectQuery(expectedQuery).WithArgs(kind, podApiVersion, namespace, "100").WillReturnRows(rows)
 
@@ -145,7 +143,7 @@ func TestQueryNamespacedResourceByName(t *testing.T) {
 
 					rows := sqlmock.NewRows(columns)
 					if ttt.data {
-						rows.AddRow("2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource))
+						rows.AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource))
 					}
 					mock.ExpectQuery(expectedQuery).WithArgs(kind, version, namespace, podName).WillReturnRows(rows)
 
@@ -172,8 +170,9 @@ func TestQueryNamespacedResourceByNameMoreThanOne(t *testing.T) {
 			db, mock := NewMock()
 			tt.database.db = db
 
-			row := []driver.Value{"2024-04-05T09:58:03Z", uuid.New().String(), json.RawMessage(testPodResource)}
-			rows := sqlmock.NewRows(columns).AddRow(row...).AddRow(row...)
+			rows := sqlmock.NewRows(columns).
+				AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource)).
+				AddRow("2024-04-05T09:58:03Z", 2, json.RawMessage(testPodResource))
 			mock.ExpectQuery(expectedQuery).WithArgs(kind, version, namespace, podName).WillReturnRows(rows)
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -65,26 +65,26 @@ func (f *Database) TestConnection(env map[string]string) error {
 	return f.err
 }
 
-func (f *Database) QueryResources(ctx context.Context, kind, version, limit, continueUUID, continueDate string) ([]*unstructured.Unstructured, string, string, error) {
+func (f *Database) QueryResources(ctx context.Context, kind, version, limit, continueId, continueDate string) ([]*unstructured.Unstructured, int64, string, error) {
 	resources := f.filterResourcesByKindAndApiVersion(kind, version)
 	var date string
-	var uuid string
+	var id int64
 	if len(resources) > 0 {
 		date = resources[len(resources)-1].GetCreationTimestamp().Format(time.RFC3339)
-		uuid = string(resources[len(resources)-1].GetUID())
+		id = int64(len(resources))
 	}
-	return resources, date, uuid, f.err
+	return resources, id, date, f.err
 }
 
-func (f *Database) QueryNamespacedResources(ctx context.Context, kind, version, namespace, limit, continueUUID, continueDate string) ([]*unstructured.Unstructured, string, string, error) {
+func (f *Database) QueryNamespacedResources(ctx context.Context, kind, version, namespace, limit, continueId, continueDate string) ([]*unstructured.Unstructured, int64, string, error) {
 	resources := f.filterResourcesByKindApiVersionAndNamespace(kind, version, namespace)
 	var date string
-	var uuid string
+	var id int64
 	if len(resources) > 0 {
 		date = resources[len(resources)-1].GetCreationTimestamp().Format(time.RFC3339)
-		uuid = string(resources[len(resources)-1].GetUID())
+		id = int64(len(resources))
 	}
-	return resources, date, uuid, f.err
+	return resources, id, date, f.err
 }
 
 func (f *Database) QueryNamespacedResourceByName(ctx context.Context, kind, version, namespace, name string) (*unstructured.Unstructured, error) {

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -27,23 +27,23 @@ func (info PostgreSQLDatabaseInfo) GetConnectionString() string {
 }
 
 func (info PostgreSQLDatabaseInfo) GetResourcesLimitedSQL() string {
-	return "SELECT data->'metadata'->>'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 ORDER BY data->'metadata'->>'creationTimestamp', uuid LIMIT $3"
+	return "SELECT data->'metadata'->>'creationTimestamp', id, data FROM resource WHERE kind=$1 AND api_version=$2 ORDER BY data->'metadata'->>'creationTimestamp' DESC, id DESC LIMIT $3"
 }
 
 func (info PostgreSQLDatabaseInfo) GetResourcesLimitedContinueSQL() string {
-	return "SELECT data->'metadata'->>'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND (data->'metadata'->>'creationTimestamp', uuid) > ($3, $4) ORDER BY data->'metadata'->>'creationTimestamp', uuid LIMIT $5"
+	return "SELECT data->'metadata'->>'creationTimestamp', id, data FROM resource WHERE kind=$1 AND api_version=$2 AND (data->'metadata'->>'creationTimestamp', id) < ($3, $4) ORDER BY data->'metadata'->>'creationTimestamp' DESC, id DESC LIMIT $5"
 }
 
 func (info PostgreSQLDatabaseInfo) GetNamespacedResourcesLimitedSQL() string {
-	return "SELECT data->'metadata'->>'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 ORDER BY data->'metadata'->>'creationTimestamp', uuid LIMIT $4"
+	return "SELECT data->'metadata'->>'creationTimestamp', id, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 ORDER BY data->'metadata'->>'creationTimestamp' DESC, id DESC LIMIT $4"
 }
 
 func (info PostgreSQLDatabaseInfo) GetNamespacedResourcesLimitedContinueSQL() string {
-	return "SELECT data->'metadata'->>'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND (data->'metadata'->>'creationTimestamp', uuid) > ($4, $5) ORDER BY data->'metadata'->>'creationTimestamp', uuid LIMIT $6"
+	return "SELECT data->'metadata'->>'creationTimestamp', id, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND (data->'metadata'->>'creationTimestamp', id) < ($4, $5) ORDER BY data->'metadata'->>'creationTimestamp' DESC, id DESC LIMIT $6"
 }
 
 func (info PostgreSQLDatabaseInfo) GetNamespacedResourceByNameSQL() string {
-	return "SELECT data->'metadata'->>'creationTimestamp', uuid, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND name=$4"
+	return "SELECT data->'metadata'->>'creationTimestamp', id, data FROM resource WHERE kind=$1 AND api_version=$2 AND namespace=$3 AND name=$4"
 }
 
 func (info PostgreSQLDatabaseInfo) GetWriteResourceSQL() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #586 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Now KubeArchive returns resources by creationTimestamp in descending order (new first)
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* The query gets a little slower in the big dataset because the DESC makes the filter remove more rows.
* Bumped CloudNative PG to 1.24.1 to PostgreSQL so it defaults to PostgreSQL v17.
* `BIGSERIAL` is not a true type, so its not reflected directly here. It is translated to a BIGINT and a series of sequence statements that make the thing autoincrement on insert.
* To test download and load 500.txt into the database, then run:

[500.txt](https://github.com/user-attachments/files/17554742/500.txt)

```
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/api/v1/pods?limit=100" | jq -r '.items[] | [.metadata.creationTimestamp, .metadata.uid] | @tsv' > 100-pods.txt
export CONTINUE_TOKEN=$(curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/api/v1/pods?limit=100" | jq -r '.metadata.continue')
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/api/v1/pods?limit=100&continue=${CONTINUE_TOKEN}" | jq -r '.items[] | [.metadata.creationTimestamp, .metadata.uid] | @tsv' > 100-continue-pods.txt
curl -s --cacert ca.crt -H "Authorization: Bearer $(kubectl create token default)" "https://localhost:8081/api/v1/pods?limit=200" | jq -r '.items[] | [.metadata.creationTimestamp, .metadata.uid] | @tsv' > 200-pods.txt

# Should equal 202 (all entries are different + 2 lines introduced by diff)
diff 100-pods.txt 100-continue-pods.txt | wc -l

# Should equal 0 (no difference)
cat 100-pods.txt 100-continue-pods.txt | diff - 200-pods.txt | wc -l
```

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
