### PR TITLE
renovate updates dependency versions in bash scripts

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/installation.adoc
+++ b/docs/modules/ROOT/pages/getting-started/installation.adoc
@@ -12,7 +12,9 @@ This document explains how to install and configure KubeArchive in your Kubernet
 == Prerequisites
 
 * A PostgreSQL instance protected with TLS (can be self-signed, KubeArchive does not verify it)
+// renovate: datasource=github-releases depName=cert-manager packageName=cert-manager/cert-manager
 * CertManager is installed on the Kubernetes cluster (+v1.9.1)
+// renovate: datasource=github-releases depName=knative-eventing packageName=knative/eventing
 * Knative Eventing is installed on the Kubernetes cluster (+v1.15.0)
 
 == Prepare the Database

--- a/hack/quick-install.sh
+++ b/hack/quick-install.sh
@@ -10,7 +10,9 @@ cd ${SCRIPT_DIR}/..
 
 bash integrations/database/postgresql/install.sh
 
+# renovate: datasource=github-releases depName=cert-manager packageName=cert-manager/cert-manager
 export CERT_MANAGER_VERSION=v1.9.1
+# renovate: datasource=github-releases depName=knative-eventing packageName=knative/eventing
 export KNATIVE_EVENTING_VERSION=v1.15.0
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml

--- a/integrations/database/mysql/install.sh
+++ b/integrations/database/mysql/install.sh
@@ -7,7 +7,8 @@ set -o errexit -o errtrace
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${SCRIPT_DIR}
 
-VERSION="9.0.1-2.2.1"
+# renovate: datasource=github-tags depName=mysql-operator packageName=mysql/mysql-operator
+VERSION=9.0.1-2.2.1
 NAMESPACE="mysql"
 
 # Install MySQL operator.

--- a/integrations/database/postgresql/install.sh
+++ b/integrations/database/postgresql/install.sh
@@ -7,7 +7,8 @@ set -o errexit
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${SCRIPT_DIR}
 
-VERSION="1.24.1"
+# renovate: datasource=github-releases depName=cloudnative-pg packageName=cloudnative-pg/cloudnative-pg
+VERSION=1.24.1
 NAMESPACE="postgresql"
 
 # Install cloudnative-pg operator.

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,17 @@
     "gomodTidy"
   ],
   "automerge": true,
-  "prHourlyLimit": 1
+  "prHourlyLimit": 1,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update _VERSION variables in bash files and in the documentation",
+      "fileMatch": [".sh", ".adoc"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:export) .+?_VERSION=(?<currentValue>.+?)\\s",
+        "\\/\\/ renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s.+? \\(\\+(?<currentValue>.+?)\\)"
+      ],
+      "versioningTemplate": ""
+    }
+  ]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #973 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The goal is to get renovate to manage the versions of dependencies we install in our bash scripts. In doing this, I also realized that we document the version of Cert Manager and Knative Eventing in our documentation, so I extended this to also manage the version we list for those dependencies in our documentation as well

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
