### PR TITLE
use knative brokers to handle event delivery

### DIFF
--- a/charts/kubearchive/templates/eventing/brokers.yaml
+++ b/charts/kubearchive/templates/eventing/brokers.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: {{ .Release.Name }}-broker
+  namespace: {{ .Release.Namespace }}
+spec:
+  delivery:
+    retry: 4
+    backoffPolicy: exponential
+    # ISO 8601 format
+    backoffDelay: PT0.5S
+    deadLetterSink:
+      ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        name: {{ .Release.Name }}-dls
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: {{ .Release.Name }}-dls
+  namespace: {{ .Release.Namespace }}
+spec:
+  delivery:
+    retry: 4
+    backoffPolicy: exponential
+    # ISO 8601 format
+    backoffDelay: PT0.5S

--- a/charts/kubearchive/templates/sink/trigger.yaml
+++ b/charts/kubearchive/templates/sink/trigger.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: {{ tpl .Values.sink.name . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  broker: {{ .Release.Name }}-broker
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: {{ tpl .Values.sink.name . }}

--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -39,9 +39,12 @@ const (
 	ApiServerSourceLabelValue = "true"
 )
 
-var k9eNs = os.Getenv("KUBEARCHIVE_NAMESPACE")
-var a13eName = k9eNs + "-a13e"
-var k9eSinkName = k9eNs + "-sink"
+var (
+	k9eNs         = os.Getenv("KUBEARCHIVE_NAMESPACE")
+	a13eName      = k9eNs + "-a13e"
+	k9eSinkName   = k9eNs + "-sink"
+	k9eBrokerName = k9eNs + "-broker"
+)
 
 // KubeArchiveConfigReconciler reconciles a KubeArchiveConfig object
 type KubeArchiveConfigReconciler struct {
@@ -468,9 +471,9 @@ func (r *KubeArchiveConfigReconciler) desiredA13e(resources []sourcesv1.APIVersi
 			SourceSpec: duckv1.SourceSpec{
 				Sink: duckv1.Destination{
 					Ref: &duckv1.KReference{
-						APIVersion: "v1",
-						Kind:       "Service",
-						Name:       k9eSinkName,
+						APIVersion: "eventing.knative.dev/v1",
+						Kind:       "Broker",
+						Name:       k9eBrokerName,
 						Namespace:  k9eNs,
 					},
 				},

--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -14,7 +14,7 @@ export CERT_MANAGER_VERSION=v1.9.1
 export KNATIVE_EVENTING_VERSION=v1.15.0
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
-kubectl apply -f https://github.com/knative/eventing/releases/download/knative-${KNATIVE_EVENTING_VERSION}/eventing-core.yaml
+kubectl apply -f https://github.com/knative/eventing/releases/download/knative-${KNATIVE_EVENTING_VERSION}/eventing.yaml
 kubectl rollout status deployment --namespace=cert-manager --timeout=30s
 kubectl rollout status deployment --namespace=knative-eventing --timeout=30s
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Related #240 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
cloudevent delivery is retried up to five times 
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
KubeArchive uses a knative eventing broker to receive cloudevents from ApiServerSource and uses a knative eventing trigger to subscribe the sink to all events from the broker. The broker is configured to retry the delivery of cloudevents if the initial delivery fails. If all retries fail, the broker sends the cloudevent an other broker so that the cloudevents are not lost.

I replaced `eventing-core.yaml` with `eventing.yaml` in `hack/quick-install.sh` because `eventing.yaml` is `eventing-core.yaml` plus `in-memory-channel.yaml` and `mt-channel-broker.yaml` both of which need to be installed for the brokers to work.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
