### PR TITLE
run all integrations tests in parallel

### DIFF
--- a/.github/workflows/go_test_integration.yml
+++ b/.github/workflows/go_test_integration.yml
@@ -57,4 +57,9 @@ jobs:
           bash integrations/logging/splunk/install.sh
       - name: Test Go code
         run: |
-          go test -count=1 -v ./test/integration -tags=integration -timeout 60m
+          bash test/integration/run.sh
+      - name: Archive integration test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: results
+          path: integration-results

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ release-notes.json
 # Performance
 perf-results/*
 merge/*
+
+# Integration Test Results
+integration-results/*

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+
+RESULTS_DIR="integration-results"
+FILE_PREFIX=$(date +"%d-%b-%Y_%H-%M")
+
+if [ ! -d "${RESULTS_DIR}" ]; then
+    mkdir -p ${RESULTS_DIR}
+fi
+
+go test -json -count=1 -v ./test/integration -tags=integration -timeout 60m \
+    | tee ${RESULTS_DIR}/${FILE_PREFIX}_results.jsonl \
+    | jq -r 'select(.Action == "output") | .Output | rtrimstr("\n")'
+
+jq --slurp -r 'group_by(.Test) | .[] | .[] | select(.Action == "output") | .Output | rtrimstr("\n")' ${RESULTS_DIR}/${FILE_PREFIX}_results.jsonl > ${RESULTS_DIR}/${FILE_PREFIX}_formatted.txt
+
+# Don't fail if we can't generate a summary of the action
+set +o errexit
+
+cat << EOF > ${GITHUB_STEP_SUMMARY:-/dev/stdout}
+## Integration Test Logs Grouped by Test
+\`\`\`
+$(cat ${RESULTS_DIR}/${FILE_PREFIX}_formatted.txt)
+\`\`\`
+
+## Integration Test Logs as JSON Lines
+\`\`\`
+$(cat ${RESULTS_DIR}/${FILE_PREFIX}_results.jsonl)
+\`\`\`
+EOF


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #866

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
`TestEmptyKAC`, `TestNonEmptyKAC`, and `TestDatabaseConnection` cannot be run in parallel. `TestEmptyKAC` and `TestNonEmptyKAC` cannot be run in parallel because they are affected by KACs created by other tests. `TestDatabaseConnection` cannot be run in parallel because messing with the api server and sink database connections affect other tests.

The code to port forward the api server and run the log generators has been modified to allow each to be called concurrently. Functions that write to stdout or stderr have been updated to call `t.Log` or `t.Log`f to make it easier to understand which test is printing what output.

Helper functions that write to stdout or stderr now call `t.Helper` to register themselves as helper functions to make tracing errors easier.

The total time to run all of the integration tests locally has gone from 249.431s to 93.001s

The total time to run all of the integration test in the github actions has gone from ~4m to 2m 46s

The total time to run the whole integration test github action has gone from 11m to 10m
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
