### PR TITLE
Fix timeout errors in integration tests

### DIFF
--- a/.github/workflows/go_test_integration.yml
+++ b/.github/workflows/go_test_integration.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Test Go code
         run: |
           export KO_DOCKER_REPO="kind.local"
-          go test -count=1 -v ./test/integration -tags=integration
+          go test -count=1 -v ./test/integration -tags=integration -timeout 30m

--- a/cmd/api/logging/logging.go
+++ b/cmd/api/logging/logging.go
@@ -154,7 +154,8 @@ func LogRetrieval() gin.HandlerFunc {
 		}
 
 		if !logsReturned {
-			abort.Abort(c, fmt.Errorf("no parsed logs for the json path: %s", jsonPathParser.String()),
+			abort.Abort(c, fmt.Errorf("no parsed logs for the json path: %s from logs in %s",
+				jsonPathParser.String(), logUrl),
 				http.StatusNotFound)
 		}
 	}

--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -16,6 +16,6 @@ export KNATIVE_EVENTING_VERSION=v1.15.0
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
 kubectl apply -f https://github.com/knative/eventing/releases/download/knative-${KNATIVE_EVENTING_VERSION}/eventing.yaml
 kubectl rollout status deployment --namespace=cert-manager --timeout=30s
-kubectl rollout status deployment --namespace=knative-eventing --timeout=30s
+kubectl rollout status deployment --namespace=knative-eventing --timeout=50s
 
 bash hack/kubearchive-install.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #740 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

Fixes:

1. Timeout on log retrieval. Due to the needed time for the logs to get to splunk, the total time of the test need to be increased. By default it was 10 minutes and I extended it to 30 minutes (I experienced failures with 15 and 20 minutes). 
2. The timeout on the pagination test is addressed by increasing the number of retries from 30 to 60
3. The timeout on the deployment of knative-eventing in the installation part has been extended from 30s to 50s.
4. Included 3 retries to the port-forward operation that sometimes failed.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
