### PR TITLE
Add aggregated ClusterRoles

### DIFF
--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -36,4 +36,5 @@ resources:
   - templates/sink/sink.yaml
   - templates/sink/trigger.yaml
   - templates/certificates.yaml
+  - templates/clusterroles.yaml
   - templates/namespace.yaml

--- a/config/templates/clusterroles.yaml
+++ b/config/templates/clusterroles.yaml
@@ -1,0 +1,30 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    app.kubernetes.io/name: kubearchive-edit
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: "${NEXT_VERSION}"
+rules:
+  - apiGroups: ["kubearchive.org"]
+    resources: ["*"]
+    verbs: ["create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    app.kubernetes.io/name: kubearchive-view
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: "${NEXT_VERSION}"
+rules:
+  - apiGroups: ["kubearchive.org"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1087 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Added `kubearchive-edit` and `kubearchive-view` roles that get automatically aggregated to ClusterRoles `edit` and `view`.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* Roles are not aggregated to `admin` because by default `view` and `edit` are aggregated into `admin` automatically. Check the labels of those clusterroles on the cluster, they should have `rbac.authorization.k8s.io/aggregate-to-admin: "true"` themselves.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
