### PR TITLE
fix how operator determines sink name

### DIFF
--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -42,8 +42,8 @@ const (
 var (
 	k9eNs         = os.Getenv("KUBEARCHIVE_NAMESPACE")
 	a13eName      = k9eNs + "-a13e"
-	k9eSinkName   = k9eNs + "-sink"
-	k9eBrokerName = k9eNs + "-broker"
+	k9eSinkName   = "kubearchive-sink"
+	k9eBrokerName = "kubearchive-broker"
 )
 
 // KubeArchiveConfigReconciler reconciles a KubeArchiveConfig object


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #589 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
fix bug where operator uses the wrong service name for the sink when deployed in a namespace that is not kubearchive
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
make sure that the operator will use the name `kubearchive-sink` even if KubeArchive is not deployed in the `kubearchive` namespace
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
