### PR TITLE
Retrieve log urls

### DIFF
--- a/cmd/api/auth/authz_test.go
+++ b/cmd/api/auth/authz_test.go
@@ -27,13 +27,19 @@ const (
 )
 
 type fakeSubjectAccessReviews struct {
-	allowed bool
-	sar     *apiAuthzv1.SubjectAccessReview
+	allowed []bool
+	index   int
+	sar     []*apiAuthzv1.SubjectAccessReview
 }
 
 func (c *fakeSubjectAccessReviews) Create(ctx context.Context, subjectAccessReview *apiAuthzv1.SubjectAccessReview, opts metav1.CreateOptions) (*apiAuthzv1.SubjectAccessReview, error) {
-	subjectAccessReview.Status.Allowed = c.allowed
-	c.sar = subjectAccessReview
+	subjectAccessReview.Status.Allowed = c.allowed[c.index]
+	if c.sar == nil {
+		c.sar = []*apiAuthzv1.SubjectAccessReview{subjectAccessReview}
+	} else {
+		c.sar = append(c.sar, subjectAccessReview)
+	}
+	c.index++
 	return subjectAccessReview, nil
 }
 
@@ -110,7 +116,7 @@ func TestAuthZMiddleware(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New()
-			fsar := &fakeSubjectAccessReviews{allowed: tc.authorized}
+			fsar := &fakeSubjectAccessReviews{allowed: []bool{tc.authorized}}
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
 			c.Set("user", apiAuthnv1.UserInfo{Username: username, UID: "fake", Groups: []string{usergroup}})
@@ -124,13 +130,13 @@ func TestAuthZMiddleware(t *testing.T) {
 			c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 			RBACAuthorization(fsar, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
 			assert.Equal(t, tc.expected, res.Code)
-			ra := fsar.sar.Spec.ResourceAttributes
+			ra := fsar.sar[0].Spec.ResourceAttributes
 			assert.Equal(t, group, ra.Group)
 			assert.Equal(t, resource, ra.Resource)
 			assert.Equal(t, version, ra.Version)
 			assert.Equal(t, tc.verb, ra.Verb)
 			assert.Equal(t, tc.namespace, ra.Namespace)
-			assert.Equal(t, tc.authorized, cache.Get(fsar.sar.Spec.String()), "Cache should be populated with the proper value.")
+			assert.Equal(t, tc.authorized, cache.Get(fsar.sar[0].Spec.String()), "Cache should be populated with the proper value.")
 		})
 	}
 }
