### PR TITLE
Add NamespaceVacuumConfig and ClusterVacuumConfig resources.

### DIFF
--- a/cmd/operator/api/v1alpha1/clusterkubearchiveconfig_types.go
+++ b/cmd/operator/api/v1alpha1/clusterkubearchiveconfig_types.go
@@ -4,8 +4,14 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+var ClusterKubeArchiveConfigGVR = schema.GroupVersionResource{Group: "kubearchive.kubearchive.org", Version: "v1alpha1", Resource: "clusterkubearchiveconfigs"}
 
 // ClusterKubeArchiveConfigSpec defines the desired state of ClusterKubeArchiveConfig
 type ClusterKubeArchiveConfigSpec KubeArchiveConfigSpec
@@ -33,6 +39,19 @@ type ClusterKubeArchiveConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ClusterKubeArchiveConfig `json:"items"`
+}
+
+func ConvertUnstructuredToClusterKubeArchiveConfig(object *unstructured.Unstructured) (*ClusterKubeArchiveConfig, error) {
+	bytes, err := object.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	kac := &ClusterKubeArchiveConfig{}
+	if err := json.Unmarshal(bytes, kac); err != nil {
+		return nil, err
+	}
+	return kac, nil
 }
 
 func init() {

--- a/cmd/operator/api/v1alpha1/clustervacuumconfig_types.go
+++ b/cmd/operator/api/v1alpha1/clustervacuumconfig_types.go
@@ -1,0 +1,51 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var ClusterVacuumConfigGVR = schema.GroupVersionResource{Group: "kubearchive.kubearchive.org", Version: "v1alpha1", Resource: "clustervacuumconfigs"}
+
+type ClusterVacuumConfigNamespaceSpec struct {
+	Name                      string `json:"name" yaml:"name"`
+	NamespaceVacuumConfigSpec `json:",inline"`
+}
+
+// ClusterVacuumConfigSpec defines the desired state of ClusterVacuumConfig resource
+type ClusterVacuumConfigSpec struct {
+	Namespaces []ClusterVacuumConfigNamespaceSpec `json:"namespaces" yaml:"namespaces"`
+}
+
+// ClusterVacuumConfigStatus defines the observed state of ClusterVacuumConfig resource
+type ClusterVacuumConfigStatus struct {
+}
+
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName=cvc;cvcs
+//+kubebuilder:subresource:status
+
+// ClusterVacuumConfig is the Schema for the clustervacuumconfigs API
+type ClusterVacuumConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ClusterVacuumConfigSpec   `json:"spec,omitempty"`
+	Status ClusterVacuumConfigStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// ClusterVacuumConfigList contains a list of ClusterVacuumConfig resources
+type ClusterVacuumConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ClusterVacuumConfig `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&ClusterVacuumConfig{}, &ClusterVacuumConfigList{})
+}

--- a/cmd/operator/api/v1alpha1/clustervacuumconfig_webhook.go
+++ b/cmd/operator/api/v1alpha1/clustervacuumconfig_webhook.go
@@ -1,0 +1,101 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kubearchive/kubearchive/pkg/constants"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var cvlog = logf.Log.WithName("clustervacuumconfig-resource")
+
+func SetupClusterVacuumConfigWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&ClusterVacuumConfig{}).
+		WithValidator(&ClusterVacuumConfigCustomValidator{}).
+		WithDefaulter(&ClusterVacuumConfigCustomDefaulter{}).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-kubearchive-kubearchive-org-v1alpha1-clustervacuumconfig,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubearchive.kubearchive.org,resources=clustervacuumconfig,verbs=create;update,versions=v1alpha1,name=mclustervacuumconfig.kb.io,admissionReviewVersions=v1
+
+type ClusterVacuumConfigCustomDefaulter struct{}
+
+var _ webhook.CustomDefaulter = &ClusterVacuumConfigCustomDefaulter{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type
+func (cvcd *ClusterVacuumConfigCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	cv, ok := obj.(*ClusterVacuumConfig)
+	if !ok {
+		return fmt.Errorf("expected a ClusterVacuumConfig object but got %T", obj)
+	}
+	cvlog.Info("default", "name", cv.Name)
+	return nil
+}
+
+//+kubebuilder:webhook:path=/validate-kubearchive-kubearchive-org-v1alpha1-clustervacuumconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubearchive.kubearchive.org,resources=clustervacuumconfig,verbs=create;update,versions=v1alpha1,name=vclustervacuumconfig.kb.io,admissionReviewVersions=v1
+
+type ClusterVacuumConfigCustomValidator struct {
+}
+
+var _ webhook.CustomValidator = &ClusterVacuumConfigCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (cvcv *ClusterVacuumConfigCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	cv, ok := obj.(*ClusterVacuumConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a ClusterVacuumConfig object but got %T", obj)
+	}
+	cvlog.Info("validate create", "name", cv.Name)
+
+	return cvcv.validateClusterVacuumConfig(cv)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (cvcv *ClusterVacuumConfigCustomValidator) ValidateUpdate(_ context.Context, _ runtime.Object, new runtime.Object) (admission.Warnings, error) {
+	cv, ok := new.(*ClusterVacuumConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a ClusterVacuumConfig object but got %T", new)
+	}
+	cvlog.Info("validate update", "name", cv.Name)
+
+	return cvcv.validateClusterVacuumConfig(cv)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (cvcv *ClusterVacuumConfigCustomValidator) ValidateDelete(_ context.Context, new runtime.Object) (admission.Warnings, error) {
+	cv, ok := new.(*ClusterVacuumConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a ClusterVacuumConfig object but got %T", new)
+	}
+	cvlog.Info("validate delete", "name", cv.Name)
+
+	return nil, nil
+}
+
+func (cvcv *ClusterVacuumConfigCustomValidator) validateClusterVacuumConfig(cv *ClusterVacuumConfig) (admission.Warnings, error) {
+	errList := make([]error, 0)
+	if cv.Namespace != constants.KubeArchiveNamespace {
+		errList = append(errList, fmt.Errorf("invalid namespace name '%s', resource must be in namespace '%s'",
+			cv.Namespace, constants.KubeArchiveNamespace))
+	}
+
+	for _, ns := range cv.Spec.Namespaces {
+		err := validateResources(dynaClient, ns.Name, ns.Resources)
+		if err != nil {
+			errList = append(errList, err)
+		}
+	}
+
+	return nil, errors.Join(errList...)
+}

--- a/cmd/operator/api/v1alpha1/clustervacuumconfig_webhook_test.go
+++ b/cmd/operator/api/v1alpha1/clustervacuumconfig_webhook_test.go
@@ -1,0 +1,208 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubearchive/kubearchive/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+)
+
+func TestClusterVacuumConfigCustomDefaulter(t *testing.T) {
+	defaulter := ClusterVacuumConfigCustomDefaulter{}
+	cvc := &ClusterVacuumConfig{}
+	err := defaulter.Default(context.Background(), cvc)
+	assert.NoError(t, err)
+	assert.Equal(t, ClusterVacuumConfigSpec{Namespaces: nil}, cvc.Spec)
+}
+
+func TestClusterVacuumConfigValidateName(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		validated bool
+	}{
+		{
+			name:      "valid-name",
+			namespace: constants.KubeArchiveNamespace,
+			validated: true,
+		},
+		{
+			name:      "invalid-name",
+			namespace: "other-namespace",
+			validated: false,
+		},
+	}
+	validator := ClusterVacuumConfigCustomValidator{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create resource
+			cvc := &ClusterVacuumConfig{ObjectMeta: metav1.ObjectMeta{Namespace: test.namespace, Name: "cvac"}}
+			warns, err := validator.ValidateCreate(context.Background(), cvc)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource namespace %s", test.namespace)
+			}
+			// Update resource
+			warns, err = validator.ValidateUpdate(context.Background(), &ClusterVacuumConfig{}, cvc)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource namespace %s", test.namespace)
+			}
+			// Delete resource
+			warns, err = validator.ValidateDelete(context.Background(), cvc)
+			assert.Nil(t, warns)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestClusterVacuumConfigValidateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      ClusterVacuumConfigSpec
+		validated bool
+	}{
+		{
+			name:      "No namespaces",
+			spec:      ClusterVacuumConfigSpec{},
+			validated: true,
+		},
+		{
+			name:      "Empty namespaces",
+			spec:      ClusterVacuumConfigSpec{Namespaces: []ClusterVacuumConfigNamespaceSpec{}},
+			validated: true,
+		},
+		{
+			name: "One namespace",
+			spec: ClusterVacuumConfigSpec{
+				Namespaces: []ClusterVacuumConfigNamespaceSpec{
+					{Name: "namespace-1"},
+				}},
+			validated: true,
+		},
+		{
+			name: "Muliple namespaces",
+			spec: ClusterVacuumConfigSpec{
+				Namespaces: []ClusterVacuumConfigNamespaceSpec{
+					{Name: "namespace-1"},
+					{Name: "namespace-2"},
+				}},
+			validated: true,
+		},
+		{
+			name: "With one resource",
+			spec: ClusterVacuumConfigSpec{
+				Namespaces: []ClusterVacuumConfigNamespaceSpec{
+					{Name: "namespace-1"},
+					{Name: "namespace-2",
+						NamespaceVacuumConfigSpec: NamespaceVacuumConfigSpec{Resources: []sourcesv1.APIVersionKind{
+							{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+						}}},
+				}},
+			validated: true,
+		},
+		{
+			name: "With multiple resources",
+			spec: ClusterVacuumConfigSpec{
+				Namespaces: []ClusterVacuumConfigNamespaceSpec{
+					{Name: "namespace-1"},
+					{Name: "namespace-2",
+						NamespaceVacuumConfigSpec: NamespaceVacuumConfigSpec{Resources: []sourcesv1.APIVersionKind{
+							{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+							{APIVersion: "tekton.dev/v1", Kind: "TaskRun"},
+						}}},
+				}},
+			validated: true,
+		},
+		{
+			name: "Non-configured resource",
+			spec: ClusterVacuumConfigSpec{
+				Namespaces: []ClusterVacuumConfigNamespaceSpec{
+					{Name: "namespace-1"},
+					{Name: "namespace-2",
+						NamespaceVacuumConfigSpec: NamespaceVacuumConfigSpec{Resources: []sourcesv1.APIVersionKind{
+							{APIVersion: "v1", Kind: "Event"},
+						}}},
+				}},
+			validated: false,
+		},
+	}
+
+	ckac := &ClusterKubeArchiveConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KubeArchiveConfigResourceName},
+		Spec: ClusterKubeArchiveConfigSpec{
+			Resources: []KubeArchiveConfigResource{{
+				Selector: sourcesv1.APIVersionKindSelector{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+			}},
+		},
+	}
+	kac1 := &KubeArchiveConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KubeArchiveConfigResourceName, Namespace: "namespace-1"},
+		Spec: KubeArchiveConfigSpec{
+			Resources: []KubeArchiveConfigResource{{
+				Selector: sourcesv1.APIVersionKindSelector{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+			}},
+		},
+	}
+	kac2 := &KubeArchiveConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KubeArchiveConfigResourceName, Namespace: "namespace-2"},
+		Spec: KubeArchiveConfigSpec{
+			Resources: []KubeArchiveConfigResource{{
+				Selector: sourcesv1.APIVersionKindSelector{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+			}},
+		},
+	}
+	scheme := runtime.NewScheme()
+	AddToScheme(scheme) //nolint:errcheck
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			dynaClient = fake.NewSimpleDynamicClient(scheme, ckac, kac1, kac2)
+			validator := ClusterVacuumConfigCustomValidator{}
+
+			// Create resource
+			nvc := &ClusterVacuumConfig{ObjectMeta: metav1.ObjectMeta{Name: "nvc", Namespace: constants.KubeArchiveNamespace}, Spec: test.spec}
+			warns, err := validator.ValidateCreate(context.Background(), nvc)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource in test %s", test.name)
+			}
+			// Update resource
+			warns, err = validator.ValidateUpdate(context.Background(), &ClusterVacuumConfig{}, nvc)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource name %s", test.name)
+			}
+			// Delete resource
+			warns, err = validator.ValidateDelete(context.Background(), nvc)
+			assert.Nil(t, warns)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/cmd/operator/api/v1alpha1/kubearchiveconfig_types.go
+++ b/cmd/operator/api/v1alpha1/kubearchiveconfig_types.go
@@ -4,9 +4,15 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
 )
+
+var KubeArchiveConfigGVR = schema.GroupVersionResource{Group: "kubearchive.kubearchive.org", Version: "v1alpha1", Resource: "kubearchiveconfigs"}
 
 type KubeArchiveConfigResource struct {
 	Selector        sourcesv1.APIVersionKindSelector `json:"selector,omitempty" yaml:"selector,omitempty"`
@@ -44,6 +50,19 @@ type KubeArchiveConfigList struct {
 	metav1.TypeMeta `json:",inline" yaml:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	Items           []KubeArchiveConfig `json:"items" yaml:"items"`
+}
+
+func ConvertUnstructuredToKubeArchiveConfig(object *unstructured.Unstructured) (*KubeArchiveConfig, error) {
+	bytes, err := object.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	kac := &KubeArchiveConfig{}
+	if err := json.Unmarshal(bytes, kac); err != nil {
+		return nil, err
+	}
+	return kac, nil
 }
 
 func init() {

--- a/cmd/operator/api/v1alpha1/namespacevacuumconfig_types.go
+++ b/cmd/operator/api/v1alpha1/namespacevacuumconfig_types.go
@@ -1,0 +1,47 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+)
+
+var NamespaceVacuumConfigGVR = schema.GroupVersionResource{Group: "kubearchive.kubearchive.org", Version: "v1alpha1", Resource: "namespacevacuumconfigss"}
+
+// VacuumListSpec defines the desired state of VacuumList resource
+type NamespaceVacuumConfigSpec struct {
+	Resources []sourcesv1.APIVersionKind `json:"resources" yaml:"resources"`
+}
+
+// NamespaceVacuumConfigStatus defines the observed state of NamespaceVacuumConfig resource
+type NamespaceVacuumConfigStatus struct {
+}
+
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:shortName=nvc;nvcs
+//+kubebuilder:subresource:status
+
+// NamespaceVacuumConfig is the Schema for the namespacevacuumconfigs API
+type NamespaceVacuumConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   NamespaceVacuumConfigSpec   `json:"spec,omitempty"`
+	Status NamespaceVacuumConfigStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// NamespaceVacuumConfigList contains a list of NamespaceVacuumConfig resources
+type NamespaceVacuumConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []NamespaceVacuumConfig `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&NamespaceVacuumConfig{}, &NamespaceVacuumConfigList{})
+}

--- a/cmd/operator/api/v1alpha1/namespacevacuumconfig_webhook.go
+++ b/cmd/operator/api/v1alpha1/namespacevacuumconfig_webhook.go
@@ -1,0 +1,184 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kubearchive/kubearchive/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var nvlog = logf.Log.WithName("namespacevacuumconfig-resource")
+var dynaClient dynamic.Interface
+
+func SetupNamespaceVacuumConfigWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&NamespaceVacuumConfig{}).
+		WithValidator(&NamespaceVacuumConfigCustomValidator{}).
+		WithDefaulter(&NamespaceVacuumConfigCustomDefaulter{}).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-kubearchive-kubearchive-org-v1alpha1-namespacevacuumconfig,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubearchive.kubearchive.org,resources=namespacevacuumconfig,verbs=create;update,versions=v1alpha1,name=mnamespacevacuumconfig.kb.io,admissionReviewVersions=v1
+
+type NamespaceVacuumConfigCustomDefaulter struct{}
+
+var _ webhook.CustomDefaulter = &NamespaceVacuumConfigCustomDefaulter{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type
+func (cvcd *NamespaceVacuumConfigCustomDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	cv, ok := obj.(*NamespaceVacuumConfig)
+	if !ok {
+		return fmt.Errorf("expected a NamespaceVacuumConfig object but got %T", obj)
+	}
+	nvlog.Info("default", "name", cv.Name)
+	return nil
+}
+
+//+kubebuilder:webhook:path=/validate-kubearchive-kubearchive-org-v1alpha1-namespacevacuumconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubearchive.kubearchive.org,resources=namespacevacuumconfig,verbs=create;update,versions=v1alpha1,name=vnamespacevacuumconfig.kb.io,admissionReviewVersions=v1
+
+type NamespaceVacuumConfigCustomValidator struct {
+}
+
+var _ webhook.CustomValidator = &NamespaceVacuumConfigCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (nvcv *NamespaceVacuumConfigCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	cv, ok := obj.(*NamespaceVacuumConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a NamespaceVacuumConfig object but got %T", obj)
+	}
+	nvlog.Info("validate create", "name", cv.Name)
+
+	return nvcv.validateNamespaceVacuumConfig(cv)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (nvcv *NamespaceVacuumConfigCustomValidator) ValidateUpdate(_ context.Context, _ runtime.Object, new runtime.Object) (admission.Warnings, error) {
+	cv, ok := new.(*NamespaceVacuumConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a NamespaceVacuumConfig object but got %T", new)
+	}
+	nvlog.Info("validate update", "name", cv.Name)
+
+	return nvcv.validateNamespaceVacuumConfig(cv)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (nvcv *NamespaceVacuumConfigCustomValidator) ValidateDelete(_ context.Context, new runtime.Object) (admission.Warnings, error) {
+	cv, ok := new.(*NamespaceVacuumConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a NamespaceVacuumConfig object but got %T", new)
+	}
+	nvlog.Info("validate delete", "name", cv.Name)
+
+	return nil, nil
+}
+
+func (nvcv *NamespaceVacuumConfigCustomValidator) validateNamespaceVacuumConfig(cv *NamespaceVacuumConfig) (admission.Warnings, error) {
+	errList := make([]error, 0)
+
+	err := validateResources(dynaClient, cv.Namespace, cv.Spec.Resources)
+	if err != nil {
+		errList = append(errList, err)
+	}
+
+	return nil, errors.Join(errList...)
+}
+
+func validateResources(client dynamic.Interface, namespace string, resources []sourcesv1.APIVersionKind) error {
+	gres, err := getGlobalResourceSet(client)
+	if err != nil {
+		return err
+	}
+	nres, err := getNamespaceResourceSet(client, namespace)
+	if err != nil {
+		return err
+	}
+
+	errList := make([]error, 0)
+	for _, resource := range resources {
+		_, gok := gres[resource]
+		_, nok := nres[resource]
+		if !gok && !nok {
+			errList = append(errList, errors.New("Resource with APIVersion '"+resource.APIVersion+"' and kind '"+
+				resource.Kind+"' is not configured for KubeArchive"))
+		}
+	}
+	return errors.Join(errList...)
+}
+
+func getGlobalResourceSet(client dynamic.Interface) (map[sourcesv1.APIVersionKind]struct{}, error) {
+	resources := map[sourcesv1.APIVersionKind]struct{}{}
+
+	object, err := client.Resource(ClusterKubeArchiveConfigGVR).Get(context.Background(), constants.KubeArchiveConfigResourceName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return resources, nil
+	} else if err != nil {
+		return nil, err
+	}
+	ckac, err := ConvertUnstructuredToClusterKubeArchiveConfig(object)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resource := range ckac.Spec.Resources {
+		resources[sourcesv1.APIVersionKind{APIVersion: resource.Selector.APIVersion, Kind: resource.Selector.Kind}] = struct{}{}
+	}
+
+	return resources, nil
+}
+
+func getNamespaceResourceSet(client dynamic.Interface, namespace string) (map[sourcesv1.APIVersionKind]struct{}, error) {
+	object, err := client.Resource(KubeArchiveConfigGVR).Namespace(namespace).Get(context.Background(), constants.KubeArchiveConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	kac, err := ConvertUnstructuredToKubeArchiveConfig(object)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := map[sourcesv1.APIVersionKind]struct{}{}
+	for _, resource := range kac.Spec.Resources {
+		resources[sourcesv1.APIVersionKind{APIVersion: resource.Selector.APIVersion, Kind: resource.Selector.Kind}] = struct{}{}
+	}
+
+	return resources, nil
+}
+
+func getDynamicClient() (dynamic.Interface, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return dynamicClient, nil
+}
+
+func init() {
+	var err error
+	dynaClient, err = getDynamicClient()
+	if err != nil {
+		nvlog.Error(err, "Unable to get dynamic client")
+	}
+}

--- a/cmd/operator/api/v1alpha1/namespacevacuumconfig_webhook_test.go
+++ b/cmd/operator/api/v1alpha1/namespacevacuumconfig_webhook_test.go
@@ -1,0 +1,122 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubearchive/kubearchive/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	sourcesv1 "knative.dev/eventing/pkg/apis/sources/v1"
+)
+
+func TestNamespaceVacuumConfigCustomDefaulter(t *testing.T) {
+	defaulter := NamespaceVacuumConfigCustomDefaulter{}
+	nvc := &NamespaceVacuumConfig{}
+	err := defaulter.Default(context.Background(), nvc)
+	assert.NoError(t, err)
+	assert.Equal(t, NamespaceVacuumConfigSpec{Resources: nil}, nvc.Spec)
+}
+
+func TestNamespaceVacuumConfigValidateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      NamespaceVacuumConfigSpec
+		validated bool
+	}{
+		{
+			name:      "No resources",
+			spec:      NamespaceVacuumConfigSpec{},
+			validated: true,
+		},
+		{
+			name:      "Empty resources",
+			spec:      NamespaceVacuumConfigSpec{Resources: []sourcesv1.APIVersionKind{}},
+			validated: true,
+		},
+		{
+			name: "One resource",
+			spec: NamespaceVacuumConfigSpec{
+				Resources: []sourcesv1.APIVersionKind{
+					{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+				}},
+			validated: true,
+		},
+		{
+			name: "Muliple resources",
+			spec: NamespaceVacuumConfigSpec{
+				Resources: []sourcesv1.APIVersionKind{
+					{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+					{APIVersion: "tekton.dev/v1", Kind: "TaskRun"},
+				}},
+			validated: true,
+		},
+		{
+			name: "Non configured resource",
+			spec: NamespaceVacuumConfigSpec{
+				Resources: []sourcesv1.APIVersionKind{
+					{APIVersion: "v1", Kind: "Event"},
+				}},
+			validated: false,
+		},
+	}
+
+	ckac := &ClusterKubeArchiveConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KubeArchiveConfigResourceName},
+		Spec: ClusterKubeArchiveConfigSpec{
+			Resources: []KubeArchiveConfigResource{{
+				Selector: sourcesv1.APIVersionKindSelector{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+			}},
+		},
+	}
+	kac := &KubeArchiveConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KubeArchiveConfigResourceName, Namespace: "default"},
+		Spec: KubeArchiveConfigSpec{
+			Resources: []KubeArchiveConfigResource{{
+				Selector: sourcesv1.APIVersionKindSelector{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+			}},
+		},
+	}
+	scheme := runtime.NewScheme()
+	AddToScheme(scheme) //nolint:errcheck
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			dynaClient = fake.NewSimpleDynamicClient(scheme, ckac, kac)
+			validator := NamespaceVacuumConfigCustomValidator{}
+
+			// Create resource
+			nvc := &NamespaceVacuumConfig{ObjectMeta: metav1.ObjectMeta{Name: "nvc", Namespace: "default"}, Spec: test.spec}
+			warns, err := validator.ValidateCreate(context.Background(), nvc)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource in test %s", test.name)
+			}
+			// Update resource
+			warns, err = validator.ValidateUpdate(context.Background(), &NamespaceVacuumConfig{}, nvc)
+			assert.Nil(t, warns)
+			if test.validated {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, "invalid resource name %s", test.name)
+			}
+			// Delete resource
+			warns, err = validator.ValidateDelete(context.Background(), nvc)
+			assert.Nil(t, warns)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/cmd/operator/internal/controller/clusterkubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/clusterkubearchiveconfig_controller.go
@@ -29,8 +29,7 @@ type ClusterKubeArchiveConfigReconciler struct {
 	Mapper meta.RESTMapper
 }
 
-//+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=sinkfilters,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=clusterkubearchiveconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=clusterkubearchiveconfigs;clustervacuums;namespacevacuums;sinkfilters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=clusterkubearchiveconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=clusterkubearchiveconfigs/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;delete;get;list;update;watch

--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -34,8 +34,7 @@ type KubeArchiveConfigReconciler struct {
 	Mapper meta.RESTMapper
 }
 
-//+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=sinkfilters,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=kubearchiveconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=clustervacuums;kubearchiveconfigs;namespacevacuums;sinkfilters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=kubearchiveconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kubearchive.kubearchive.org,resources=kubearchiveconfigs/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;delete;get;list;update;watch

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -211,6 +211,14 @@ func main() {
 			slog.Error("unable to create webhook", "webhook", "SinkFilter", "err", err)
 			os.Exit(1)
 		}
+		if err = kubearchiveapi.SetupNamespaceVacuumConfigWebhookWithManager(mgr); err != nil {
+			slog.Error("unable to create webhook", "webhook", "NamespaceVacuumConfig", "err", err)
+			os.Exit(1)
+		}
+		if err = kubearchiveapi.SetupClusterVacuumConfigWebhookWithManager(mgr); err != nil {
+			slog.Error("unable to create webhook", "webhook", "ClusterVacuumConfig", "err", err)
+			os.Exit(1)
+		}
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -5,7 +5,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - crds/kubearchive.kubearchive.org_clusterkubearchiveconfigs.yaml
+  - crds/kubearchive.kubearchive.org_clustervacuumconfigs.yaml
   - crds/kubearchive.kubearchive.org_kubearchiveconfigs.yaml
+  - crds/kubearchive.kubearchive.org_namespacevacuumconfigs.yaml
   - crds/kubearchive.kubearchive.org_sinkfilters.yaml
   - templates/api_server/api_server.yaml
   - templates/api_server/certificates.yaml

--- a/config/templates/operator/webhooks.yaml
+++ b/config/templates/operator/webhooks.yaml
@@ -71,7 +71,47 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - sinkfilter
+          - sinkfilters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-kubearchive-org-v1alpha1-namespacevacuumconfig
+    failurePolicy: Fail
+    name: mnamespacevacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.kubearchive.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespacevacuumconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-kubearchive-org-v1alpha1-clustervacuumconfig
+    failurePolicy: Fail
+    name: mclustervacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.kubearchive.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clustervacuumconfigs
     sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -144,5 +184,45 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - sinkfilter
+          - sinkfilters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-kubearchive-org-v1alpha1-namespacevacuumconfig
+    failurePolicy: Fail
+    name: vnamespacevacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.kubearchive.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespacevacuumconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-kubearchive-org-v1alpha1-clustervacuumconfig
+    failurePolicy: Fail
+    name: vclustervacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.kubearchive.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clustervacuumconfigs
     sideEffects: None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Related to #991

### Cluster Vacuum

A cluster vacuum is configured in the KubeArchive installation namespace.  It allows the KubeArchive administrator
to vacuum any or all namespaces that are configured for KubeArchive. The ClusterVacuumConfig resources is used 
to configure which resources should be vacuumed on a namespace level. The configuration follows the following
rules:

- If a namespace is configured with no resources, then all resources configured for KubeArchive in that namespace are vacuumed.
- If a namespace is configured with a list of resources, then only those resources specified under that namespace are vacuumed.
- The special namespace name "---all-namespaces---" indicates that all namespaces configured for KubeArchive should be vacuumed. This allow an easy way to indicate all namespaces and not have to keep the list up-to-date. It may have resources listed under it, in which cases only those resources will be vacuumed in all namespaces.

The following ClusterVacuumConfig will vacuum all of the resources configured for KubeArchive
in each of the listed namespaces.

```
apiVersion: kubearchive.kubearchive.org/v1alpha1
kind: ClusterVacuumConfig
metadata:
  name: vacuum-namespaces
  namespace: kubearchive
