### PR TITLE
Fix empty log annotation use-case

### DIFF
--- a/pkg/database/sql/reader.go
+++ b/pkg/database/sql/reader.go
@@ -91,7 +91,7 @@ func (db *sqlDatabaseImpl) getLogsForPodSelector(ctx context.Context, sb *sqlbui
 		annotations := pod.GetAnnotations()
 		var ok bool
 		containerName, ok = annotations[defaultContainerAnnotation]
-		if !ok {
+		if !ok || containerName == "" {
 			// This is to avoid index out of bounds error with no context
 			if len(pod.Spec.Containers) == 0 {
 				return "", "", fmt.Errorf("pod '%s/%s' does not have containers, something went wrong", namespace, name)

--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -159,110 +159,89 @@ func TestDefaultContainer(t *testing.T) {
 			},
 		},
 	}
-
 	test.CreateKAC(t, namespaceName, resources)
 
-	// Create a pod
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "defaults-to-first",
+	tests := []struct {
+		podName     string
+		annotations map[string]string
+		expectedLog string
+	}{
+		{
+			podName:     "defaults-to-first",
+			annotations: map[string]string{},
+			expectedLog: "I'm the container called first.",
 		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:    "first",
-					Image:   "quay.io/fedora/fedora:latest",
-					Command: []string{"echo", "-n", "I'm the container called first."},
-				},
-				{
-					Name:    "second",
-					Image:   "quay.io/fedora/fedora:latest",
-					Command: []string{"echo", "-n", "I'm the container called second."},
-				},
-			},
-		},
-	}
-	_, err := clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pod = &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "wants-second",
-			Annotations: map[string]string{
+		{
+			podName: "wants-second",
+			annotations: map[string]string{
 				"kubectl.kubernetes.io/default-container": "second",
-			}},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:    "first",
-					Image:   "quay.io/fedora/fedora:latest",
-					Command: []string{"echo", "-n", "I'm the container called first."},
-				},
-				{
-					Name:    "second",
-					Image:   "quay.io/fedora/fedora:latest",
-					Command: []string{"echo", "-n", "I'm the container called second."},
-				},
 			},
+			expectedLog: "I'm the container called second.",
+		},
+		{
+			podName: "empty-annotation",
+			annotations: map[string]string{
+				"kubectl.kubernetes.io/default-container": "",
+			},
+			expectedLog: "I'm the container called first.",
 		},
 	}
-	_, err = clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(err)
+
+	for _, testCase := range tests {
+		// Create a pod
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        testCase.podName,
+				Annotations: testCase.annotations,
+			},
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{
+					{
+						Name:    "first",
+						Image:   "quay.io/fedora/fedora-minimal:latest",
+						Command: []string{"echo", "-n", "I'm the container called first."},
+					},
+					{
+						Name:    "second",
+						Image:   "quay.io/fedora/fedora-minimal:latest",
+						Command: []string{"echo", "-n", "I'm the container called second."},
+					},
+				},
+			},
+		}
+		_, err := clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	url := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods/defaults-to-first/log", port, namespaceName)
-	retryErr := retry.Do(func() error {
-		body, err := test.GetLogs(t, token.Status.Token, url)
-		if err != nil {
-			return err
+	for _, testCase := range tests {
+		t.Logf("checking logs for pod '%s', expected log '%s'", testCase.podName, testCase.expectedLog)
+		url := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods/%s/log", port, namespaceName, testCase.podName)
+		retryErr := retry.Do(func() error {
+			body, err := test.GetLogs(t, token.Status.Token, url)
+			if err != nil {
+				return err
+			}
+
+			if len(body) == 0 {
+				return errors.New("could not retrieve the pod log")
+			}
+			t.Log("Successfully retrieved logs")
+
+			bodyString := string(body)
+			if strings.Trim(bodyString, "\n") != testCase.expectedLog {
+				t.Log("log does not match")
+				return fmt.Errorf("log does not match the expected '%s'", testCase.expectedLog)
+			}
+
+			return nil
+		}, retry.Attempts(30), retry.MaxDelay(5*time.Second))
+
+		if retryErr != nil {
+			t.Fatal(retryErr)
 		}
-
-		if len(body) == 0 {
-			return errors.New("could not retrieve the pod log")
-		}
-		t.Log("Successfully retrieved logs")
-
-		bodyString := string(body)
-		if strings.Trim(bodyString, "\n") != "I'm the container called first." {
-			t.Log("log does not match")
-			return fmt.Errorf("log does not match the expected 'I'm the container called first.'")
-		}
-
-		return nil
-	}, retry.Attempts(30), retry.MaxDelay(2*time.Second))
-
-	if retryErr != nil {
-		t.Fatal(retryErr)
-	}
-
-	url = fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods/wants-second/log", port, namespaceName)
-	retryErr = retry.Do(func() error {
-		body, err := test.GetLogs(t, token.Status.Token, url)
-		if err != nil {
-			return err
-		}
-
-		if len(body) == 0 {
-			return errors.New("could not retrieve the pod log")
-		}
-		t.Log("Successfully retrieved logs")
-
-		bodyString := string(body)
-		if strings.Trim(bodyString, "\n") != "I'm the container called second." {
-			t.Log("log does not match")
-			return fmt.Errorf("log does not match the expected 'I'm the container called second.'")
-		}
-
-		return nil
-	}, retry.Attempts(30), retry.MaxDelay(2*time.Second))
-
-	if retryErr != nil {
-		t.Fatal(retryErr)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolve #1027  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Fixed bug where the API did not return logs if the annotation `kubectl.kubernetes.io/default-container` had an empty value. Now the API returns the first container of the pod instead.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* Simplified the related integration tests.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
