### PR TITLE
Add sqlx for structscan support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/cel-go v0.22.0
+	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -325,6 +327,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/XSAM/otelsql"
 	"github.com/avast/retry-go/v4"
+	"github.com/jmoiron/sqlx"
 )
 
-func establishConnection(driver, connectionString string) *sql.DB {
+func establishConnection(driver, connectionString string) *sqlx.DB {
 	configs := []retry.Option{
 		retry.Attempts(10),
 		retry.OnRetry(func(n uint, err error) {
@@ -36,5 +37,5 @@ func establishConnection(driver, connectionString string) *sql.DB {
 		return nil
 	}
 	log.Println("Successfully connected to the database")
-	return conn
+	return sqlx.NewDb(conn, driver)
 }

--- a/pkg/database/query.go
+++ b/pkg/database/query.go
@@ -5,11 +5,8 @@ package database
 
 import (
 	"context"
-	"database/sql"
-	"errors"
-	"fmt"
-	"reflect"
-	"strings"
+
+	"github.com/jmoiron/sqlx"
 )
 
 type paramQuery struct {
@@ -39,13 +36,11 @@ func (q *paramQuery) parse() (string, []any, error) {
 }
 
 type queryPerformer[T any] struct {
-	zeroVal T
-	db      *sql.DB
+	db *sqlx.DB
 }
 
-func newQueryPerformer[T any](db *sql.DB) queryPerformer[T] {
-	var zeroVal T
-	return queryPerformer[T]{zeroVal, db}
+func newQueryPerformer[T any](db *sqlx.DB) queryPerformer[T] {
+	return queryPerformer[T]{db}
 }
 
 func (q queryPerformer[T]) performQuery(ctx context.Context, paramQuery *paramQuery) ([]T, error) {
@@ -53,102 +48,10 @@ func (q queryPerformer[T]) performQuery(ctx context.Context, paramQuery *paramQu
 	if err != nil {
 		return nil, err
 	}
-	return q.parseRows(q.db.QueryContext(ctx, query, args...))
-}
-
-func (q queryPerformer[T]) parseRows(rows *sql.Rows, err error) ([]T, error) {
+	var res []T
+	err = q.db.SelectContext(ctx, &res, query, args...)
 	if err != nil {
 		return nil, err
 	}
-	defer func(rows *sql.Rows) {
-		err = rows.Close()
-	}(rows)
-	switch reflect.TypeOf(q.zeroVal).Kind() {
-	case reflect.Struct:
-		return q.structScan(rows)
-	default:
-		return q.oneFieldScan(rows)
-	}
-}
-
-func (q queryPerformer[T]) oneFieldScan(rows *sql.Rows) ([]T, error) {
-	var res []T
-	for rows.Next() {
-		var val T
-		if err := rows.Scan(&val); err != nil {
-			return res, err
-		}
-		res = append(res, val)
-	}
-	return res, nil
-}
-
-// structScan is a function based on
-// https://ferencfbin.medium.com/golang-own-structscan-method-for-sql-rows-978c5c80f9b5
-// while this feature isn't natively supported in db/sql
-// https://github.com/golang/go/issues/61637
-func (q queryPerformer[T]) structScan(rows *sql.Rows) ([]T, error) {
-	var res []T
-	v := reflect.ValueOf(&q.zeroVal)
-	if v.Kind() != reflect.Ptr {
-		return res, errors.New("must pass a pointer, not a value, to StructScan destination")
-	}
-
-	v = reflect.Indirect(v)
-	t := v.Type()
-
-	cols, _ := rows.Columns()
-
-	var rowsMap []map[string]any
-	for rows.Next() {
-		columns := make([]any, len(cols))
-		columnPointers := make([]any, len(cols))
-		for i := range columns {
-			columnPointers[i] = &columns[i]
-		}
-
-		if err := rows.Scan(columnPointers...); err != nil {
-			return res, err
-		}
-
-		m := make(map[string]any)
-		for i, colName := range cols {
-			val := columnPointers[i].(*any)
-			m[colName] = *val
-		}
-		rowsMap = append(rowsMap, m)
-	}
-
-	for _, m := range rowsMap {
-		for i := 0; i < v.NumField(); i++ {
-			field := strings.Split(t.Field(i).Tag.Get("json"), ",")[0]
-
-			if item, ok := m[field]; ok {
-				if v.Field(i).CanSet() {
-					if item != nil {
-						switch v.Field(i).Kind() {
-						case reflect.String:
-							v.Field(i).SetString(fmt.Sprintf("%s", item))
-						case reflect.Int64:
-							v.Field(i).SetInt(item.(int64))
-						case reflect.Float32, reflect.Float64:
-							v.Field(i).SetFloat(item.(float64))
-						case reflect.Ptr:
-							if reflect.ValueOf(item).Kind() == reflect.Bool {
-								itemBool := item.(bool)
-								v.Field(i).Set(reflect.ValueOf(&itemBool))
-							}
-						case reflect.Struct, reflect.Slice:
-							v.Field(i).Set(reflect.ValueOf(item))
-						default:
-							fmt.Println(t.Field(i).Name, ": ", v.Field(i).Kind(), " - > - ", reflect.ValueOf(item).Kind())
-						}
-					}
-				}
-			}
-		}
-		res = append(res, v.Interface().(T))
-	}
-
 	return res, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #634 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

I kept the queryPerformer struct because of the variadic args handled with the `DBParamParser` interface of the `paramQuery` struct.

I also used string instead of `sql.RawBytes` (an alias of `[]byte`) because its usage is discouraged given that some drivers override its value after the `rows.Next()` execution.
More info about this on:
* https://github.com/DATA-DOG/go-sqlmock/issues/176
* https://jmoiron.github.io/sqlx/#query

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
