### PR TITLE
Increase the work_mem parameter from 4MB (default) to 64MB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,7 @@ indent_size = 2
 
 [{*.go,go.mod,go.sum}]
 indent_style = tab
+
+[*.sql]
+indent_style = space
+indent_size = 4

--- a/integrations/database/postgresql/kubearchive.sql
+++ b/integrations/database/postgresql/kubearchive.sql
@@ -44,6 +44,7 @@ SET row_security = off;
 --
 
 ALTER DATABASE kubearchive SET "TimeZone" TO 'UTC';
+ALTER DATABASE kubearchive SET work_mem TO '64MB';
 
 
 \connect kubearchive
@@ -88,7 +89,7 @@ CREATE TABLE public.log_url (
     uuid uuid NOT NULL,
     url text NOT NULL,
     container_name text NOT NULL,
-	json_path text,
+    json_path text,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -264,3 +265,4 @@ ALTER TABLE ONLY public.log_url
 --
 -- PostgreSQL database dump complete
 --
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #901 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

There is a cosmetic change of a tab to spaces that was done automatically by `pg_dump`.
I'm not sure why there was a tab instead of a set of spaces previously.

To prevent further errors like this, I've added the change suggested by Sam to get the IDE configured to do spacing instead of tabbing in the SQL files.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
