### PR TITLE
Support empty KubeArchiveConfig.

### DIFF
--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -13,11 +13,13 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/kubearchive/kubearchive/test"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	errs "k8s.io/apimachinery/pkg/api/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -66,6 +68,18 @@ func TestLogging(t *testing.T) {
 		errNamespace = clientset.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})
 		if errNamespace != nil {
 			t.Fatal(errNamespace)
+		}
+
+		retryErr := retry.Do(func() error {
+			_, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
+			if !errs.IsNotFound(getErr) {
+				return errors.New("Waiting for namespace "+namespaceName+" to be deleted")
+			}
+			return nil
+		}, retry.Attempts(10), retry.MaxDelay(3*time.Second))
+
+		if retryErr != nil {
+			t.Log(retryErr)
 		}
 	})
 

--- a/test/integration/operator_test.go
+++ b/test/integration/operator_test.go
@@ -1,0 +1,227 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	kubearchivev1alpha1 "github.com/kubearchive/kubearchive/cmd/operator/api/v1alpha1"
+	"github.com/kubearchive/kubearchive/test"
+	corev1 "k8s.io/api/core/v1"
+	errs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type Test int
+
+const (
+	emptyKAC Test = iota
+	nonEmptyKAC
+)
+
+const (
+	kacName     = "kubearchive"
+	a13eName    = kacName + "-a13e"
+	sinkName    = kacName + "-sink"
+	filtersName = "sink-filters"
+)
+
+func TestEmptyKAC(t *testing.T) {
+	runTest(t, emptyKAC, map[string]any{})
+}
+
+func TestNonEmptyKAC(t *testing.T) {
+	resources := map[string]any{
+		"resources": []map[string]any{
+			{
+				"selector": map[string]string{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+				},
+				"archiveWhen": "true",
+				"deleteWhen":  "status.phase == 'Succeeded'",
+			},
+		},
+	}
+	runTest(t, nonEmptyKAC, resources)
+}
+
+func runTest(t testing.TB, testName Test, resources map[string]any) {
+	t.Helper()
+
+	clientset, dynaclient, errClient := test.GetKubernetesClient()
+	if errClient != nil {
+		t.Fatal(errClient)
+	}
+
+	// Create test namespace
+	namespaceName := fmt.Sprintf("test-%s", test.RandomString())
+	t.Log("Running test in namespace "+namespaceName)
+	_, errNamespace := clientset.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaceName,
+		},
+	}, metav1.CreateOptions{})
+	if errNamespace != nil {
+		t.Fatal(errNamespace)
+	}
+	// This register the function.
+	t.Cleanup(func() {
+		// delete the test namespace
+		errNamespace = clientset.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})
+		if errNamespace != nil {
+			t.Fatal(errNamespace)
+		}
+
+		retryErr := retry.Do(func() error {
+			_, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
+			if !errs.IsNotFound(getErr) {
+				return errors.New("Waiting for namespace "+namespaceName+" to be deleted")
+			}
+			return nil
+		}, retry.Attempts(10), retry.MaxDelay(3*time.Second))
+
+		if retryErr != nil {
+			t.Log(retryErr)
+		}
+	})
+
+	kac := newKAC(namespaceName, resources)
+	gvr := kubearchivev1alpha1.GroupVersion.WithResource("kubearchiveconfigs")
+	_, err := dynaclient.Resource(gvr).Namespace(namespaceName).Create(context.Background(), kac, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkResourcesAfterApply(t, namespaceName, testName)
+
+	err = dynaclient.Resource(gvr).Namespace(namespaceName).Delete(context.Background(), kacName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkResourcesAfterDelete(t, namespaceName, testName)
+}
+
+func checkResourcesAfterApply(t testing.TB, namespace string, testName Test) {
+	t.Helper()
+
+	clientset, dynaclient, _ := test.GetKubernetesClient()
+
+	err := retry.Do(func() error {
+		gvr := schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1", Resource: "apiserversources"}
+		_, getErr := dynaclient.Resource(gvr).Namespace(test.K9eNamespace).Get(context.Background(), a13eName, metav1.GetOptions{})
+		if testName == emptyKAC {
+			if !errs.IsNotFound(getErr) {
+				return errors.New("Unexpectedly found an ApiServerSource.")
+			}
+		} else {
+			if getErr != nil {
+				return getErr
+			}
+		}
+		_, getErr = clientset.CoreV1().ConfigMaps(test.K9eNamespace).Get(context.Background(), filtersName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.CoreV1().ServiceAccounts(test.K9eNamespace).Get(context.Background(), a13eName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.RbacV1().ClusterRoles().Get(context.Background(), a13eName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.RbacV1().RoleBindings(namespace).Get(context.Background(), a13eName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.RbacV1().Roles(namespace).Get(context.Background(), sinkName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.RbacV1().RoleBindings(namespace).Get(context.Background(), sinkName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		return nil
+	}, retry.Attempts(10), retry.MaxDelay(3*time.Second))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkResourcesAfterDelete(t testing.TB, namespace string, testName Test) {
+	t.Helper()
+
+	clientset, dynaclient, _ := test.GetKubernetesClient()
+
+	err := retry.Do(func() error {
+		gvr := schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1", Resource: "apiserversources"}
+		_, getErr := dynaclient.Resource(gvr).Namespace(test.K9eNamespace).Get(context.Background(), a13eName, metav1.GetOptions{})
+		if testName == emptyKAC || testName == nonEmptyKAC {
+			if !errs.IsNotFound(getErr) {
+				return errors.New("Unexpectedly found an ApiServerSource.")
+			}
+		} else {
+			if getErr != nil {
+				return getErr
+			}
+		}
+		_, getErr = clientset.CoreV1().ConfigMaps(test.K9eNamespace).Get(context.Background(), filtersName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.CoreV1().ServiceAccounts(test.K9eNamespace).Get(context.Background(), a13eName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.RbacV1().ClusterRoles().Get(context.Background(), a13eName, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		_, getErr = clientset.RbacV1().RoleBindings(namespace).Get(context.Background(), a13eName, metav1.GetOptions{})
+		if !errs.IsNotFound(getErr) {
+			return errors.New("Unexpectedly found Rolebinding " + a13eName + " in namespace " + namespace + ".")
+		}
+		_, getErr = clientset.RbacV1().Roles(namespace).Get(context.Background(), sinkName, metav1.GetOptions{})
+		if !errs.IsNotFound(getErr) {
+			return errors.New("Unexpectedly found Role " + sinkName + " in namespace " + namespace + ".")
+		}
+		_, getErr = clientset.RbacV1().RoleBindings(namespace).Get(context.Background(), sinkName, metav1.GetOptions{})
+		if !errs.IsNotFound(getErr) {
+			return errors.New("Unexpectedly found Rolebinding " + sinkName + " in namespace " + namespace + ".")
+		}
+		return nil
+	}, retry.Attempts(10), retry.MaxDelay(3*time.Second))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newKAC(namespace string, resources map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "KubeArchiveConfig",
+			"apiVersion": fmt.Sprintf("%s/%s",
+				kubearchivev1alpha1.SchemeBuilder.GroupVersion.Group,
+				kubearchivev1alpha1.SchemeBuilder.GroupVersion.Version),
+			"metadata": map[string]string{
+				"name":      kacName,
+				"namespace": namespace,
+			},
+			"spec": resources,
+		},
+	}
+}

--- a/test/integration/pagination_test.go
+++ b/test/integration/pagination_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-
 	"testing"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	errs "k8s.io/apimachinery/pkg/api/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -45,6 +45,18 @@ func TestPagination(t *testing.T) {
 		err = clientset.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		retryErr := retry.Do(func() error {
+			_, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
+			if !errs.IsNotFound(getErr) {
+				return errors.New("Waiting for namespace "+namespaceName+" to be deleted")
+			}
+			return nil
+		}, retry.Attempts(10), retry.MaxDelay(3*time.Second))
+
+		if retryErr != nil {
+			t.Log(retryErr)
 		}
 	})
 
@@ -87,8 +99,8 @@ func TestPagination(t *testing.T) {
 			Containers: []corev1.Container{
 				corev1.Container{
 					Name:    "fedora",
-					Command: []string{"sleep", "10"},
-					Image:   "quay.io/fedora/fedora:latest",
+					Command: []string{"sleep", "1"},
+					Image:   "quay.io/fedora/fedora-minimal:latest",
 				},
 			},
 		},
@@ -171,7 +183,7 @@ func TestPagination(t *testing.T) {
 			return nil
 		}
 		return errors.New("could not retrieve Pods from the API")
-	}, retry.Attempts(80), retry.MaxDelay(4*time.Second))
+	}, retry.Attempts(240), retry.MaxDelay(4*time.Second))
 
 	if err != nil {
 		t.Fatal(err)

--- a/test/main.go
+++ b/test/main.go
@@ -34,6 +34,7 @@ import (
 const (
 	letterBytes   = "abcdefghijklmnopqrstuvwxyz"
 	randSuffixLen = 8
+	K9eNamespace  = "kubearchive"
 )
 
 func RandomString() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #780

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
ApiServerSource requires resources to run successfully.  These changes take that into account. If at any point reconcile finds there are no resources to give to ApiServerSource, then the existing ApiServerSource is deleted.  It will be recreated the next time reconcile runs and has resources.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
