### PR TITLE
add liveness and readyness endpoints to the sink

### DIFF
--- a/cmd/sink/routers/routers.go
+++ b/cmd/sink/routers/routers.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -14,15 +16,20 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	ceClient "github.com/cloudevents/sdk-go/v2/client"
 	"github.com/gin-gonic/gin"
+	"github.com/kubearchive/kubearchive/cmd/api/abort"
 	"github.com/kubearchive/kubearchive/cmd/sink/filters"
 	"github.com/kubearchive/kubearchive/cmd/sink/logs"
 	"github.com/kubearchive/kubearchive/pkg/database"
 	"github.com/kubearchive/kubearchive/pkg/models"
+	"github.com/kubearchive/kubearchive/pkg/observability"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 )
+
+const namespaceEnvVar = "KUBEARCHIVE_NAMESPACE"
 
 type Controller struct {
 	ceHandler     *ceClient.EventReceiver
@@ -227,4 +234,45 @@ func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Ev
 
 func (c *Controller) CloudEventsHandler(ctx *gin.Context) {
 	c.ceHandler.ServeHTTP(ctx.Writer, ctx.Request)
+}
+
+func (c *Controller) Livez(ctx *gin.Context) {
+	observabilityConfig := os.Getenv(observability.OtelStartEnvVar)
+	if observabilityConfig == "" {
+		observabilityConfig = "disabled"
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"Code":          http.StatusOK,
+		"ginMode":       gin.Mode(),
+		"openTelemetry": observabilityConfig,
+		"message":       "healthy",
+	})
+}
+
+// Readyz checks connections to the Database and to the Kubernetes API
+func (c *Controller) Readyz(ctx *gin.Context) {
+	err := c.Db.Ping(ctx.Request.Context())
+	if err != nil {
+		abort.Abort(ctx, err, http.StatusServiceUnavailable)
+		return
+	}
+	ns := os.Getenv(namespaceEnvVar)
+	if ns == "" {
+		err = fmt.Errorf(
+			"Could not determine the KubeArchive namespace. Environment variable %s is not set", namespaceEnvVar,
+		)
+		abort.Abort(ctx, err, http.StatusServiceUnavailable)
+	}
+	cm := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+	}
+	resource, _ := meta.UnsafeGuessKindToResource(cm.GroupVersionKind())
+	_, err = c.K8sClient.Resource(resource).Namespace(ns).List(ctx.Request.Context(), metav1.ListOptions{})
+	if err != nil {
+		abort.Abort(ctx, err, http.StatusServiceUnavailable)
+	}
+	ctx.JSON(http.StatusOK, gin.H{"message": "ready"})
 }

--- a/cmd/sink/server/server.go
+++ b/cmd/sink/server/server.go
@@ -30,6 +30,10 @@ func NewServer(controller *routers.Controller) *Server {
 	router.Use(otelgin.Middleware(""))
 
 	router.POST("/", controller.CloudEventsHandler)
+
+	router.GET("/livez", controller.Livez)
+	router.GET("/readyz", controller.Readyz)
+
 	return &Server{
 		controller: controller,
 		router:     router,

--- a/config/templates/sink/sink.yaml
+++ b/config/templates/sink/sink.yaml
@@ -71,6 +71,14 @@ spec:
                   fieldPath: metadata.namespace
             - name: KUBEARCHIVE_LOGGING_DIR
               value: /data/logging
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #306 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The readiness endpoint checks if the sink can connect to the database AND the Kubernetes API. Since the dynamic client does not have any kind of connection check method, the sink instead tries to list the ConfigMaps in the namespace it is deployed in (which it should always have the permissions to do)
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
