### PR TITLE
Fix deprecated usage of Defaulter and Validator webhooks

### DIFF
--- a/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook_test.go
+++ b/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook_test.go
@@ -1,0 +1,151 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKubeArchiveConfigCustomDefaulter(t *testing.T) {
+	defaulter := KubeArchiveConfigCustomDefaulter{}
+	kac := &KubeArchiveConfig{}
+	err := defaulter.Default(context.Background(), kac)
+	assert.NoError(t, err)
+	assert.Equal(t, KubeArchiveConfigSpec{Resources: nil}, kac.Spec)
+}
+
+func TestKubeArchiveConfigValidateName(t *testing.T) {
+	k9eResourceName := "kubearchive"
+	tests := []struct {
+		name      string
+		kacName   string
+		validated bool
+	}{
+		{
+			name:      "Valid name",
+			kacName:   k9eResourceName,
+			validated: true,
+		},
+		{
+			name:      "Invalid name",
+			kacName:   "otherName",
+			validated: false,
+		},
+	}
+	validator := KubeArchiveConfigCustomValidator{kubearchiveResourceName: k9eResourceName}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create resource
+			kac := &KubeArchiveConfig{ObjectMeta: metav1.ObjectMeta{Name: test.kacName}}
+			warns, err := validator.ValidateCreate(context.Background(), kac)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource name %s", test.kacName)
+			}
+			// Update resource
+			warns, err = validator.ValidateUpdate(context.Background(), &KubeArchiveConfig{}, kac)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource name %s", test.kacName)
+			}
+			// Delete resource
+			warns, err = validator.ValidateDelete(context.Background(), kac)
+			assert.Nil(t, warns)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateCELExpression(t *testing.T) {
+	k9eResourceName := "kubearchive"
+	invalid := "status.state *^ Completed'"
+	valid := "status.state == 'Completed'"
+	tests := []struct {
+		name            string
+		archiveWhen     string
+		deleteWhen      string
+		archiveOnDelete string
+		validated       bool
+	}{
+		{
+			name:            "Invalid archiveWhen expression",
+			archiveWhen:     invalid,
+			deleteWhen:      valid,
+			archiveOnDelete: valid,
+			validated:       false,
+		},
+		{
+			name:            "Invalid deleteWhen expression",
+			archiveWhen:     valid,
+			deleteWhen:      invalid,
+			archiveOnDelete: valid,
+			validated:       false,
+		},
+		{
+			name:            "Invalid archiveOnDelete expression",
+			archiveWhen:     valid,
+			deleteWhen:      valid,
+			archiveOnDelete: invalid,
+			validated:       false,
+		},
+		{
+			name:            "All expressions invalid",
+			archiveWhen:     invalid,
+			deleteWhen:      invalid,
+			archiveOnDelete: invalid,
+			validated:       false,
+		},
+		{
+			name:            "All expressions valid",
+			archiveWhen:     valid,
+			deleteWhen:      valid,
+			archiveOnDelete: valid,
+			validated:       true,
+		},
+	}
+	validator := KubeArchiveConfigCustomValidator{kubearchiveResourceName: k9eResourceName}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create resource
+			kac := &KubeArchiveConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: k9eResourceName},
+				Spec: KubeArchiveConfigSpec{
+					Resources: []KubeArchiveConfigResource{
+						{
+							ArchiveWhen:     test.archiveWhen,
+							DeleteWhen:      test.deleteWhen,
+							ArchiveOnDelete: test.archiveOnDelete,
+						},
+					}},
+			}
+			warns, err := validator.ValidateCreate(context.Background(), kac)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Contains(t, err.Error(), "Syntax error")
+			}
+			// Update resource
+			warns, err = validator.ValidateUpdate(context.Background(), &KubeArchiveConfig{}, kac)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Contains(t, err.Error(), "Syntax error")
+			}
+			// Delete resource
+			warns, err = validator.ValidateDelete(context.Background(), kac)
+			assert.Nil(t, warns)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -132,7 +132,7 @@ func main() {
 		os.Exit(1)
 	}
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err = (&kubearchiveapi.KubeArchiveConfig{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = kubearchiveapi.SetupWebhookWithManager(mgr); err != nil {
 			slog.Error("unable to create webhook", "webhook", "KubeArchiveConfig", "err", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #749 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Replaced webhook.Validator with webhook.CustomValidator
Replaced webhook.Defaulter with webhook.CustomDeafulter
Renamed private method validateCELExpressions to validateKAC so it can also allocate the name validation
to avoid having this piece repeated.

Everything was done by following the kubebuilder docs  of the webhook implementation - https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation

With this effort unit tests were also added for the custom defaulter and validator

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
