### PR TITLE
Use sprintf + Var instead of sqlbuilder.Build

### DIFF
--- a/pkg/database/mariadb.go
+++ b/pkg/database/mariadb.go
@@ -62,17 +62,16 @@ type MariaDBFilter struct {
 }
 
 func (MariaDBFilter) CreationTSAndIDFilter(cond sqlbuilder.Cond, continueDate, continueId string) string {
-	return cond.Var(sqlbuilder.Build(
-		"(CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid) < ($?, $?)",
-		continueDate, continueId,
-	))
+	return fmt.Sprintf(
+		"(CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime), uuid) < (%s, %s)",
+		cond.Var(continueDate), cond.Var(continueId),
+	)
 }
 
 func (MariaDBFilter) OwnerFilter(cond sqlbuilder.Cond, uuids []string) string {
-	return cond.Var(sqlbuilder.Build(
-		"JSON_OVERLAPS(JSON_EXTRACT(data, '$.metadata.ownerReferences.**.uid'), JSON_ARRAY($?))",
-		sqlbuilder.List(uuids),
-	))
+	return fmt.Sprintf(
+		"JSON_OVERLAPS(JSON_EXTRACT(data, '$.metadata.ownerReferences.**.uid'), JSON_ARRAY(%s))",
+		cond.Var(sqlbuilder.List(uuids)))
 }
 
 func (MariaDBFilter) ExistsLabelFilter(cond sqlbuilder.Cond, labels []string) string {

--- a/pkg/database/postgresql.go
+++ b/pkg/database/postgresql.go
@@ -66,39 +66,39 @@ type PostgreSQLFilter struct {
 }
 
 func (PostgreSQLFilter) CreationTSAndIDFilter(cond sqlbuilder.Cond, continueDate, continueId string) string {
-	return cond.Var(sqlbuilder.Build(
-		"(data->'metadata'->>'creationTimestamp', id) < ($?, $?)",
-		continueDate, continueId,
-	))
+	return fmt.Sprintf(
+		"(data->'metadata'->>'creationTimestamp', id) < (%s, %s)",
+		cond.Var(continueDate), cond.Var(continueId),
+	)
 }
 
 func (PostgreSQLFilter) OwnerFilter(cond sqlbuilder.Cond, owners []string) string {
-	return cond.Var(sqlbuilder.Build(
-		"jsonb_path_query_array(data->'metadata'->'ownerReferences', '$[*].uid') ?| $?",
-		pq.Array(owners),
-	))
+	return fmt.Sprintf(
+		"jsonb_path_query_array(data->'metadata'->'ownerReferences', '$[*].uid') ?| %s",
+		cond.Var(pq.Array(owners)),
+	)
 }
 
 func (PostgreSQLFilter) ExistsLabelFilter(cond sqlbuilder.Cond, labels []string) string {
-	return cond.Var(sqlbuilder.Build(
-		"data->'metadata'->'labels' ?& $?",
-		pq.Array(labels),
-	))
+	return fmt.Sprintf(
+		"data->'metadata'->'labels' ?& %s",
+		cond.Var(pq.Array(labels)),
+	)
 }
 
 func (PostgreSQLFilter) NotExistsLabelFilter(cond sqlbuilder.Cond, labels []string) string {
-	return cond.Var(sqlbuilder.Build(
-		"NOT data->'metadata'->'labels' ?| $?",
-		pq.Array(labels),
-	))
+	return fmt.Sprintf(
+		"NOT data->'metadata'->'labels' ?| %s",
+		cond.Var(pq.Array(labels)),
+	)
 }
 
-func (PostgreSQLFilter) EqualsLabelFilter(cond sqlbuilder.Cond, labels map[string]string) string {
+func (PostgreSQLFilter) EqualsLabelFilter(_ sqlbuilder.Cond, labels map[string]string) string {
 	jsonLabels, _ := json.Marshal(labels)
-	return cond.Var(sqlbuilder.Build(
-		"data->'metadata'->'labels' @> $?",
+	return fmt.Sprintf(
+		"data->'metadata'->'labels' @> %s",
 		string(jsonLabels),
-	))
+	)
 }
 
 func (PostgreSQLFilter) NotEqualsLabelFilter(cond sqlbuilder.Cond, labels map[string]string) string {
@@ -106,10 +106,10 @@ func (PostgreSQLFilter) NotEqualsLabelFilter(cond sqlbuilder.Cond, labels map[st
 	for key, value := range labels {
 		jsons = append(jsons, fmt.Sprintf("{\"%s\":\"%s\"}", key, value))
 	}
-	return cond.Var(sqlbuilder.Build(
-		"NOT data->'metadata'->'labels' @> ANY($?::jsonb[])",
-		pq.Array(jsons),
-	))
+	return fmt.Sprintf(
+		"NOT data->'metadata'->'labels' @> ANY(%s::jsonb[])",
+		cond.Var(pq.Array(jsons)),
+	)
 }
 
 func (PostgreSQLFilter) InLabelFilter(cond sqlbuilder.Cond, labels map[string][]string) string {
@@ -119,10 +119,9 @@ func (PostgreSQLFilter) InLabelFilter(cond sqlbuilder.Cond, labels map[string][]
 		for _, value := range values {
 			jsons = append(jsons, fmt.Sprintf("{\"%s\":\"%s\"}", key, value))
 		}
-		clauses = append(clauses, cond.Var(sqlbuilder.Build(
-			"data->'metadata'->'labels' @> ANY($?::jsonb[])",
-			pq.Array(jsons),
-		)))
+		clauses = append(clauses, fmt.Sprintf(
+			"data->'metadata'->'labels' @> ANY(%s::jsonb[])",
+			cond.Var(pq.Array(jsons))))
 	}
 	return cond.And(clauses...)
 }
@@ -135,10 +134,9 @@ func (f PostgreSQLFilter) NotInLabelFilter(cond sqlbuilder.Cond, labels map[stri
 			jsons = append(jsons, fmt.Sprintf("{\"%s\":\"%s\"}", key, value))
 		}
 	}
-	notContainsClause := cond.Var(sqlbuilder.Build(
-		"NOT data->'metadata'->'labels' @> ANY($?::jsonb[])",
-		pq.Array(jsons),
-	))
+	notContainsClause := fmt.Sprintf(
+		"NOT data->'metadata'->'labels' @> ANY(%s::jsonb[])",
+		cond.Var(pq.Array(jsons)))
 	return cond.And(f.ExistsLabelFilter(cond, slices.Collect(keys)), notContainsClause)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #926

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

With this change I believe it's more clear that we work with strings with regards to the filters, and that the sqlbuilder.Var, sqlbuilder.Cond are helpers to get those strings well formatted.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
