### PR TITLE
Sink no configured resources

### DIFF
--- a/cmd/sink/filters/fake/filters.go
+++ b/cmd/sink/filters/fake/filters.go
@@ -51,3 +51,7 @@ func (f *Filters) MustArchiveOnDelete(ctx context.Context, obj *unstructured.Uns
 	}
 	return false
 }
+
+func (f *Filters) IsConfigured(ctx context.Context, obj *unstructured.Unstructured) bool {
+	return f.MustArchiveOnDelete(ctx, obj) || f.MustArchive(ctx, obj) || f.MustDelete(ctx, obj)
+}

--- a/cmd/sink/filters/filters_test.go
+++ b/cmd/sink/filters/filters_test.go
@@ -339,3 +339,97 @@ func TestChangeGlobalFilters(t *testing.T) {
 	}
 
 }
+
+func TestIsConfigured(t *testing.T) {
+	filters := NewFilters(nil)
+	fh, err := os.Open("testdata/sf.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { fh.Close() })
+
+	fileBytes, err := io.ReadAll(fh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var unstructuredData map[string]interface{}
+	err = yaml.Unmarshal(fileBytes, &unstructuredData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj := &unstructured.Unstructured{Object: unstructuredData}
+	bytes, err := obj.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sf := &kubearchiveapi.SinkFilter{}
+
+	if err = json.Unmarshal(bytes, sf); err != nil {
+		t.Fatal(err)
+	}
+
+	err = filters.changeFilters(sf.Spec.Namespaces)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		resource     unstructured.Unstructured
+		isConfigured bool
+	}{
+		{
+			name: "pod is configured",
+			resource: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]any{
+						"name":      "busybox",
+						"namespace": "pods-archive",
+					},
+				},
+			},
+			isConfigured: true,
+		},
+		{
+			name: "cronjob is configured",
+			resource: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "batch/v1",
+					"kind":       "CronJob",
+					"metadata": map[string]any{
+						"name":      "busybox",
+						"namespace": "pods-archive",
+					},
+				},
+			},
+			isConfigured: true,
+		},
+		{
+			name: "Deployment is not configured",
+			resource: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]any{
+						"name":      "busybox",
+						"namespace": "pods-archive",
+					},
+				},
+			},
+			isConfigured: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			isConfigured := filters.IsConfigured(context.Background(), &testCase.resource)
+
+			assert.Equal(t, testCase.isConfigured, isConfigured)
+		})
+	}
+}

--- a/docs/modules/ROOT/pages/configuration/observability.adoc
+++ b/docs/modules/ROOT/pages/configuration/observability.adoc
@@ -15,8 +15,9 @@ KubeArchive exposes the following custom metrics:
 Tracks the total number of Cloud Events (resource updates) received aggregated by `resource_type`,
 `event_type` and `result`.
 
-* `result`: one of `insert`, `update`, `none`, `error` or `no_match`. `none` is returned when the
-Cloud Event contains data older than the one already persisted (out of order).
+* `result`: one of `insert`, `update`, `none`, `error`, `no_match` or `no_conf`. `none` is returned when the
+Cloud Event contains data older than the one already persisted (out of order), `no_conf` is returned when the
+a resource is received but it is not configured.
 * `resource_type`: a combination of the resource `apiVersion` and `kind`. For example `apps/v1/Deployment`,
 `v1/Pods` or `tekton.dev/v1/PipelineRun`.
 * `event_type`: one of `dev.knative.apiserver.resource.new`, `dev.knative.apiserver.resource.update`

--- a/pkg/observability/metrics.go
+++ b/pkg/observability/metrics.go
@@ -14,11 +14,12 @@ var CloudEvents metric.Int64UpDownCounter
 type CEResult string
 
 const (
-	CEResultInsert  CEResult = "insert"
-	CEResultUpdate  CEResult = "update"
-	CEResultNone    CEResult = "none"
-	CEResultError   CEResult = "error"
-	CEResultNoMatch CEResult = "no_match"
+	CEResultInsert          CEResult = "insert"
+	CEResultUpdate          CEResult = "update"
+	CEResultNone            CEResult = "none"
+	CEResultError           CEResult = "error"
+	CEResultNoMatch         CEResult = "no_match"
+	CEResultNoConfiguration CEResult = "no_conf"
 )
 
 func NewCEResultFromWriteResourceResult(result interfaces.WriteResourceResult) CEResult {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1029 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Added a new label value for `kubearchive.cloudevents.total` to identify cloudevents from resources that are not configured. Read the observability documentation for more information.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
