### PR TITLE
separate global and local cel expressions

### DIFF
--- a/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook.go
+++ b/cmd/operator/api/v1alpha1/kubearchiveconfig_webhook.go
@@ -99,19 +99,19 @@ func (kaccv *KubeArchiveConfigCustomValidator) validateKAC(kac *KubeArchiveConfi
 	}
 	for _, resource := range kac.Spec.Resources {
 		if resource.ArchiveWhen != "" {
-			_, err := cel.CompileOrCELExpression(resource.ArchiveWhen)
+			_, err := cel.CompileCELExpr(resource.ArchiveWhen)
 			if err != nil {
 				errList = append(errList, err)
 			}
 		}
 		if resource.DeleteWhen != "" {
-			_, err := cel.CompileOrCELExpression(resource.DeleteWhen)
+			_, err := cel.CompileCELExpr(resource.DeleteWhen)
 			if err != nil {
 				errList = append(errList, err)
 			}
 		}
 		if resource.ArchiveOnDelete != "" {
-			_, err := cel.CompileOrCELExpression(resource.ArchiveOnDelete)
+			_, err := cel.CompileCELExpr(resource.ArchiveOnDelete)
 			if err != nil {
 				errList = append(errList, err)
 			}

--- a/cmd/sink/filters/filters_test.go
+++ b/cmd/sink/filters/filters_test.go
@@ -199,7 +199,7 @@ func TestChangeGlobalFilters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = filters.changeGlobalFilters(cm.Data)
+	err = filters.changeFilters(cm.Data)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/sink/filters/namespace_gvk.go
+++ b/cmd/sink/filters/namespace_gvk.go
@@ -21,9 +21,16 @@ func NamespaceGVKFromObject(obj *unstructured.Unstructured) NamespaceGroupVersio
 	if obj == nil {
 		return ":"
 	}
-	return NamespaceGroupVersionKind(
-		fmt.Sprintf("%s:%s", obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind()),
-	)
+	return NamespaceGVKFromNamespaceAndGvk(obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind())
+}
+
+// GlobalNGVKFromObject returns a NamespaceGroupVersionKind that is based on the kubearchive namespace and the
+// GroupVersionKind of obj.
+func GlobalNGVKFromObject(obj *unstructured.Unstructured) NamespaceGroupVersionKind {
+	if obj == nil {
+		return ":"
+	}
+	return NamespaceGVKFromNamespaceAndGvk(globalKey, obj.GetObjectKind().GroupVersionKind())
 }
 
 // NamespaceGroupVersionKind returns a NamespaceGroupVersionKind from a namespace and GroupVersionKind.

--- a/pkg/cel/cel.go
+++ b/pkg/cel/cel.go
@@ -6,7 +6,6 @@ package cel
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -49,14 +48,6 @@ func init() {
 	}
 }
 
-// CompileOrCELExpression attempts to compile cel expression strings into a cel.Program. If exprs contains more than one cel
-// expression string, it will surround each cell expression in parentheses and or them together.
-func CompileOrCELExpression(exprs ...string) (*cel.Program, error) {
-	exprs = FormatCelExprs(exprs...)
-	expr := strings.Join(exprs, " || ")
-	return CompileCELExpr(expr)
-}
-
 func CompileCELExpr(expr string) (*cel.Program, error) {
 	parsed, issues := env.Parse(expr)
 	if issues != nil && issues.Err() != nil {
@@ -71,21 +62,6 @@ func CompileCELExpr(expr string) (*cel.Program, error) {
 		return nil, err
 	}
 	return &program, err
-}
-
-// FormatCelExprs takes a []string of cel expression strings and surrounds them with parentheses so that the can be
-// combined into a larger expression. Any empty strings in exprs, are removed from the []string returned.
-func FormatCelExprs(exprs ...string) []string {
-	newExprs := []string{}
-	if len(exprs) < 2 {
-		return exprs
-	}
-	for _, expr := range exprs {
-		if expr != "" {
-			newExprs = append(newExprs, fmt.Sprintf("( %s )", expr))
-		}
-	}
-	return newExprs
 }
 
 // ExecuteBoolean CEL executes the cel program with obj as the input. If the program returns and error or


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.
-->

Related to #986 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
The sink current creates CEL expressions for `archiveWhen`, `deleteWhen`, and `archiveOnDelete` for namespaces as follow:
```
(< cel expression for ApiVersion and Kind from KubeArchiveConfig in namespace >) || (< cel expression from KubeArchiveConfig in the Kubearchive namespace for the same ApiVersion and Kind if it exists >)
```

This PR changes this so that CEL expression for the KubeArchiveConfig in the kubearchive namespace are compiled into a separate CEL program from the CEL expressions from other namespaces. Then the functions that determine if a resource should be archived check if there is a CEL expression for this namespace and if there is a global CEL expression, executes both and performs the or on their results
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

Add one of the following labels:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
