### PR TITLE
Added integration tests for labelSelector

### DIFF
--- a/pkg/database/sql/postgresql.go
+++ b/pkg/database/sql/postgresql.go
@@ -77,7 +77,7 @@ func (postgreSQLFilter) ExistsLabelFilter(cond sqlbuilder.Cond, labels []string,
 
 func (postgreSQLFilter) NotExistsLabelFilter(cond sqlbuilder.Cond, labels []string, _ *sqlbuilder.WhereClause) string {
 	return fmt.Sprintf(
-		"NOT data->'metadata'->'labels' ?| %s",
+		"((NOT data->'metadata'->'labels' ?| %s) OR data->'metadata'->'labels' IS NULL)",
 		cond.Var(pq.Array(labels)),
 	)
 }
@@ -96,7 +96,7 @@ func (postgreSQLFilter) NotEqualsLabelFilter(cond sqlbuilder.Cond, labels map[st
 		jsons = append(jsons, fmt.Sprintf("{\"%s\":\"%s\"}", key, value))
 	}
 
-	uuidWithAnyLabelQuery := sqlbuilder.Select("uuid").From("resources")
+	uuidWithAnyLabelQuery := sqlbuilder.Select("uuid").From("resource")
 	uuidWithAnyLabelQuery.AddWhereClause(clause)
 	uuidWithAnyLabelQuery.Where(fmt.Sprintf(
 		"data->'metadata'->'labels' @> ANY(%s::jsonb[])",

--- a/pkg/models/labels.go
+++ b/pkg/models/labels.go
@@ -27,12 +27,12 @@ func NewLabelFilters(labelRequirements []labels.Requirement) (*LabelFilters, err
 		switch r.Operator() {
 		case selection.Exists:
 			if lf.Exists == nil {
-				lf.Exists = make([]string, 1)
+				lf.Exists = []string{}
 			}
 			lf.Exists = append(lf.Exists, r.Key())
 		case selection.DoesNotExist:
 			if lf.NotExists == nil {
-				lf.NotExists = make([]string, 1)
+				lf.NotExists = []string{}
 			}
 			lf.NotExists = append(lf.NotExists, r.Key())
 		case selection.Equals:

--- a/test/integration/labels_test.go
+++ b/test/integration/labels_test.go
@@ -1,0 +1,230 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/kubearchive/kubearchive/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestLabels(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+	port := test.PortForwardApiServer(t, clientset)
+
+	test.CreateKAC(t, namespaceName, map[string]any{
+		"resources": []map[string]any{
+			{
+				"selector": map[string]string{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+				},
+				"archiveWhen": "status.phase == 'Succeeded'",
+			},
+		},
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaceName,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				corev1.Container{
+					Name:    "fedora",
+					Command: []string{"sleep", "1"},
+					Image:   "quay.io/fedora/fedora-minimal:latest",
+				},
+			},
+		},
+	}
+
+	podsLabels := map[string]map[string]string{
+		"no-labels":   map[string]string{},
+		"hello-world": map[string]string{"hello": "world"},
+		"env-prod":    map[string]string{"env": "prod"},
+		"env-dev":     map[string]string{"env": "dev"},
+		"env-stage":   map[string]string{"env": "stage"},
+	}
+
+	for podName, labels := range podsLabels {
+		pod.SetName(podName)
+		pod.SetLabels(labels)
+		_, err := clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCases := map[string]struct {
+		selector     string
+		expectedPods []string
+	}{
+		"no selector": {
+			selector:     "",
+			expectedPods: []string{"no-labels", "hello-world", "env-prod", "env-dev", "env-stage"},
+		},
+		"hello label does not exist": {
+			selector:     "!hello",
+			expectedPods: []string{"no-labels", "env-prod", "env-dev", "env-stage"},
+		},
+		"env label does not exist": {
+			selector:     "!env",
+			expectedPods: []string{"no-labels", "hello-world"},
+		},
+		"equality label selector": {
+			selector:     "hello=world",
+			expectedPods: []string{"hello-world"},
+		},
+		"hello:world set based selector": {
+			selector:     "hello in (world)",
+			expectedPods: []string{"hello-world"},
+		},
+		"key hello with no world value - set based": {
+			selector:     "hello notin (world)",
+			expectedPods: []string{},
+		},
+		"env label existence": {
+			selector:     "env",
+			expectedPods: []string{"env-prod", "env-dev", "env-stage"},
+		},
+		"env different from prod - inequality": {
+			selector:     "env!=prod",
+			expectedPods: []string{"env-dev", "no-labels", "hello-world", "env-stage"},
+		},
+		"env label and no 'prod' value - inequality": {
+			selector:     "env,env!=prod",
+			expectedPods: []string{"env-dev", "env-stage"},
+		},
+		"env:prod set based selector": {
+			selector:     "env in (prod)",
+			expectedPods: []string{"env-prod"},
+		},
+		"env different from prod - set based": {
+			selector:     "env notin (prod)",
+			expectedPods: []string{"env-dev", "env-stage"},
+		},
+		"env different from dev - set based": {
+			selector:     "env notin (dev)",
+			expectedPods: []string{"env-prod", "env-stage"},
+		},
+		"env different from stage - set based": {
+			selector:     "env notin (stage)",
+			expectedPods: []string{"env-prod", "env-dev"},
+		},
+		"env different from stage or dev - set based": {
+			selector:     "env notin (stage, dev)",
+			expectedPods: []string{"env-prod"},
+		},
+		"env different from stage or dev and hello:world - set based": {
+			selector:     "env notin (stage, dev),hello in (world)",
+			expectedPods: []string{},
+		},
+		"env different from stage or dev and hello different from world - set based": {
+			selector:     "env notin (stage, dev),hello notin (world)",
+			expectedPods: []string{},
+		},
+		"env different from stage or dev - set based - and hello:world - equality": {
+			selector:     "env notin (stage, dev), hello=world",
+			expectedPods: []string{},
+		},
+	}
+
+	var list *unstructured.UnstructuredList
+	podsURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods", port, namespaceName)
+	retryErr := retry.Do(func() error {
+		var getUrlErr error
+		list, getUrlErr = test.GetUrl(t, token.Status.Token, podsURL)
+		if getUrlErr != nil {
+			t.Fatal(getUrlErr)
+		}
+
+		// We want to wait until everything is stored in the DB to avoid out of order inserts
+		if len(list.Items) >= len(podsLabels) {
+			return nil
+		}
+
+		return errors.New("could not retrieve Pods from the API")
+	}, retry.Attempts(240), retry.MaxDelay(4*time.Second))
+
+	if retryErr != nil {
+		t.Fatal(retryErr)
+	}
+
+	t.Log("All pods were archived, starting to check label selector results...")
+
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			labelSelector := testData.selector
+			podNames := testData.expectedPods
+
+			t.Logf("testing selector '%s'", labelSelector)
+			podsURL = fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods", port, namespaceName)
+			if labelSelector != "" {
+				selector := url.QueryEscape(labelSelector)
+				podsURL = fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods?labelSelector=%s", port, namespaceName, selector)
+			}
+
+			retryErr := retry.Do(func() error {
+				podList, getUrlErr := test.GetUrl(t, token.Status.Token, podsURL)
+				if getUrlErr != nil {
+					t.Fatal(getUrlErr)
+				}
+
+				if len(podList.Items) != len(podNames) {
+					msg := fmt.Sprintf("expected '%d' pods, got '%d'", len(podNames), len(podList.Items))
+					t.Log(msg)
+					return errors.New(msg)
+				}
+
+				retrievedPodNames := []string{}
+				for _, pod := range podList.Items {
+					retrievedPodNames = append(retrievedPodNames, pod.GetName())
+				}
+
+				missingPods := []string{}
+				for _, podName := range podNames {
+					found := false
+					for _, retrievedPodName := range retrievedPodNames {
+						if podName == retrievedPodName {
+							found = true
+						}
+					}
+
+					if !found {
+						missingPods = append(missingPods, podName)
+					}
+				}
+
+				if len(missingPods) >= 1 {
+					msg := fmt.Sprintf("There were missing pods: %s", strings.Join(missingPods, ", "))
+					t.Log(msg)
+					return errors.New(msg)
+				}
+
+				t.Log("found expected pods for the selector")
+				return nil
+			}, retry.Attempts(240), retry.MaxDelay(4*time.Second))
+
+			if retryErr != nil {
+				t.Fatal(retryErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1022  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Fixed the "existence" label selector, now resources without labels are returned too.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* I had to change a query to include adding resources with empty labels, to mimic the Kubernetes API results. Should we check again with the DB expert on performance?
* `make([]string, 1)` was creating an slice with an empty string `[]string{""}` that was leading to some problems.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
