### PR TITLE
Set sslmode as required for PostgreSQL

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/installation.adoc
+++ b/docs/modules/ROOT/pages/getting-started/installation.adoc
@@ -11,7 +11,7 @@ This document explains how to install and configure KubeArchive in your Kubernet
 
 == Prerequisites
 
-* A PostgreSQL instance
+* A PostgreSQL instance protected with TLS (can be self-signed, KubeArchive does not verify it)
 * CertManager is installed on the Kubernetes cluster (+v1.9.1)
 * Knative Eventing is installed on the Kubernetes cluster (+v1.15.0)
 

--- a/integrations/database/postgresql/postgres.yaml
+++ b/integrations/database/postgresql/postgres.yaml
@@ -7,6 +7,11 @@ metadata:
   name: kubearchive
 spec:
   instances: 1
+  postgresql:
+    # https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+    # columns: connection-type database user address auth-options
+    pg_hba:
+      - hostnossl  all  all  all  reject
   bootstrap:
     initdb:
       database: kubearchive

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -32,7 +32,7 @@ func (creator PostgreSQLCreator) GetDriverName() string {
 }
 
 func (creator PostgreSQLCreator) GetConnectionString() string {
-	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s sslmode=disable", creator.env[DbUserEnvVar],
+	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%s sslmode=require", creator.env[DbUserEnvVar],
 		creator.env[DbPasswordEnvVar], creator.env[DbNameEnvVar], creator.env[DbHostEnvVar], creator.env[DbPortEnvVar])
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #755 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
KubeArchive now requires PostgreSQL databases to be protected with TLS. It can be with a self-signed certificate as the certificate is not verified, just required.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
