### PR TITLE
Database.WriteUrls does not transact with invalid arguments

### DIFF
--- a/cmd/sink/main.go
+++ b/cmd/sink/main.go
@@ -91,6 +91,10 @@ func (sink *Sink) writeLogs(ctx context.Context, obj *unstructured.Unstructured)
 		slog.Error("Could not build log urls for object", "objectID", obj.GetUID(), "err", err)
 		return
 	}
+	if len(urls) == 0 {
+		slog.Info("No log urls were generated for object", "objectID", obj.GetUID())
+		return
+	}
 	err = sink.Db.WriteUrls(logCtx, obj, sink.logUrlBuilder.GetJsonPath(), urls...)
 	if err != nil {
 		slog.Error("Failed to write log urls for object to the database", "objectID", obj.GetUID(), "err", err)

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -6,6 +6,7 @@ package fake
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/kubearchive/kubearchive/pkg/models"
@@ -156,6 +157,10 @@ func (f *Database) WriteResource(_ context.Context, k8sObj *unstructured.Unstruc
 }
 
 func (f *Database) WriteUrls(_ context.Context, k8sObj *unstructured.Unstructured, jsonPath string, logs ...models.LogTuple) error {
+	if k8sObj == nil {
+		return errors.New("Cannot write log urls to the database when k8sObj is nil")
+	}
+
 	newLogUrls := make([]LogUrlRow, 0)
 	for _, row := range f.logUrl {
 		if k8sObj.GetUID() != row.Uuid {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #720

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Fixed bug where KubeArchive crashed under some circumstances and fixed a bug where KubeArchive could delete all logs related to a resource.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Databases.WriteUrls checks if k8sObj is nil If this condition is true, it returns an error and
does not perform any database transactions. sink.writeLogs checks if len(urls) == 0 and logs
that no urls were generated and does not call Database.WriteUrls when this condition is true
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
