### PR TITLE
Add now() function for CEL expressions.

### DIFF
--- a/pkg/cel/cel.go
+++ b/pkg/cel/cel.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/decls"
@@ -36,6 +37,16 @@ func CompileCELExpr(expr string) (*cel.Program, error) {
 			decls.NewVariable("metadata", mapStrDyn),
 			decls.NewVariable("spec", mapStrDyn),
 			decls.NewVariable("status", mapStrDyn),
+		),
+		cel.Function("now",
+			cel.Overload("now",
+				[]*cel.Type{},
+				cel.TimestampType,
+				cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+					return types.Timestamp{Time: time.Now()}
+				},
+				),
+			),
 		),
 	)
 	if err != nil {

--- a/pkg/cel/cel_test.go
+++ b/pkg/cel/cel_test.go
@@ -1,0 +1,57 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+package cel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	//"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNowFunction(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expr     string
+		expected bool
+		object   map[string]interface{}
+	}{
+		{
+			name:     "earlier",
+			expr:     "now() > timestamp(status.startTime)",
+			expected: true,
+			object:   map[string]interface{}{"status": map[string]any{"startTime": "2025-03-27T22:44:31Z"}},
+		},
+		{
+			name:     "later",
+			expr:     "now() < timestamp('2100-01-01T10:00:00Z')",
+			expected: true,
+			object:   map[string]interface{}{"status": map[string]any{"startTime": "2100-03-27T22:44:31Z"}},
+		},
+		{
+			name:     "not earlier",
+			expr:     "now() < timestamp(status.startTime)",
+			expected: false,
+			object:   map[string]interface{}{"status": map[string]any{"startTime": "2025-03-27T22:44:31Z"}},
+		},
+		{
+			name:     "not later",
+			expr:     "now() > timestamp('2100-01-01T10:00:00Z')",
+			expected: false,
+			object:   map[string]interface{}{"status": map[string]any{"startTime": "2100-03-27T22:44:31Z"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			program, e := CompileCELExpr(tc.expr)
+			if e != nil {
+				fmt.Println("Error in compilation: ", e)
+			}
+			result, _, _ := (*program).ContextEval(context.Background(), tc.object)
+			assert.Equal(t, tc.expected, result.Value(), "Does not match")
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Resolves #959

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Add now() CEL extension, which returns the current timestamp.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
