### PR TITLE
Old versions of resources do not get written to db

### DIFF
--- a/cmd/sink/k8s/objects.go
+++ b/cmd/sink/k8s/objects.go
@@ -1,0 +1,23 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8s
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// GetLastUpdateTs returns the last time obj was updated on the cluster
+func GetLastUpdateTs(obj *unstructured.Unstructured) time.Time {
+	fields := obj.GetManagedFields()
+	var latest *metav1.Time
+	for _, elem := range fields {
+		if latest == nil || latest.Before(elem.Time) {
+			latest = elem.Time
+		}
+	}
+	return latest.Time
+}

--- a/cmd/sink/routers/routers.go
+++ b/cmd/sink/routers/routers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/sink/filters"
+	"github.com/kubearchive/kubearchive/cmd/sink/k8s"
 	"github.com/kubearchive/kubearchive/cmd/sink/logs"
 	"github.com/kubearchive/kubearchive/pkg/abort"
 	"github.com/kubearchive/kubearchive/pkg/database"
@@ -110,9 +111,10 @@ func (c *Controller) writeLogs(ctx context.Context, obj *unstructured.Unstructur
 }
 
 func (c *Controller) writeResource(ctx context.Context, obj *unstructured.Unstructured, event cloudevents.Event) error {
+	lastUpdateTs := k8s.GetLastUpdateTs(obj)
 	dbCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 	defer cancel()
-	err := c.Db.WriteResource(dbCtx, obj, event.Data())
+	err := c.Db.WriteResource(dbCtx, obj, event.Data(), lastUpdateTs)
 	if err != nil {
 		slog.Error(
 			"Failed to write object from cloudevent to the database",

--- a/docs/modules/ROOT/pages/reference/database.adoc
+++ b/docs/modules/ROOT/pages/reference/database.adoc
@@ -42,6 +42,10 @@ This document lists and details the database schema used by KubeArchive.
 |timestamp not null
 |Last time this record was updated.
 
+|cluster_updated_ts
+|timestamp not null
+|Timestamp when the resource was last updated on the cluster.
+
 |cluster_deleted_ts
 |timestamp not null
 |Timestamp when KubeArchive deleted the resource from the cluster.

--- a/integrations/database/postgresql/kubearchive.sql
+++ b/integrations/database/postgresql/kubearchive.sql
@@ -131,6 +131,7 @@ CREATE TABLE public.resource (
     resource_version character varying,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    cluster_updated_ts timestamp with time zone NOT NULL,
     cluster_deleted_ts timestamp with time zone,
     data jsonb NOT NULL
 );

--- a/pkg/database/facade/inserter.go
+++ b/pkg/database/facade/inserter.go
@@ -5,6 +5,7 @@ package facade
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/huandu/go-sqlbuilder"
 )
@@ -13,6 +14,7 @@ import (
 type DBInserter interface {
 	ResourceInserter(
 		uuid, apiVersion, kind, name, namespace, version string,
+		clusterUpdatedTs time.Time,
 		clusterDeletedTs sql.NullString,
 		data []byte,
 	) *sqlbuilder.InsertBuilder

--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -6,6 +6,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/huandu/go-sqlbuilder"
@@ -117,16 +118,24 @@ type MariaDBInserter struct {
 
 func (MariaDBInserter) ResourceInserter(
 	uuid, apiVersion, kind, name, namespace, version string,
+	clusterUpdatedTs time.Time,
 	clusterDeletedTs sql.NullString,
 	data []byte,
 ) *sqlbuilder.InsertBuilder {
 	ib := sqlbuilder.NewInsertBuilder()
 	ib.InsertInto("resource")
-	ib.Cols("uuid", "api_version", "kind", "name", "namespace", "resource_version", "cluster_deleted_ts", "data")
-	ib.Values(uuid, apiVersion, kind, name, namespace, version, clusterDeletedTs, data)
+	ib.Cols(
+		"uuid", "api_version", "kind", "name", "namespace", "resource_version", "cluster_updated_ts",
+		"cluster_deleted_ts", "data",
+	)
+	ib.Values(uuid, apiVersion, kind, name, namespace, version, clusterUpdatedTs, clusterDeletedTs, data)
 	ib.SQL(ib.Var(sqlbuilder.Build(
-		"ON DUPLICATE KEY UPDATE name=$?, namespace=$?, resource_version=$?, cluster_deleted_ts=$?, data=$?",
-		name, namespace, version, clusterDeletedTs, data,
+		"ON DUPLICATE KEY UPDATE name=$?, namespace=$?, resource_version=$?, cluster_updated_ts=$?, cluster_deleted_ts=$?, data=$?",
+		name, namespace, version, clusterUpdatedTs, clusterDeletedTs, data,
+	)))
+	ib.SQL(ib.Var(sqlbuilder.Build(
+		"WHERE resource.cluster_deleted_ts < $?",
+		clusterUpdatedTs,
 	)))
 	return ib
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #817 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
sink does not update resources in the database with older version of that resource
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
This change adds `cluster_updated_ts` which is the timestamp for the last update of the resource on the cluster. This can be calculated by iterating over the elements in the `metadata.managedFields` and finding the most recent `time` field

The Insert query for resources now includes a `WHERE` clause that checks if the current `cluster_updated_ts` in the database is older than the new `cluster_updated_ts`. If it is, the resource is updated. If it is not, the resource is left as is and the sink responds with a http 202 response to the cloud event
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