@@ -157,7 +163,7 @@ func TestAuthorizationCache(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New()
-			fsar := &fakeSubjectAccessReviews{allowed: tc.allowed}
+			fsar := &fakeSubjectAccessReviews{allowed: []bool{tc.allowed}}
 			cache.Set(sarSpec.String(), !tc.allowed, cacheExpirationDuration)
 
 			res := httptest.NewRecorder()
@@ -198,7 +204,7 @@ func TestDifferentAuthorizationExpirations(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := cache.New()
-			fsar := &fakeSubjectAccessReviews{allowed: tc.allowed}
+			fsar := &fakeSubjectAccessReviews{allowed: []bool{tc.allowed}}
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
 			c.Set("user", apiAuthnv1.UserInfo{Username: username, UID: "fake", Groups: []string{usergroup}})
@@ -217,6 +223,81 @@ func TestDifferentAuthorizationExpirations(t *testing.T) {
 				assert.Equal(t, nil, cache.Get(sarSpec.String()), "Cache should be 'nil' because of negative expiration time.")
 			}
 			assert.Equal(t, tc.expected, res.Code)
+		})
+	}
+}
+
+func TestTwoSARForLogRequest(t *testing.T) {
+	tests := []struct {
+		name            string
+		logsAllowed     bool
+		resourceAllowed bool
+		sarRequests     int
+		expected        int
+	}{
+		{
+			name:            "Logs and resource get allowed",
+			logsAllowed:     true,
+			resourceAllowed: true,
+			sarRequests:     2,
+			expected:        http.StatusOK,
+		},
+		{
+			name:            "Logs allowed but resource get not",
+			logsAllowed:     true,
+			resourceAllowed: false,
+			sarRequests:     1,
+			expected:        http.StatusUnauthorized,
+		},
+		{
+			name:            "Resource allowed but logs get not",
+			logsAllowed:     false,
+			resourceAllowed: true,
+			sarRequests:     2,
+			expected:        http.StatusUnauthorized,
+		},
+		{
+			name:            "Nothing is allowed",
+			logsAllowed:     false,
+			resourceAllowed: false,
+			sarRequests:     1,
+			expected:        http.StatusUnauthorized,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := cache.New()
+			fsar := &fakeSubjectAccessReviews{allowed: []bool{tc.resourceAllowed, tc.logsAllowed}}
+			res := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(res)
+			c.Set("user", apiAuthnv1.UserInfo{Username: username, UID: "fake", Groups: []string{usergroup}})
+			c.Params = gin.Params{
+				gin.Param{Key: "group", Value: group},
+				gin.Param{Key: "version", Value: version},
+				gin.Param{Key: "resourceType", Value: resource},
+				gin.Param{Key: "namespace", Value: "ns"},
+				gin.Param{Key: "name", Value: "resource"},
+			}
+			c.Request = httptest.NewRequest(http.MethodGet, "/log", nil)
+			RBACAuthorization(fsar, cache, cacheExpirationDuration, cacheExpirationDuration)(c)
+			assert.Equal(t, tc.expected, res.Code)
+			assert.Equal(t, tc.sarRequests, len(fsar.sar))
+			ra := fsar.sar[0].Spec.ResourceAttributes
+			assert.Equal(t, group, ra.Group)
+			assert.Equal(t, resource, ra.Resource)
+			assert.Equal(t, version, ra.Version)
+			assert.Equal(t, "get", ra.Verb)
+			assert.Equal(t, "ns", ra.Namespace)
+			assert.Equal(t, tc.resourceAllowed, cache.Get(fsar.sar[0].Spec.String()), "Cache should be populated with the proper value.")
+			if tc.resourceAllowed {
+				ra = fsar.sar[1].Spec.ResourceAttributes
+				assert.NotEqual(t, group, ra.Group)
+				assert.Equal(t, "pods/log", ra.Resource)
+				assert.Equal(t, "v1", ra.Version)
+				assert.Equal(t, "get", ra.Verb)
+				assert.Equal(t, "ns", ra.Namespace)
+				assert.Equal(t, tc.logsAllowed, cache.Get(fsar.sar[1].Spec.String()), "Cache should be populated with the proper value.")
+			}
 		})
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -81,10 +81,12 @@ func NewServer(k8sClient kubernetes.Interface, controller routers.Controller, ca
 	apisGroup.GET("/:group/:version/:resourceType", controller.GetAllResources)
 	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType", controller.GetNamespacedResources)
 	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType/:name", controller.GetNamespacedResourceByName)
+	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType/:name/log", controller.GetLogURLsByResourceName)
 
 	apiGroup.GET("/:version/:resourceType", controller.GetAllCoreResources)
 	apiGroup.GET("/:version/namespaces/:namespace/:resourceType", controller.GetNamespacedCoreResources)
 	apiGroup.GET("/:version/namespaces/:namespace/:resourceType/:name", controller.GetNamespacedCoreResourceByName)
+	apiGroup.GET("/:version/namespaces/:namespace/:resourceType/:name/log", controller.GetLogURLsByCoreResourceName)
 
 	return &Server{
 		router:    router,

--- a/cmd/api/pagination/pagination.go
+++ b/cmd/api/pagination/pagination.go
@@ -26,7 +26,7 @@ const (
 )
 
 // GetValuesFromContext is a helper function for routes to retrieve the
-// information needed. This is kept here so its close to the function
+// information needed. This is kept here, so it's close to the function
 // that sets these values in the context (Middleware)
 func GetValuesFromContext(context *gin.Context) (string, string, string) {
 	return context.GetString(limitKey), context.GetString(continueIdKey), context.GetString(continueDateKey)
@@ -45,10 +45,10 @@ func CreateToken(uuid int64, date string) string {
 
 // Middleware validates the `limit` and `continue` query parameters
 // and populates `limit` and `continueValue` in the context with their
-// respective values so they are retrieved by the endpoints that need it
+// respective values, so they are retrieved by the endpoints that need it
 func Middleware() gin.HandlerFunc {
 	return func(context *gin.Context) {
-		// We always a default limit because we don't want to return
+		// We always use a default limit because we don't want to return
 		// large collections if users don't remember to specify a limit
 		limitString := context.DefaultQuery(limitKey, defaultLimit)
 		continueToken := context.Query(continueKey)
@@ -94,7 +94,8 @@ func Middleware() gin.HandlerFunc {
 			continueTimestamp, err := time.Parse(time.RFC3339, continueDate)
 			if err != nil {
 				log.Printf("Error: %s", err)
-				abort.Abort(context, fmt.Sprintf("second element of the continue token does not match '%s'", time.RFC3339), http.StatusBadRequest)
+				abort.Abort(context, fmt.Sprintf("second element of the continue token '%s' does not match '%s'",
+					continueDate, time.RFC3339), http.StatusBadRequest)
 				return
 			}
 

--- a/cmd/api/pagination/pagination_test.go
+++ b/cmd/api/pagination/pagination_test.go
@@ -78,12 +78,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			name:               "invalid second part of continue",
-			query:              fmt.Sprintf("/?continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("1 %s", time.Now().Format(time.DateOnly))))),
+			query:              fmt.Sprintf("/?continue=%s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("1 %s", "2024-11-08")))),
 			expectedLimit:      "",
 			expectedInt64:      "",
 			expectedDate:       "",
 			expectedStatusCode: http.StatusBadRequest,
-			expectedBody:       `{"message":"second element of the continue token does not match '2006-01-02T15:04:05Z07:00'"}`,
+			expectedBody:       `{"message":"second element of the continue token '2024-11-08' does not match '2006-01-02T15:04:05Z07:00'"}`,
 		},
 		{
 			name:               "valid limit and continue",

--- a/integrations/database/postgresql/README.md
+++ b/integrations/database/postgresql/README.md
@@ -3,7 +3,7 @@
 Accessing the PostgreSQL database from outside the cluster requires port forwarding.  This
 command should be run in its own terminal:
 ```
-kubectl -n postgres port-forward service/kubearchive-rw 5433:5432 &
+kubectl -n postgresql port-forward service/kubearchive-rw 5433:5432 &
 ```
 The local port (5433) in this case can be changed, but whatever value is chosen
 needs to be used in the following command.

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"log/slog"
 	"os"
@@ -27,18 +28,18 @@ const (
 	testPodResource     = `{"kind": "Pod", "apiVersion": "v1", "spec": {"volumes": [{"name": "otel-config", "configMap": {"name": "otel-collector-config", "items": [{"key": "otelcol.yaml", "path": "otelcol.yaml"}], "optional": true, "defaultMode": 420}}, {"name": "kube-api-access-njsk9", "projected": {"sources": [{"serviceAccountToken": {"path": "token", "expirationSeconds": 3607}}, {"configMap": {"name": "kube-root-ca.crt", "items": [{"key": "ca.crt", "path": "ca.crt"}]}}, {"downwardAPI": {"items": [{"path": "namespace", "fieldRef": {"fieldPath": "metadata.namespace", "apiVersion": "v1"}}]}}, {"configMap": {"name": "openshift-service-ca.crt", "items": [{"key": "service-ca.crt", "path": "service-ca.crt"}]}}], "defaultMode": 420}}], "nodeName": "ip-10-30-218-170.ec2.internal", "priority": 0, "dnsPolicy": "ClusterFirst", "containers": [{"args": ["--config=/etc/otel/otelcol.yaml"], "name": "test-pod", "image": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib@sha256:1720f9ce46441e0bb6e4b9ac448c476a950db0767fe774bb73877ecd46017dd7", "ports": [{"protocol": "TCP", "containerPort": 4317}, {"protocol": "TCP", "containerPort": 8889}], "resources": {"limits": {"cpu": "1", "memory": "2Gi"}, "requests": {"cpu": "200m", "memory": "100Mi"}}, "volumeMounts": [{"name": "otel-config", "subPath": "otelcol.yaml", "readOnly": true, "mountPath": "/etc/otel/otelcol.yaml"}, {"name": "kube-api-access-njsk9", "readOnly": true, "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"}], "livenessProbe": {"httpGet": {"path": "/", "port": 13133, "scheme": "HTTP"}, "periodSeconds": 10, "timeoutSeconds": 30, "failureThreshold": 30, "successThreshold": 1, "initialDelaySeconds": 1800}, "readinessProbe": {"httpGet": {"path": "/", "port": 13133, "scheme": "HTTP"}, "periodSeconds": 10, "timeoutSeconds": 30, "failureThreshold": 300, "successThreshold": 1, "initialDelaySeconds": 300}, "imagePullPolicy": "IfNotPresent", "securityContext": {"runAsUser": 1000930000, "capabilities": {"drop": ["ALL"]}, "runAsNonRoot": true, "allowPrivilegeEscalation": false}, "terminationMessagePath": "/dev/termination-log", "terminationMessagePolicy": "File"}], "tolerations": [{"key": "node.kubernetes.io/not-ready", "effect": "NoExecute", "operator": "Exists", "tolerationSeconds": 300}, {"key": "node.kubernetes.io/unreachable", "effect": "NoExecute", "operator": "Exists", "tolerationSeconds": 300}, {"key": "node.kubernetes.io/memory-pressure", "effect": "NoSchedule", "operator": "Exists"}], "restartPolicy": "Always", "schedulerName": "default-scheduler", "serviceAccount": "default", "securityContext": {"fsGroup": 1000930000, "seLinuxOptions": {"level": "s0:c31,c0"}, "seccompProfile": {"type": "RuntimeDefault"}}, "imagePullSecrets": [{"name": "cpaas-container-registries"}, {"name": "default-dockercfg-rhb7z"}], "preemptionPolicy": "PreemptLowerPriority", "enableServiceLinks": true, "serviceAccountName": "default", "terminationGracePeriodSeconds": 30}, "status": {"phase": "Running", "podIP": "10.131.2.206", "hostIP": "10.30.218.170", "podIPs": [{"ip": "10.131.2.206"}], "qosClass": "Burstable", "startTime": "2024-04-05T09:57:32Z", "conditions": [{"type": "Initialized", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T09:57:32Z"}, {"type": "Ready", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T10:02:42Z"}, {"type": "ContainersReady", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T10:02:42Z"}, {"type": "PodScheduled", "status": "True", "lastProbeTime": null, "lastTransitionTime": "2024-04-05T09:57:32Z"}], "containerStatuses": [{"name": "otel-collector", "image": "image-registry.openshift-image-registry.svc:5000/cpaas-ci-widget-o6uljbey/opentelemetry-collector-contrib:0.64.1", "ready": true, "state": {"running": {"startedAt": "2024-04-05T09:57:34Z"}}, "imageID": "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib@sha256:1720f9ce46441e0bb6e4b9ac448c476a950db0767fe774bb73877ecd46017dd7", "started": true, "lastState": {}, "containerID": "cri-o://b6622cb6edcf8a9319771fd21c94d1796bc0d3a3f9b06c4cb44f154cadc0b06f", "restartCount": 0}]}, "metadata": {"uid": "42422d92-1a72-418d-97cf-97019c2d56e8", "name": "test-pod", "labels": {"app": "otelcollector", "otel-infra": "otel-pod", "pod-template-hash": "85fc74bc47"}, "namespace": "cpaas-ci", "annotations": {"openshift.io/scc": "restricted-v2", "k8s.v1.cni.cncf.io/network-status": "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.131.2.206\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]", "seccomp.security.alpha.kubernetes.io/pod": "runtime/default", "alpha.image.policy.openshift.io/resolve-names": "*"}, "generateName": "otelcollector-85fc74bc47-", "ownerReferences": [{"uid": "852e6139-ad94-44e1-a813-f70b7ab1c033", "kind": "ReplicaSet", "name": "test-pod", "apiVersion": "apps/v1", "controller": true, "blockOwnerDeletion": true}], "resourceVersion": "1883964183", "creationTimestamp": "2024-04-05T09:57:32Z"} }`
 )
 
-var columns = []string{"created_at", "uuid,", "data"}
+var resourceQueryColumns = []string{"created_at", "id", "data"}
 var tests = []struct {
 	name     string
 	database *Database
 }{
 	{
 		name:     "mariadb",
-		database: &Database{info: &MariaDBDatabaseInfo{}},
+		database: &Database{info: &MariaDBDatabaseInfo{}, paramParser: &MariaDBParamParser{}},
 	},
 	{
 		name:     "postgresql",
-		database: &Database{info: &PostgreSQLDatabaseInfo{}},
+		database: &Database{info: &PostgreSQLDatabaseInfo{}, paramParser: &PostgreSQLParamParser{}},
 	},
 }
 
@@ -69,6 +70,97 @@ func NewMock() (*sql.DB, sqlmock.Sqlmock) {
 	return db, mock
 }
 
+func TestPodQueryLogURLs(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedQuery := regexp.QuoteMeta(tt.database.info.GetLogURLsByPodNameSQL())
+			db, mock := NewMock()
+			tt.database.db = db
+
+			rows := sqlmock.NewRows([]string{"url"})
+			rows.AddRow("mock-url-container1")
+			rows.AddRow("mock-url-container2")
+			mock.ExpectQuery(expectedQuery).WithArgs(podApiVersion, namespace, podName).WillReturnRows(rows)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			logUrls, err := tt.database.QueryLogURLs(ctx, "Pod", podApiVersion, namespace, podName)
+			assert.Equal(t, 2, len(logUrls))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestLogURLsFromNonExistentResource(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock := NewMock()
+			tt.database.db = db
+			rows := sqlmock.NewRows([]string{"uuid"})
+			mock.ExpectQuery(regexp.QuoteMeta(tt.database.info.GetUUIDSQL())).WithArgs(kind, cronJobApiVersion, namespace, cronJobName).WillReturnRows(rows)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			logUrls, err := tt.database.QueryLogURLs(ctx, kind, cronJobApiVersion, namespace, cronJobName)
+			assert.Equal(t, 0, len(logUrls))
+			assert.Error(t, err, "resource not found")
+		})
+	}
+}
+
+func TestCronJobQueryLogURLs(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock := NewMock()
+			tt.database.db = db
+
+			// Get UUID query
+			rows := sqlmock.NewRows([]string{"uuid"})
+			rows.AddRow("mock-uuid-cronjob")
+			mock.ExpectQuery(regexp.QuoteMeta(tt.database.info.GetUUIDSQL())).WithArgs(kind, cronJobApiVersion, namespace, cronJobName).WillReturnRows(rows)
+
+			ownedResourcesQuery := regexp.QuoteMeta(tt.database.info.GetOwnedResourcesSQL())
+
+			// Get owned job
+			rows = sqlmock.NewRows([]string{"kind", "uuid"})
+			rows.AddRow("Job", "mock-uuid-job")
+			query, args, _ := tt.database.paramParser.ParseParams(ownedResourcesQuery, []string{"mock-uuid-cronjob"})
+			mock.ExpectQuery(query).WithArgs(sliceOfAny2sliceOfValue(args)...).WillReturnRows(rows)
+
+			// Get owned pods
+			rows = sqlmock.NewRows([]string{"kind", "uuid"})
+			rows.AddRow("Pod", "mock-uuid-pod1")
+			rows.AddRow("Pod", "mock-uuid-pod2")
+			query, args, _ = tt.database.paramParser.ParseParams(ownedResourcesQuery, []string{"mock-uuid-job"})
+			mock.ExpectQuery(query).WithArgs(sliceOfAny2sliceOfValue(args)...).WillReturnRows(rows)
+
+			// Get pods log urls
+			rows = sqlmock.NewRows([]string{"url"})
+			rows.AddRow("mock-log-url-pod1")
+			rows.AddRow("mock-log-url-pod2")
+			query, args, _ = tt.database.paramParser.ParseParams(regexp.QuoteMeta(tt.database.info.GetLogURLsSQL()), []string{"mock-uuid-pod1", "mock-uuid-pod2"})
+			mock.ExpectQuery(query).WithArgs(sliceOfAny2sliceOfValue(args)...).WillReturnRows(rows)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			logUrls, err := tt.database.QueryLogURLs(ctx, kind, cronJobApiVersion, namespace, cronJobName)
+			assert.Equal(t, 2, len(logUrls))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func sliceOfAny2sliceOfValue(values []any) []driver.Value {
+	var parsedValues []driver.Value
+	for _, v := range values {
+		parsedValues = append(parsedValues, v)
+	}
+	return parsedValues
+}
+
 func TestQueryResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -78,20 +170,22 @@ func TestQueryResources(t *testing.T) {
 					db, mock := NewMock()
 					tt.database.db = db
 
-					rows := sqlmock.NewRows(columns)
+					rows := sqlmock.NewRows(resourceQueryColumns)
 					if ttt.data {
-						rows.AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource))
+						rows.AddRow("2024-04-05T09:58:03Z", 5, json.RawMessage(testPodResource))
 					}
 					mock.ExpectQuery(expectedQuery).WithArgs(kind, podApiVersion, "100").WillReturnRows(rows)
 
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 					defer cancel()
 
-					resources, _, _, err := tt.database.QueryResources(ctx, kind, version, "100", "", "")
+					resources, lastId, _, err := tt.database.QueryResources(ctx, kind, version, "100", "", "")
 					if ttt.numResources == 0 {
 						assert.Nil(t, resources)
+						assert.Equal(t, int64(0), lastId)
 					} else {
 						assert.NotNil(t, resources)
+						assert.Equal(t, int64(5), lastId)
 					}
 					assert.Equal(t, ttt.numResources, len(resources))
 					assert.NoError(t, err)
@@ -110,7 +204,7 @@ func TestQueryNamespacedResources(t *testing.T) {
 					db, mock := NewMock()
 					tt.database.db = db
 
-					rows := sqlmock.NewRows(columns)
+					rows := sqlmock.NewRows(resourceQueryColumns)
 					if ttt.data {
 						rows.AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource))
 					}
@@ -141,7 +235,7 @@ func TestQueryNamespacedResourceByName(t *testing.T) {
 					db, mock := NewMock()
 					tt.database.db = db
 
-					rows := sqlmock.NewRows(columns)
+					rows := sqlmock.NewRows(resourceQueryColumns)
 					if ttt.data {
 						rows.AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource))
 					}
@@ -170,7 +264,7 @@ func TestQueryNamespacedResourceByNameMoreThanOne(t *testing.T) {
 			db, mock := NewMock()
 			tt.database.db = db
 
-			rows := sqlmock.NewRows(columns).
+			rows := sqlmock.NewRows(resourceQueryColumns).
 				AddRow("2024-04-05T09:58:03Z", 1, json.RawMessage(testPodResource)).
 				AddRow("2024-04-05T09:58:03Z", 2, json.RawMessage(testPodResource))
 			mock.ExpectQuery(expectedQuery).WithArgs(kind, version, namespace, podName).WillReturnRows(rows)
@@ -180,7 +274,7 @@ func TestQueryNamespacedResourceByNameMoreThanOne(t *testing.T) {
 
 			resource, err := tt.database.QueryNamespacedResourceByName(ctx, kind, version, namespace, podName)
 			assert.Nil(t, resource)
-			assert.EqualError(t, err, "More than one resource found")
+			assert.EqualError(t, err, "more than one resource found")
 		})
 	}
 }

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CreateTestResources() []*unstructured.Unstructured {
-	ret := []*unstructured.Unstructured{}
+	var ret []*unstructured.Unstructured
 	crontab := &unstructured.Unstructured{}
 	crontab.SetKind("Crontab")
 	crontab.SetAPIVersion("stable.example.com/v1")
@@ -76,6 +76,17 @@ func (f *Database) QueryResources(ctx context.Context, kind, version, limit, con
 		id = int64(len(resources))
 	}
 	return resources, id, date, f.err
+}
+
+func (f *Database) QueryLogURLs(ctx context.Context, kind, apiVersion, namespace, name string) ([]string, error) {
+	if kind == "Pod" {
+		return []string{f.logUrl[0].Url}, f.err
+	}
+	var urls []string
+	for _, l := range f.logUrl {
+		urls = append(urls, l.Url)
+	}
+	return urls, f.err
 }
 
 func (f *Database) QueryNamespacedResources(ctx context.Context, kind, version, namespace, limit, continueId, continueDate string) ([]*unstructured.Unstructured, int64, string, error) {

--- a/pkg/database/fake/database_generated_test.go
+++ b/pkg/database/fake/database_generated_test.go
@@ -279,3 +279,30 @@ func TestWriteUrls(t *testing.T) {
 		})
 	}
 }
+
+func TestQueryLogURLs(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		kind     string
+		expected int
+	}{
+		{
+			name:     "Logs from one pod",
+			kind:     "Pod",
+			expected: 1,
+		},
+		{
+			name:     "Logs from another resource",
+			kind:     "Job",
+			expected: len(testLogUrls),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := NewFakeDatabase(testResources, testLogUrls)
+			urls, _ := db.QueryLogURLs(context.Background(), tt.kind, "", "", "")
+			assert.Equal(t, tt.expected, len(urls))
+		})
+	}
+}

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -6,6 +6,8 @@ package database
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/kubearchive/kubearchive/pkg/models"
@@ -49,6 +51,23 @@ func (info MariaDBDatabaseInfo) GetNamespacedResourceByNameSQL() string {
 	return "SELECT JSON_VALUE(data, '$.metadata.creationTimestamp'), uuid, data FROM resource WHERE kind=? AND api_version=? AND namespace=? AND name=?"
 }
 
