### PR TITLE
remove deleteWhen so splunk correctly stores logs for pods with multiple containers

### DIFF
--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/kubearchive/kubearchive/test"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	errs "k8s.io/apimachinery/pkg/api/errors"
 	rbacv1 "k8s.io/api/rbac/v1"
+	errs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -75,7 +75,7 @@ func TestLogging(t *testing.T) {
 		retryErr := retry.Do(func() error {
 			_, getErr := clientset.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
 			if !errs.IsNotFound(getErr) {
-				return errors.New("Waiting for namespace "+namespaceName+" to be deleted")
+				return errors.New("Waiting for namespace " + namespaceName + " to be deleted")
 			}
 			return nil
 		}, retry.Attempts(10), retry.MaxDelay(3*time.Second))
@@ -255,7 +255,6 @@ func TestDefaultContainer(t *testing.T) {
 							"kind":       "Pod",
 						},
 						"archiveWhen": "true",
-						"deleteWhen":  "status.phase == 'Succeeded'",
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #905

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Splunk has issues with the logs for the container `second` because it seems like the pod gets deleted too quickly. For now the fix is removing the `deleteWhen` clause in the test, but a more robust change maybe implemented later
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
