### PR TITLE
sink sends proper http response based on processing of a cloud event

### DIFF
--- a/cmd/sink/routers/result.go
+++ b/cmd/sink/routers/result.go
@@ -1,0 +1,19 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package routers
+
+import (
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/protocol"
+)
+
+func NewCEResult(statusCode int, err error) protocol.Result {
+	if statusCode >= 200 && statusCode < 400 {
+		// Cloud Event Processed successfully
+		return cloudevents.NewHTTPResult(statusCode, "cloud event processed successfully")
+	} else if err == nil {
+		return cloudevents.NewHTTPResult(statusCode, "an error occurred while processing the cloud event")
+	}
+	return cloudevents.NewHTTPResult(statusCode, "an error occurred while processing the cloud event", err.Error())
+}

--- a/cmd/sink/routers/routers.go
+++ b/cmd/sink/routers/routers.go
@@ -15,6 +15,7 @@ import (
 	ceOtelObs "github.com/cloudevents/sdk-go/observability/opentelemetry/v2/http"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	ceClient "github.com/cloudevents/sdk-go/v2/client"
+	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/abort"
 	"github.com/kubearchive/kubearchive/cmd/sink/filters"
@@ -60,7 +61,7 @@ func NewController(
 	return controller, nil
 }
 
-func (c *Controller) writeLogs(ctx context.Context, obj *unstructured.Unstructured) {
+func (c *Controller) writeLogs(ctx context.Context, obj *unstructured.Unstructured) error {
 	logCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	urls, err := c.LogUrlBuilder.Urls(logCtx, obj)
@@ -73,7 +74,7 @@ func (c *Controller) writeLogs(ctx context.Context, obj *unstructured.Unstructur
 			"name", obj.GetName(),
 			"err", err,
 		)
-		return
+		return err
 	}
 	if len(urls) == 0 {
 		slog.Info(
@@ -83,7 +84,7 @@ func (c *Controller) writeLogs(ctx context.Context, obj *unstructured.Unstructur
 			"namespace", obj.GetNamespace(),
 			"name", obj.GetName(),
 		)
-		return
+		return nil
 	}
 	err = c.Db.WriteUrls(logCtx, obj, c.LogUrlBuilder.GetJsonPath(), urls...)
 	if err != nil {
@@ -95,18 +96,19 @@ func (c *Controller) writeLogs(ctx context.Context, obj *unstructured.Unstructur
 			"name", obj.GetName(),
 			"err", err,
 		)
-	} else {
-		slog.Info(
-			"Successfully wrote log urls for object to the database",
-			"id", obj.GetUID(),
-			"kind", obj.GetKind(),
-			"namespace", obj.GetNamespace(),
-			"name", obj.GetName(),
-		)
+		return err
 	}
+	slog.Info(
+		"Successfully wrote log urls for object to the database",
+		"id", obj.GetUID(),
+		"kind", obj.GetKind(),
+		"namespace", obj.GetNamespace(),
+		"name", obj.GetName(),
+	)
+	return nil
 }
 
-func (c *Controller) writeResource(ctx context.Context, obj *unstructured.Unstructured, event cloudevents.Event) {
+func (c *Controller) writeResource(ctx context.Context, obj *unstructured.Unstructured, event cloudevents.Event) error {
 	dbCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
 	err := c.Db.WriteResource(dbCtx, obj, event.Data())
@@ -121,35 +123,40 @@ func (c *Controller) writeResource(ctx context.Context, obj *unstructured.Unstru
 			"name", obj.GetName(),
 			"err", err,
 		)
-	} else {
-		slog.Info(
-			"Successfully wrote object from cloudevent to the database",
-			"event-id", event.ID(),
-			"event-type", event.Type(),
-			"id", obj.GetUID(),
-			"kind", obj.GetKind(),
-			"namespace", obj.GetNamespace(),
-			"name", obj.GetName(),
-			"id", event.ID(),
-		)
+		return err
 	}
+	slog.Info(
+		"Successfully wrote object from cloudevent to the database",
+		"event-id", event.ID(),
+		"event-type", event.Type(),
+		"id", obj.GetUID(),
+		"kind", obj.GetKind(),
+		"namespace", obj.GetNamespace(),
+		"name", obj.GetName(),
+		"id", event.ID(),
+	)
 	// only write logs for k8s resources likes pods that have them and UrlBuilder is configured
 	if c.LogUrlBuilder != nil && strings.ToLower(obj.GetKind()) == "pod" {
-		c.writeLogs(ctx, obj)
+		err = c.writeLogs(ctx, obj)
 	}
+	return err
 }
 
-func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Event) {
+// receiveCloudEvent returns an HTTP 422 if event.Data is not a kubernetes object. All other failures should return HTTP
+// 500 instead.
+func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Event) protocol.Result {
 	k8sObj, err := models.UnstructuredFromByteSlice(event.Data())
 	if err != nil {
 		slog.Error("Received malformed CloudEvent", "event-id", event.ID(), "err", err)
-		return
+		return NewCEResult(http.StatusUnprocessableEntity, err)
 	}
 
 	if strings.HasSuffix(event.Type(), ".delete") {
 		if c.Filters.MustArchiveOnDelete(ctx, k8sObj) {
-			c.writeResource(ctx, k8sObj, event)
-			return
+			err = c.writeResource(ctx, k8sObj, event)
+			if err != nil {
+				return NewCEResult(http.StatusInternalServerError, err)
+			}
 		}
 
 		slog.Info(
@@ -161,7 +168,7 @@ func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Ev
 			"namespace", k8sObj.GetNamespace(),
 			"name", k8sObj.GetName(),
 		)
-		return
+		return NewCEResult(http.StatusOK, nil)
 	}
 
 	if !c.Filters.MustArchive(ctx, k8sObj) {
@@ -174,10 +181,13 @@ func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Ev
 			"namespace", k8sObj.GetNamespace(),
 			"name", k8sObj.GetName(),
 		)
-		return
+		return NewCEResult(http.StatusOK, nil)
 	}
 
-	c.writeResource(ctx, k8sObj, event)
+	err = c.writeResource(ctx, k8sObj, event)
+	if err != nil {
+		return NewCEResult(http.StatusInternalServerError, err)
+	}
 
 	if !c.Filters.MustDelete(ctx, k8sObj) {
 		slog.Info(
@@ -189,7 +199,7 @@ func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Ev
 			"namespace", k8sObj.GetNamespace(),
 			"name", k8sObj.GetName(),
 		)
-		return
+		return NewCEResult(http.StatusOK, err)
 	}
 
 	kind := k8sObj.GetObjectKind().GroupVersionKind()
@@ -214,12 +224,15 @@ func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Ev
 			"name", k8sObj.GetName(),
 			"err", err,
 		)
