### PR TITLE
Add sink cloudevent publisher.

### DIFF
--- a/cmd/operator/api/v1alpha1/clusterkubearchiveconfig_types.go
+++ b/cmd/operator/api/v1alpha1/clusterkubearchiveconfig_types.go
@@ -47,11 +47,12 @@ func ConvertUnstructuredToClusterKubeArchiveConfig(object *unstructured.Unstruct
 		return nil, err
 	}
 
-	kac := &ClusterKubeArchiveConfig{}
-	if err := json.Unmarshal(bytes, kac); err != nil {
+	ckac := &ClusterKubeArchiveConfig{}
+
+	if err := json.Unmarshal(bytes, ckac); err != nil {
 		return nil, err
 	}
-	return kac, nil
+	return ckac, nil
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0-alpha.1 // indirect
+	k8s.io/apiserver v0.33.0-alpha.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJ
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coreos/go-oidc v2.3.0+incompatible h1:+5vEsrgprdLjjQ9FzIKAzQz1wwPD+83hQRfUIPh7rO0=
 github.com/coreos/go-oidc/v3 v3.9.0 h1:0J/ogVOd4y8P0f0xUh8l9t07xRP/d8tccvjHl2dcsSo=
 github.com/coreos/go-oidc/v3 v3.9.0/go.mod h1:rTKz2PYwftcrtoCzV5g5kvfJoWcm0Mk8AF8y1iAQro4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/pkg/cloudevents/sink_publisher.go
+++ b/pkg/cloudevents/sink_publisher.go
@@ -1,0 +1,262 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudevents
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	otelObs "github.com/cloudevents/sdk-go/observability/opentelemetry/v2/client"
+	ce "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/client"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	kubearchiveapi "github.com/kubearchive/kubearchive/cmd/operator/api/v1alpha1"
+	"github.com/kubearchive/kubearchive/cmd/sink/k8s"
+	"github.com/kubearchive/kubearchive/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	kclient "knative.dev/eventing/pkg/client/clientset/versioned"
+)
+
+type SinkCloudEventPublisherResult struct {
+	Name    string
+	Message string
+	Result  error
+}
+
+type SinkCloudEventPublisher struct {
+	httpClient      client.Client
+	dynaClient      *dynamic.DynamicClient
+	mapper          meta.RESTMapper
+	target          string
+	source          string
+	etype           string
+	globalResources map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource
+}
+
+func NewSinkCloudEventPublisher(source string, etype string) (*SinkCloudEventPublisher, error) {
+	scep := &SinkCloudEventPublisher{source: source, etype: etype}
+
+	var err error
+	if scep.httpClient, err = otelObs.NewClientHTTP([]cehttp.Option{}, []client.Option{}); err != nil {
+		slog.Error("Failed to create client", "error", err)
+		return nil, err
+	}
+
+	if scep.target, err = getBrokerUrl(); err != nil {
+		slog.Error("Unable to get broker URL", "error", err)
+		return nil, err
+	}
+
+	if scep.mapper, err = k8s.GetRESTMapper(); err != nil {
+		slog.Error("Unable to get RESTMapper", "error", err)
+		return nil, err
+	}
+
+	if scep.dynaClient, err = k8s.GetKubernetesClient(); err != nil {
+		slog.Error("Unable to get dynamic client", "error", err)
+		return nil, err
+	}
+
+	if scep.globalResources, err = scep.getKubeArchiveConfigResources(""); err != nil {
+		slog.Error("Unable to get global resources", "error", err)
+		return nil, err
+	}
+
+	return scep, nil
+}
+
+func (scep *SinkCloudEventPublisher) SendByGVK(ctx context.Context, avk *sourcesv1.APIVersionKind, namespace string) []SinkCloudEventPublisherResult {
+
+	return []SinkCloudEventPublisherResult{}
+}
+
+func (scep *SinkCloudEventPublisher) SendByNamespace(ctx context.Context, namespace string) (map[sourcesv1.APIVersionKind][]SinkCloudEventPublisherResult, error) {
+
+	localResources, err := scep.getKubeArchiveConfigResources(namespace)
+	if err != nil {
+		slog.Error("Unable to get local KubeArchiveConfig resources", "error", err)
+		return nil, err
+	}
+
+	results := map[sourcesv1.APIVersionKind][]SinkCloudEventPublisherResult{}
+	allResources := mergeResources(scep.globalResources, localResources)
+
+	for avk := range allResources {
+		results[avk] = scep.SendByAPIVersionKind(ctx, namespace, &avk)
+	}
+
+	return results, nil
+}
+
+func (scep *SinkCloudEventPublisher) SendByAPIVersionKind(ctx context.Context, namespace string, avk *sourcesv1.APIVersionKind) []SinkCloudEventPublisherResult {
+	results := []SinkCloudEventPublisherResult{}
+
+	gvr, err := getGVR(scep.mapper, avk)
+	if err != nil {
+		slog.Error("Unable to get GVR", "error", err)
+		return results
+	}
+
+	localResources, err := scep.getKubeArchiveConfigResources(namespace)
+	if err != nil {
+		slog.Error("Unable to get local KubeArchiveConfig resources", "error", err)
+		return results
+	}
+
+	list, err := scep.dynaClient.Resource(gvr).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		slog.Error("Unable to list resources", "error", err)
+		return results
+	}
+
+	for _, item := range list.Items {
+		metadata := item.Object["metadata"].(map[string]interface{})
+		name := metadata["name"].(string)
+
+		result := SinkCloudEventPublisherResult{Name: name, Message: "No event sent"}
+		if shouldSend(avk, scep.globalResources, localResources) {
+			result.Result = scep.send(ctx, item.Object)
+			if result.Result != nil {
+				result.Message = "Event send failed"
+			} else {
+				result.Message = "Event sent successfully"
+			}
+		}
+		slog.Info(result.Message, "apiversion", avk.APIVersion, "kind", avk.Kind, "namespace", namespace, "name", name, "result", result.Result)
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func (scep *SinkCloudEventPublisher) send(ctx context.Context, resource map[string]interface{}) error {
+	event := ce.NewEvent()
+	event.SetSource(scep.source)
+	event.SetType(scep.etype)
+	if err := event.SetData(ce.ApplicationJSON, resource); err != nil {
+		slog.Error("Error setting cloudevent data", "error", err)
+		return err
+	}
+
+	event.SetExtension("apiversion", resource["apiVersion"].(string))
+	event.SetExtension("kind", resource["kind"].(string))
+	metadata := resource["metadata"].(map[string]interface{})
+	event.SetExtension("name", metadata["name"])
+	event.SetExtension("namespace", metadata["namespace"])
+
+	ectx := ce.ContextWithTarget(ctx, scep.target)
+
+	return scep.httpClient.Send(ectx, event)
+}
+
+func (scep *SinkCloudEventPublisher) getKubeArchiveConfigResources(namespace string) (map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource, error) {
+	var resources = []kubearchiveapi.KubeArchiveConfigResource{}
+	if namespace == "" {
+		gvr := kubearchiveapi.GroupVersion.WithResource("clusterkubearchiveconfigs")
+		obj, err := scep.dynaClient.Resource(gvr).Get(context.Background(), constants.KubeArchiveConfigResourceName, metav1.GetOptions{})
+		if err == nil {
+			kac, cerr := kubearchiveapi.ConvertUnstructuredToClusterKubeArchiveConfig(obj)
+			if cerr != nil {
+				return nil, err
+			}
+			resources = kac.Spec.Resources
+		} else if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+	} else {
+		gvr := kubearchiveapi.GroupVersion.WithResource("kubearchiveconfigs")
+		obj, err := scep.dynaClient.Resource(gvr).Namespace(namespace).Get(context.Background(), constants.KubeArchiveConfigResourceName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		kac, cerr := kubearchiveapi.ConvertUnstructuredToKubeArchiveConfig(obj)
+		if cerr != nil {
+			return nil, err
+		}
+		resources = kac.Spec.Resources
+	}
+
+	var resourceMap = make(map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource)
+	for _, resource := range resources {
+		avk := sourcesv1.APIVersionKind{APIVersion: resource.Selector.APIVersion, Kind: resource.Selector.Kind}
+		resourceMap[avk] = resource
+	}
+	return resourceMap, nil
+}
+
+func mergeResources(globalRes map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource, localRes map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource) map[sourcesv1.APIVersionKind]struct{} {
+	var resourceMap = make(map[sourcesv1.APIVersionKind]struct{})
+	for avk := range globalRes {
+		resourceMap[avk] = struct{}{}
+	}
+	for avk := range localRes {
+		resourceMap[avk] = struct{}{}
+	}
+	return resourceMap
+}
+
+func getBrokerUrl() (string, error) {
+	client, err := getEventingClientset()
+	if err != nil {
+		slog.Error("Failed to create eventing clientset", "error", err)
+		return "", err
+	}
+
+	broker, err := client.EventingV1().Brokers(constants.KubeArchiveNamespace).Get(context.Background(), constants.KubeArchiveBrokerName, metav1.GetOptions{})
+	if err != nil {
+		slog.Error("Failed to get KubeArchive broker", "error", err)
+		return "", err
+	}
+
+	return broker.Status.Address.URL.String(), nil
+}
+
+func getEventingClientset() (*kclient.Clientset, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving in-cluster eventing client config: %s", err)
+	}
+	client, err := kclient.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error instantiating eventing client from host %s: %s", config.Host, err)
+	}
+	return client, nil
+}
+
+func getGVR(mapper meta.RESTMapper, avk *sourcesv1.APIVersionKind) (schema.GroupVersionResource, error) {
+	apiGroup := ""
+	apiVersion := avk.APIVersion
+	data := strings.Split(apiVersion, "/")
+	if len(data) > 1 {
+		apiGroup = data[0]
+		apiVersion = data[1]
+	}
+	mapping, err := mapper.RESTMapping(schema.GroupKind{Group: apiGroup, Kind: avk.Kind}, apiVersion)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
+}
+
+func shouldSend(avk *sourcesv1.APIVersionKind, globalResources map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource, localResources map[sourcesv1.APIVersionKind]kubearchiveapi.KubeArchiveConfigResource) bool {
+	resource, ok := globalResources[*avk]
+	if ok && (resource.ArchiveWhen != "" || resource.DeleteWhen != "") {
+		return true
+	}
+
+	resource, ok = localResources[*avk]
+	if ok && (resource.ArchiveWhen != "" || resource.DeleteWhen != "") {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Related to #991

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Here's a sample code snippet for using this new package to send a cloud event to the sink.
```
func main() {
	namespacePtr := flag.String("namespace", "default", "Namespace to vacuum.")
	slog.Info("Started publishing sink events", "namespace", *namespacePtr)

	scep, err := cloudevents.NewSinkCloudEventPublisher("localhost:8080:/foo", "org.kubearchive.vacuum.update")
	if err != nil {
		slog.Error("Unable to create sink cloudevent publisher", "error", err)
		return
	}

	selector := sourcesv1.APIVersionKindSelector{
		APIVersion: "apps/v1",
		Kind:       "Deployment",
	}

	result := scep.SendByAPIVersionKindSelector(context.Background(), *namespacePtr, &selector)
	if !ce.IsACK(result) {
		slog.Error("Unable to send cloudevent", "result", result)
		return
	}

	slog.Info("Finished publishing sink events", "namespace", *namespacePtr)
}

func getGVR(mapper meta.RESTMapper, selector *sourcesv1.APIVersionKindSelector) (schema.GroupVersionResource, error) {
	apiGroup := ""
	apiVersion := selector.APIVersion
	data := strings.Split(apiVersion, "/")
	if len(data) > 1 {
		apiGroup = data[0]
		apiVersion = data[1]
	}
	mapping, err := mapper.RESTMapping(schema.GroupKind{Group: apiGroup, Kind: selector.Kind}, apiVersion)
	if err != nil {
		return schema.GroupVersionResource{}, err
	}
	return mapping.Resource, nil
}
```
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
