### PR TITLE
enable additional checks in `golangci-lint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,15 @@ linters:
     - goimports
     - gosec
     - nilerr
+    - nilnil
     - usestdlibvars
     - wastedassign
     - unparam
+linters-settings:
+  govet:
+    enable-all: false
+    disable-all: false
+    enable:
+      - loopclosure
+      - nilness
+      - shadow

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -113,9 +113,9 @@ func main() {
 		os.Exit(1)
 	}
 	defer func(db database.DBInterface) {
-		err := db.CloseDB()
-		if err != nil {
-			slog.Error("Could not close the database connection", "error", err.Error())
+		deferErr := db.CloseDB()
+		if deferErr != nil {
+			slog.Error("Could not close the database connection", "error", deferErr.Error())
 		} else {
 			slog.Info("Connection closed successfully")
 		}

--- a/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook.go
+++ b/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook.go
@@ -60,7 +60,6 @@ func (kac *KubeArchiveConfig) ValidateUpdate(old runtime.Object) (admission.Warn
 		return nil, fmt.Errorf("Cannot update KubeArchiveConfig resource named '%s'.", kubearchiveResourceName)
 	}
 
-
 	return kac.validateCELExpressions()
 }
 

--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -492,7 +492,7 @@ func (r *KubeArchiveConfigReconciler) reconcileFilterConfigMap(ctx context.Conte
 	cm := &corev1.ConfigMap{}
 	err := r.Get(ctx, types.NamespacedName{Name: SinkFilterConfigMapName, Namespace: k9eNs}, cm)
 	if err == nil {
-		cm, err := r.desiredFilterConfigMap(ctx, kaconfig, cm)
+		cm, err = r.desiredFilterConfigMap(ctx, kaconfig, cm)
 		if err != nil {
 			log.Error(err, "Unable to get desired ConfigMap "+SinkFilterConfigMapName)
 			return cm, err
@@ -503,7 +503,7 @@ func (r *KubeArchiveConfigReconciler) reconcileFilterConfigMap(ctx context.Conte
 			return cm, err
 		}
 	} else if errors.IsNotFound(err) {
-		cm, err := r.desiredFilterConfigMap(ctx, kaconfig, nil)
+		cm, err = r.desiredFilterConfigMap(ctx, kaconfig, nil)
 		if err != nil {
 			log.Error(err, "Unable to get desired filter ConfigMap "+SinkFilterConfigMapName)
 			return cm, err

--- a/cmd/sink/filters/filters.go
+++ b/cmd/sink/filters/filters.go
@@ -95,12 +95,12 @@ func (f *Filters) changeGlobalFilters(stringResources map[string]string) error {
 	deleteMap := make(map[NamespaceGroupVersionKind]cel.Program)
 	archiveOnDeleteMap := make(map[NamespaceGroupVersionKind]cel.Program)
 	for namespace, kacResources := range stringResources {
-		nsArchive, nsDelete, nsArchiveOnDelete, err := f.createFilters(namespace, kacResources, globalArchive, globalDelete, globalArchiveOnDelete)
+		nsArchive, nsDelete, nsArchiveOnDelete, nsErr := f.createFilters(namespace, kacResources, globalArchive, globalDelete, globalArchiveOnDelete)
 		maps.Copy(archiveMap, nsArchive)
 		maps.Copy(deleteMap, nsDelete)
 		maps.Copy(archiveOnDeleteMap, nsArchiveOnDelete)
-		if err != nil {
-			errList = append(errList, err)
+		if nsErr != nil {
+			errList = append(errList, nsErr)
 		}
 	}
 	err = errors.Join(errList...)

--- a/hack/get-next-version.go
+++ b/hack/get-next-version.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	var releaseNotes map[string]any
-	if err := json.Unmarshal(releaseNotesBytes, &releaseNotes); err != nil {
+	if err = json.Unmarshal(releaseNotesBytes, &releaseNotes); err != nil {
 		panic(err)
 	}
 

--- a/pkg/observability/trace.go
+++ b/pkg/observability/trace.go
@@ -80,9 +80,6 @@ func Start(serviceName string) error {
 		metric.WithResource(res),
 		metric.WithReader(metric.NewPeriodicReader(metricExporter)),
 	)
-	if err != nil {
-		return err
-	}
 
 	otel.SetMeterProvider(mp)
 	err = host.Start(host.WithMeterProvider(mp))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #638 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The following `govet` analyzers are now enabled:
- the default set of `govet` analyzers (were already enabled before this PR)
- loopclosure: Check references to loop variables from within nested functions
- nilness: Check for redundant or impossible nil comparisons
- shadow: Check for possible unintended shadowing of variables

The following linters are now enabled:
- nilnil: Checks that there is no simultaneous return of nil error and an invalid value

Made some fixes so that all `golangci-lint` linters pass
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