-		return
+		return NewCEResult(http.StatusInternalServerError, err)
 	}
 
 	deleteTs := metav1.Now()
 	k8sObj.SetDeletionTimestamp(&deleteTs)
-	c.writeResource(ctx, k8sObj, event)
+	err = c.writeResource(ctx, k8sObj, event)
+	if err != nil {
+		return NewCEResult(http.StatusInternalServerError, err)
+	}
 
 	slog.Info(
 		"Resource was updated, archived and deleted from the cluster",
@@ -230,6 +243,7 @@ func (c *Controller) receiveCloudEvent(ctx context.Context, event cloudevents.Ev
 		"namespace", k8sObj.GetNamespace(),
 		"name", k8sObj.GetName(),
 	)
+	return NewCEResult(http.StatusOK, nil)
 }
 
 func (c *Controller) CloudEventsHandler(ctx *gin.Context) {

--- a/cmd/sink/routers/testdata/CE-not-k8s.json
+++ b/cmd/sink/routers/testdata/CE-not-k8s.json
@@ -1,0 +1,18 @@
+{
+  "specversion": "1.0",
+  "type": "dev.knative.apiserver.resource.update",
+  "source": "http://localhost",
+  "subject": "/apis/batch/v1/namespaces/generate-logs-cronjobs/jobs/generate-log-1-28968184",
+  "id": "cbec9e69-accf-4dfd-a22b-e9947376e01c",
+  "time": "2025-01-28T19:04:03.880155449Z",
+  "datacontenttype": "application/json",
+  "apiversion": "batch/v1",
+  "kind": "Job",
+  "knativearrivaltime": "2025-01-28T19:04:03.880549164Z",
+  "name": "generate-log-1-28968184",
+  "namespace": "generate-logs-cronjobs",
+  "data": {
+    "foo": "bar",
+    "fizz": "buzz"
+  }
+}

--- a/cmd/sink/routers/testdata/CE-pod-does-not-exist.json
+++ b/cmd/sink/routers/testdata/CE-pod-does-not-exist.json
@@ -1,0 +1,187 @@
+{
+  "specversion": "1.0",
+  "type": "dev.knative.apiserver.resource.update",
+  "source": "http://localhost",
+  "subject": "/apis/batch/v1/namespaces/generate-logs-cronjobs/pods/generate-log-1-28806900-sp286",
+  "id": "cbec9e69-accf-4dfd-a22b-e9947376e01c",
+  "time": "2025-01-28T19:04:03.880155449Z",
+  "datacontenttype": "application/json",
+  "apiversion": "v1",
+  "kind": "Pod",
+  "knativearrivaltime": "2025-01-28T19:04:03.880549164Z",
+  "name": "generate-log-2-28806900-sp286",
+  "namespace": "generate-logs-cronjobs",
+  "data": {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "creationTimestamp": "2024-10-08T19:00:00Z",
+      "finalizers": [
+        "batch.kubernetes.io/job-tracking"
+      ],
+      "generateName": "generate-log-1-28806900-",
+      "labels": {
+        "batch.kubernetes.io/controller-uid": "9b2849e4-c5af-4ff8-9bd1-61d06dba67ad",
+        "batch.kubernetes.io/job-name": "generate-log-1-28806900",
+        "controller-uid": "9b2849e4-c5af-4ff8-9bd1-61d06dba67ad",
+        "job-name": "generate-log-1-28806900"
+      },
+      "managedFields": [
+        {
+          "apiVersion": "v1",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:finalizers": {
+                ".": {},
+                "v:\"batch.kubernetes.io/job-tracking\"": {}
+              },
+              "f:generateName": {},
+              "f:labels": {
+                ".": {},
+                "f:batch.kubernetes.io/controller-uid": {},
+                "f:batch.kubernetes.io/job-name": {},
+                "f:controller-uid": {},
+                "f:job-name": {}
+              },
+              "f:ownerReferences": {
+                ".": {},
+                "k:{\"uid\":\"9b2849e4-c5af-4ff8-9bd1-61d06dba67ad\"}": {}
+              }
+            },
+            "f:spec": {
+              "f:containers": {
+                "k:{\"name\":\"generate\"}": {
+                  ".": {},
+                  "f:args": {},
+                  "f:image": {},
+                  "f:imagePullPolicy": {},
+                  "f:name": {},
+                  "f:resources": {},
+                  "f:terminationMessagePath": {},
+                  "f:terminationMessagePolicy": {}
+                }
+              },
+              "f:dnsPolicy": {},
+              "f:enableServiceLinks": {},
+              "f:restartPolicy": {},
+              "f:schedulerName": {},
+              "f:securityContext": {},
+              "f:terminationGracePeriodSeconds": {}
+            }
+          },
+          "manager": "kube-controller-manager",
+          "operation": "Update",
+          "time": "2024-10-08T19:00:00Z"
+        }
+      ],
+      "name": "generate-log-2-28806900-sp286",
+      "namespace": "generate-logs-cronjobs",
+      "ownerReferences": [
+        {
+          "apiVersion": "batch/v1",
+          "blockOwnerDeletion": true,
+          "controller": true,
+          "kind": "Job",
+          "name": "generate-log-1-28806900",
+          "uid": "9b2849e4-c5af-4ff8-9bd1-61d06dba67ad"
+        }
+      ],
+      "resourceVersion": "34272",
+      "uid": "4df2df3f-7397-4a63-86b4-9f5f1ff84f99"
+    },
+    "spec": {
+      "containers": [
+        {
+          "args": [
+            "-n",
+            "1024",
+            "-d",
+            "20ms"
+          ],
+          "image": "quay.io/kubearchive/mingrammer/flog",
+          "imagePullPolicy": "IfNotPresent",
+          "name": "generate",
+          "resources": {},
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+              "name": "kube-api-access-n82dz",
+              "readOnly": true
+            }
+          ]
+        }
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "enableServiceLinks": true,
+      "preemptionPolicy": "PreemptLowerPriority",
+      "priority": 0,
+      "restartPolicy": "OnFailure",
+      "schedulerName": "default-scheduler",
+      "securityContext": {},
+      "serviceAccount": "default",
+      "serviceAccountName": "default",
+      "terminationGracePeriodSeconds": 30,
+      "tolerations": [
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        },
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        }
+      ],
+      "volumes": [
+        {
+          "name": "kube-api-access-n82dz",
+          "projected": {
+            "defaultMode": 420,
+            "sources": [
+              {
+                "serviceAccountToken": {
+                  "expirationSeconds": 3607,
+                  "path": "token"
+                }
+              },
+              {
+                "configMap": {
+                  "items": [
+                    {
+                      "key": "ca.crt",
+                      "path": "ca.crt"
+                    }
+                  ],
+                  "name": "kube-root-ca.crt"
+                }
+              },
+              {
+                "downwardAPI": {
+                  "items": [
+                    {
+                      "fieldRef": {
+                        "apiVersion": "v1",
+                        "fieldPath": "metadata.namespace"
+                      },
+                      "path": "namespace"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "status": {
+      "phase": "Pending",
+      "qosClass": "BestEffort"
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #779, related to #814

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Now KubeArchive retries to process resource updates if a failure happens.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
if the sink fails to write the resource or log urls from a cloud event to the database or if the sink fails to delete
the resource from the cluster, the sink will respond with an http 500 response. This will allow senders of Cloud
Events to respond to cloud event delivery failure. The exception to this is when the payload of the Cloud Event
is not a kubernetes resource. In this case a 422 response is sent.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
