### PR TITLE
add json_path to log_url table

### DIFF
--- a/cmd/sink/logs/logs.go
+++ b/cmd/sink/logs/logs.go
@@ -20,6 +20,7 @@ import (
 const (
 	celPrefix        = "cel:"
 	containerNameCel = "cel:spec.containers.map(m, m.name)"
+	jsonPathKey      = "LOG_URL_JSONPATH"
 )
 
 func getKubeArchiveLoggingConfig() (map[string]string, error) {
@@ -43,7 +44,8 @@ func getKubeArchiveLoggingConfig() (map[string]string, error) {
 }
 
 type UrlBuilder struct {
-	logMap map[string]interface{}
+	jsonPath string
+	logMap   map[string]interface{}
 }
 
 func NewUrlBuilder() (*UrlBuilder, error) {
@@ -74,9 +76,13 @@ func NewUrlBuilder() (*UrlBuilder, error) {
 			logMap[key] = val
 		}
 	}
-	return &UrlBuilder{logMap: logMap}, nil
+	return &UrlBuilder{jsonPath: loggingConf[jsonPathKey], logMap: logMap}, nil
 }
 
 func (ub *UrlBuilder) Urls(ctx context.Context, data *unstructured.Unstructured) ([]models.LogTuple, error) {
 	return logurls.GenerateLogURLs(ctx, ub.logMap, data)
+}
+
+func (ub *UrlBuilder) GetJsonPath() string {
+	return ub.jsonPath
 }

--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -91,7 +91,7 @@ func (sink *Sink) writeLogs(ctx context.Context, obj *unstructured.Unstructured)
 		slog.Error("Could not build log urls for object", "objectID", obj.GetUID(), "err", err)
 		return
 	}
-	err = sink.Db.WriteUrls(logCtx, obj, urls...)
+	err = sink.Db.WriteUrls(logCtx, obj, sink.logUrlBuilder.GetJsonPath(), urls...)
 	if err != nil {
 		slog.Error("Failed to write log urls for object to the database", "objectID", obj.GetUID(), "err", err)
 	} else {

--- a/integrations/database/mariadb/kubearchive.sql
+++ b/integrations/database/mariadb/kubearchive.sql
@@ -59,6 +59,7 @@ CREATE TABLE `log_url` (
   `uuid` uuid NOT NULL,
   `url` text NOT NULL,
   `container_name` text NOT NULL,
+  `json_path` text,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;

--- a/integrations/database/postgresql/kubearchive.sql
+++ b/integrations/database/postgresql/kubearchive.sql
@@ -88,6 +88,7 @@ CREATE TABLE public.log_url (
     uuid uuid NOT NULL,
     url text NOT NULL,
     container_name text NOT NULL,
+	json_path text,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
     updated_at timestamp without time zone DEFAULT now() NOT NULL
 );

--- a/pkg/database/facade/inserter.go
+++ b/pkg/database/facade/inserter.go
@@ -16,15 +16,15 @@ type DBInserter interface {
 		clusterDeletedTs sql.NullString,
 		data []byte,
 	) *sqlbuilder.InsertBuilder
-	UrlInserter(uuid, url, containerName string) *sqlbuilder.InsertBuilder
+	UrlInserter(uuid, url, containerName, jsonPath string) *sqlbuilder.InsertBuilder
 }
 
 type PartialDBInserterImpl struct{}
 
-func (PartialDBInserterImpl) UrlInserter(uuid, url, containerName string) *sqlbuilder.InsertBuilder {
+func (PartialDBInserterImpl) UrlInserter(uuid, url, containerName, jsonPath string) *sqlbuilder.InsertBuilder {
 	ib := sqlbuilder.NewInsertBuilder()
 	ib.InsertInto("log_url")
-	ib.Cols("uuid", "url", "container_name")
-	ib.Values(uuid, url, containerName)
+	ib.Cols("uuid", "url", "container_name", "json_path")
+	ib.Values(uuid, url, containerName, jsonPath)
 	return ib
 }

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -41,6 +41,7 @@ type LogUrlRow struct {
 	Uuid          types.UID
 	Url           string
 	ContainerName string
+	JsonPath      string
 }
 
 type Database struct {
@@ -156,7 +157,7 @@ func (f *Database) WriteResource(ctx context.Context, k8sObj *unstructured.Unstr
 	return nil
 }
 
-func (f *Database) WriteUrls(ctx context.Context, k8sObj *unstructured.Unstructured, logs ...models.LogTuple) error {
+func (f *Database) WriteUrls(ctx context.Context, k8sObj *unstructured.Unstructured, jsonPath string, logs ...models.LogTuple) error {
 	newLogUrls := make([]LogUrlRow, 0)
 	for _, row := range f.logUrl {
 		if k8sObj.GetUID() != row.Uuid {
@@ -166,7 +167,7 @@ func (f *Database) WriteUrls(ctx context.Context, k8sObj *unstructured.Unstructu
 	f.logUrl = newLogUrls
 
 	for _, url := range logs {
-		f.logUrl = append(f.logUrl, LogUrlRow{Uuid: k8sObj.GetUID(), Url: url.Url, ContainerName: url.ContainerName})
+		f.logUrl = append(f.logUrl, LogUrlRow{Uuid: k8sObj.GetUID(), Url: url.Url, ContainerName: url.ContainerName, JsonPath: jsonPath})
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #689 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
add json_path column to the log_url table
sink writes the value for LOG_URL_JSONPATH from the logging ConfigMap to the json_path column for the log_url table
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
UrlBuilder stores the value for `LOG_URL_JSONPATH` from the logging ConfigMap. Sink calls the `UrlBuilder.GetJsonPath()` method when writing log urls to the database.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