spec:
  namespaces:
    - name: default
    - name: database
    - name: work
      resources: []
```

The following ClusterVacuumConfig will vacuum all of the resources configured for KubeArchive
in the `default` and `database` namespaces, and only archive PipelineRun and TaskRun resources
in the `work` namespace.

```
apiVersion: kubearchive.kubearchive.org/v1alpha1
kind: ClusterVacuumConfig
metadata:
  name: vacuum-mixed
  namespace: kubearchive
spec:
  namespaces:
    - name: default
    - name: database
    - name: work
      resources:
        - apiVersion: tekton.dev/v1
          kind: PipelineRun
        - apiVersion: tekton.dev/v1
          kind: TaskRun
```

### Namepspace Vacuum

A namespace vacuum is configured in an individual namespace.  It allows the namespace owners
to vacuum resources in the namespace that are configured for KubeArchive. The configuration
follows the following rules:

- If no resources are configured, then all resources configured for KubeArchive in that namespace are vacuumed.
- If a list of resources is configured, then only those resources are vacuumed.


The following NamespaceVacuumConfig will vacuum all of the resources configured for KubeArchive
in then namespaces.
```
apiVersion: kubearchive.kubearchive.org/v1alpha1
kind: NamespaceVacuumConfig
metadata:
  name: vacuum-all
  namespace: work
spec:
  resources: []
```

The following NamespaceVacuumConfig will vacuum only archive PipelineRun and TaskRun resources
in the namespace.

```
apiVersion: kubearchive.kubearchive.org/v1alpha1
kind: NamespaceVacuumConfig
metadata:
  name: vacuum-resources
  namespace: work
spec:
  resources:
    - apiVersion: tekton.dev/v1
      kind: PipelineRun
    - apiVersion: tekton.dev/v1
      kind: TaskRun
```

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors. If this
change has no user-visible impact, leave the code block as is.
-->

```release-note
Add NamespaceVacuumConfig and ClusterVacuumConfig resources.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
