### PR TITLE
Add a test to check the order of retrieved logs

### DIFF
--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -71,6 +71,75 @@ func TestLogging(t *testing.T) {
 	}
 }
 
+func TestLogOrder(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	port := test.PortForwardApiServer(t, clientset)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+
+	resources := map[string]any{
+		"resources": []map[string]any{
+			{
+				"selector": map[string]string{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+				},
+				"archiveWhen": "true",
+			},
+		},
+	}
+
+	test.CreateKAC(t, namespaceName, resources)
+
+	// Create a pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "logs-order",
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "logs",
+					Image:   "quay.io/fedora/fedora:latest",
+					Command: []string{"/bin/sh", "-c", "echo First && sleep 10 && echo Second"},
+				},
+			},
+		},
+	}
+	_, err := clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	url := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods/logs-order/log", port, namespaceName)
+	retryErr := retry.Do(func() error {
+		body, err := test.GetLogs(t, token.Status.Token, url)
+		if err != nil {
+			return err
+		}
+
+		if len(body) == 0 {
+			return errors.New("could not retrieve the pod log")
+		}
+		t.Log("Successfully retrieved logs")
+
+		bodyString := string(body)
+		if bodyString != "First\nSecond\n" {
+			t.Log("log does not match")
+			return fmt.Errorf("log does not match the expected 'First\nSecond\n'")
+		}
+
+		return nil
+	}, retry.Attempts(1000), retry.MaxDelay(2*time.Second))
+
+	if retryErr != nil {
+		t.Fatal(retryErr)
+	}
+
+}
+
 func TestDefaultContainer(t *testing.T) {
 	t.Parallel()
 

--- a/test/main.go
+++ b/test/main.go
@@ -318,7 +318,7 @@ func RunLogGenerator(t testing.TB, namespace string) string {
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
-						corev1.Container{
+						{
 							Name:    "flog",
 							Command: []string{"flog", "-n", "10", "-d", "1ms"},
 							Image:   "quay.io/kubearchive/mingrammer/flog",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #953 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The LOG_URL retrieves the logs in the expected order, but now we have a test that ensures that.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
