### PR TITLE
Sink and API now fail on DB startup error

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -60,7 +60,10 @@ func NewDatabase() (DBInterface, error) {
 		return nil, fmt.Errorf("no database registered with name '%s'", env[DbKindEnvVar])
 	}
 
-	conn := establishConnection(creator.GetDriverName(), creator.GetConnectionString())
+	conn, err := establishConnection(creator.GetDriverName(), creator.GetConnectionString())
+	if err != nil {
+		return nil, err
+	}
 
 	var database DBInterface
 	if init, ok := RegisteredDatabases[env[DbKindEnvVar]]; ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #753 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
KubeArchive Sink component now fail if it can't connect to the database.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* The release notes just mention the sink because the API was failing before due to the ready endpoint, so from the user perspective the sink wasn't failing correctly but the API did (but for another reason).

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