+func (info MariaDBDatabaseInfo) GetUUIDSQL() string {
+	return "SELECT uuid FROM resource WHERE kind=? AND api_version=? AND namespace=? AND name=?"
+}
+
+func (info MariaDBDatabaseInfo) GetOwnedResourcesSQL() string {
+	// TODO test
+	return "SELECT uuid, kind FROM resource WHERE JSON_OVERLAPS(JSON_EXTRACT(data, '$.metadata.ownerReferences.**.uid'), JSON_ARRAY(?))"
+}
+
+func (info MariaDBDatabaseInfo) GetLogURLsByPodNameSQL() string {
+	return "SELECT log.url FROM log_url log JOIN resource res ON log.uuid=res.uuid WHERE res.kind='Pod' AND res.api_version=? AND res.namespace=? AND res.name=?"
+}
+
+func (info MariaDBDatabaseInfo) GetLogURLsSQL() string {
+	return "SELECT url FROM log_url WHERE uuid IN (?)"
+}
+
 func (info MariaDBDatabaseInfo) GetWriteResourceSQL() string {
 	return "INSERT INTO resource (uuid, api_version, kind, name, namespace, resource_version, cluster_deleted_ts, data) " +
 		"VALUES (?, ?, ?, ?, ?, ?, ?, ?) " +
@@ -63,14 +82,39 @@ func (info MariaDBDatabaseInfo) GetDeleteUrlsSQL() string {
 	return "DELETE FROM log_url WHERE uuid=?"
 }
 
+type MariaDBParamParser struct{}
+
+// ParseParams in MariaDB transform the query from one param ? to one for each element in the array and
+// flattens the array of strings into strings as MariaDB doesn't support arrays as parameters for
+// prepared queries
+func (MariaDBParamParser) ParseParams(query string, args ...any) (string, []any, error) {
+	var parsedArgs []any
+	parsedQuery := query
+	for i, arg := range args {
+		switch reflect.TypeOf(arg).Kind() {
+		case reflect.Slice:
+			arraySize := len(arg.([]string))
+			newParams := strings.Join(strings.Fields(strings.Repeat("? ", arraySize)), ",")
+			parsedQuery = replaceNth(query, "?", newParams, i)
+			for _, elem := range arg.([]string) {
+				parsedArgs = append(parsedArgs, elem)
+			}
+		default:
+			parsedArgs = append(parsedArgs, arg)
+		}
+	}
+	return parsedQuery, parsedArgs, nil
+}
+
 type MariaDBDatabase struct {
 	*Database
 }
 
 func NewMariaDBDatabase(env map[string]string) DBInterface {
 	info := MariaDBDatabaseInfo{env: env}
+	paramParser := MariaDBParamParser{}
 	db := establishConnection(info.GetDriverName(), info.GetConnectionString())
-	return MariaDBDatabase{&Database{db: db, info: info}}
+	return MariaDBDatabase{&Database{db: db, info: info, paramParser: paramParser}}
 }
 
 func (db MariaDBDatabase) WriteResource(ctx context.Context, k8sObj *unstructured.Unstructured, data []byte) error {
@@ -111,4 +155,21 @@ func (db MariaDBDatabase) WriteResource(ctx context.Context, k8sObj *unstructure
 		return fmt.Errorf("commit to database failed and the transactions was rolled back: %s", execErr)
 	}
 	return nil
+}
+
+// Replace the nth occurrence of old in s by replaced.
+func replaceNth(s, old, replaced string, n int) string {
+	i := 0
+	for m := 1; m <= n; m++ {
+		x := strings.Index(s[i:], old)
+		if x < 0 {
+			break
+		}
+		i += x
+		if m == n {
+			return s[:i] + replaced + s[i+len(old):]
+		}
+		i += len(old)
+	}
+	return s
 }

--- a/pkg/database/query.go
+++ b/pkg/database/query.go
@@ -1,0 +1,154 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type paramQuery struct {
+	query         string
+	arguments     []any
+	dbArrayParser DBParamParser
+	hasArray      bool
+}
+
+func (q *paramQuery) addStringParams(args ...string) {
+	for _, arg := range args {
+		q.arguments = append(q.arguments, arg)
+	}
+}
+
+func (q *paramQuery) addStringArrayParam(arg []string) {
+	q.hasArray = true
+	q.arguments = append(q.arguments, arg)
+}
+
+func (q *paramQuery) parse() (string, []any, error) {
+	if !q.hasArray {
+		return q.query, q.arguments, nil
+	} else {
+		return q.dbArrayParser.ParseParams(q.query, q.arguments...)
+	}
+}
+
+type queryPerformer[T any] struct {
+	zeroVal T
+	db      *sql.DB
+}
+
+func newQueryPerformer[T any](db *sql.DB) queryPerformer[T] {
+	var zeroVal T
+	return queryPerformer[T]{zeroVal, db}
+}
+
+func (q queryPerformer[T]) performQuery(ctx context.Context, paramQuery *paramQuery) ([]T, error) {
+	query, args, err := paramQuery.parse()
+	if err != nil {
+		return nil, err
+	}
+	return q.parseRows(q.db.QueryContext(ctx, query, args...))
+}
+
+func (q queryPerformer[T]) parseRows(rows *sql.Rows, err error) ([]T, error) {
+	if err != nil {
+		return nil, err
+	}
+	defer func(rows *sql.Rows) {
+		err = rows.Close()
+	}(rows)
+	switch reflect.TypeOf(q.zeroVal).Kind() {
+	case reflect.Struct:
+		return q.structScan(rows)
+	default:
+		return q.oneFieldScan(rows)
+	}
+}
+
+func (q queryPerformer[T]) oneFieldScan(rows *sql.Rows) ([]T, error) {
+	var res []T
+	for rows.Next() {
+		var val T
+		if err := rows.Scan(&val); err != nil {
+			return res, err
+		}
+		res = append(res, val)
+	}
+	return res, nil
+}
+
+// structScan is a function based on
+// https://ferencfbin.medium.com/golang-own-structscan-method-for-sql-rows-978c5c80f9b5
+// while this feature isn't natively supported in db/sql
+// https://github.com/golang/go/issues/61637
+func (q queryPerformer[T]) structScan(rows *sql.Rows) ([]T, error) {
+	var res []T
+	v := reflect.ValueOf(&q.zeroVal)
+	if v.Kind() != reflect.Ptr {
+		return res, errors.New("must pass a pointer, not a value, to StructScan destination")
+	}
+
+	v = reflect.Indirect(v)
+	t := v.Type()
+
+	cols, _ := rows.Columns()
+
+	var rowsMap []map[string]any
+	for rows.Next() {
+		columns := make([]any, len(cols))
+		columnPointers := make([]any, len(cols))
+		for i := range columns {
+			columnPointers[i] = &columns[i]
+		}
+
+		if err := rows.Scan(columnPointers...); err != nil {
+			return res, err
+		}
+
+		m := make(map[string]any)
+		for i, colName := range cols {
+			val := columnPointers[i].(*any)
+			m[colName] = *val
+		}
+		rowsMap = append(rowsMap, m)
+	}
+
+	for _, m := range rowsMap {
+		for i := 0; i < v.NumField(); i++ {
+			field := strings.Split(t.Field(i).Tag.Get("json"), ",")[0]
+
+			if item, ok := m[field]; ok {
+				if v.Field(i).CanSet() {
+					if item != nil {
+						switch v.Field(i).Kind() {
+						case reflect.String:
+							v.Field(i).SetString(fmt.Sprintf("%s", item))
+						case reflect.Int64:
+							v.Field(i).SetInt(item.(int64))
+						case reflect.Float32, reflect.Float64:
+							v.Field(i).SetFloat(item.(float64))
+						case reflect.Ptr:
+							if reflect.ValueOf(item).Kind() == reflect.Bool {
+								itemBool := item.(bool)
+								v.Field(i).Set(reflect.ValueOf(&itemBool))
+							}
+						case reflect.Struct, reflect.Slice:
+							v.Field(i).Set(reflect.ValueOf(item))
+						default:
+							fmt.Println(t.Field(i).Name, ": ", v.Field(i).Kind(), " - > - ", reflect.ValueOf(item).Kind())
+						}
+					}
+				}
+			}
+		}
+		res = append(res, v.Interface().(T))
+	}
+
+	return res, nil
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -503,7 +503,7 @@ func getUrl(client *http.Client, token string, url string) (*unstructured.Unstru
 	}
 
 	if response.StatusCode != http.StatusOK {
-		fmt.Printf("The HTTP status returned is not OK, %s\n", response.Status)
+		fmt.Printf("The HTTP status returned is not OK, %s - %s \n", response.Status, string(body))
 		return nil, fmt.Errorf("%d", response.StatusCode)
 	}
 
@@ -513,6 +513,6 @@ func getUrl(client *http.Client, token string, url string) (*unstructured.Unstru
 		fmt.Printf("Couldn't unmarshal JSON, %s\n", err)
 		return nil, err
 	}
-
+	fmt.Printf("The HTTP status returned is OK, %s - %s \n", response.Status, string(body))
 	return &data, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #539

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Add new endpoints for the retrieval of log URLs
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
I've included a new file called `query.go` in the `database` package with helper functions to encapsulate the logic for parsing the sql row results into structs or primitive data.
All the queries (new and old) are using this new functions.

There is a new interface `DBParamParser` to be implemented in the different drivers for transforming arrays into the allowed parameters for parametrized statements. This way we allow having queries of the type `SELECT * FROM ... WHERE key IN ?` being `?` a set of elements of undefined length.

The endpoints return 404 when the resource doesn't exist in the database.

For testing, you can run the integration tests locally, check the namespace used for the generated data and then do:
```
kubectl apply -f test/users/
kubectl get -n kubearchive secrets kubearchive-api-server-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.cr
curl -v --cacert ca.crt -H "Authorization: Bearer $(kubectl create -n test token default)" \
 https://localhost:8081/apis/batch/v1/namespaces/<ns>/cronjobs/generate-log-1/log
```

Unit tests are included but no integration tests. I will open a new issue for addressing those.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
