### PR TITLE
integration test action should fail when go test cmd fails

### DIFF
--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -4,6 +4,7 @@
 
 set -o xtrace
 set -o errexit
+set -o pipefail
 
 RESULTS_DIR="integration-results"
 FILE_PREFIX=$(date +"%d-%b-%Y_%H-%M")
@@ -12,14 +13,18 @@ if [ ! -d "${RESULTS_DIR}" ]; then
     mkdir -p ${RESULTS_DIR}
 fi
 
+# Don't fail immediately so we can generate a summary of the action
+set +o errexit
+
 go test -json -count=1 -v ./test/integration -tags=integration -timeout 60m \
     | tee ${RESULTS_DIR}/${FILE_PREFIX}_results.jsonl \
     | jq -r 'select(.Action == "output") | .Output | rtrimstr("\n")'
 
+# save return code from integration test to use as return code from this script later
+RET_CODE="$?"
+
 jq --slurp -r 'group_by(.Test) | .[] | .[] | select(.Action == "output") | .Output | rtrimstr("\n")' ${RESULTS_DIR}/${FILE_PREFIX}_results.jsonl > ${RESULTS_DIR}/${FILE_PREFIX}_formatted.txt
 
-# Don't fail if we can't generate a summary of the action
-set +o errexit
 
 cat << EOF > ${GITHUB_STEP_SUMMARY:-/dev/stdout}
 ## Integration Test Logs Grouped by Test
@@ -32,3 +37,6 @@ $(cat ${RESULTS_DIR}/${FILE_PREFIX}_formatted.txt)
 $(cat ${RESULTS_DIR}/${FILE_PREFIX}_results.jsonl)
 \`\`\`
 EOF
+
+# use exit code from integration test command as return code for this script
+exit $RET_CODE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #917 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
test/integration/run.sh needs to set `set -o pipefail` so that if the `go test` command fails, the integration test action reports as failed. The script saves the `go test` return code, generates the summary of the action, then exits the script with the saved return code
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
