### PR TITLE
Add output format on the cli - using kubectl approach

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	knative.dev/eventing v0.45.2
 	knative.dev/pkg v0.0.0-20250710001404-a4cc1bdef5b2
 	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/yaml v1.5.0
 )
 
 require (
@@ -176,5 +177,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.19.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
-	sigs.k8s.io/yaml v1.5.0 // indirect
 )

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -3,9 +3,20 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
 )
 
 func TestCompleteAPI(t *testing.T) {
@@ -15,6 +26,7 @@ func TestCompleteAPI(t *testing.T) {
 		args            []string
 		expectedApiPath string
 		isCore          bool
+		output          string
 	}{
 		{
 			name:            "core",
@@ -60,4 +72,278 @@ func TestCompleteAPI(t *testing.T) {
 		})
 	}
 
+}
+
+// Helper function to load expected content from testdata files
+func loadExpectedOutput(t *testing.T, filename string) string {
+	t.Helper()
+	path := filepath.Join("testdata", filename)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "Failed to read expected output file: %s", path)
+	return string(content)
+}
+
+// Helper function to normalize JSON for comparison
+func normalizeJSON(t *testing.T, jsonStr string) string {
+	t.Helper()
+	var obj interface{}
+	err := json.Unmarshal([]byte(jsonStr), &obj)
+	require.NoError(t, err)
+	normalized, err := json.MarshalIndent(obj, "", "    ")
+	require.NoError(t, err)
+	return string(normalized)
+}
+
+// Helper function to normalize YAML for comparison
+func normalizeYAML(t *testing.T, yamlStr string) string {
+	t.Helper()
+	var obj interface{}
+	err := yaml.Unmarshal([]byte(yamlStr), &obj)
+	require.NoError(t, err)
+	normalized, err := yaml.Marshal(obj)
+	require.NoError(t, err)
+	return string(normalized)
+}
+
+// Helper function to create a mock server that returns a pod with the specified name and timestamp
+// If podName is empty, returns an empty list
+// If timestamp is empty, no timestamp is set (for empty lists)
+func createMockServer(t *testing.T, podName string, timestamp string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"kind":       "List",
+			"apiVersion": "v1",
+			"items":      []map[string]interface{}{},
+		}
+
+		// Add a pod only if podName is provided
+		if podName != "" {
+			pod := map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"name":      podName,
+					"namespace": "default",
+				},
+			}
+
+			// Add timestamp if provided
+			if timestamp != "" {
+				pod["metadata"].(map[string]interface{})["creationTimestamp"] = timestamp
+			}
+
+			response["items"] = []map[string]interface{}{pod}
+		}
+
+		err := json.NewEncoder(w).Encode(response)
+		if err != nil {
+			return
+		}
+	}))
+}
+
+// Helper function to create a mock server that returns an error
+func createMockErrorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, err := w.Write([]byte("server error"))
+		if err != nil {
+			return
+		}
+	}))
+}
+
+// Helper function to create test options with two separate mock servers
+func createTestOptionsWithTwoServers(t *testing.T, kubernetesServerURL, kubeArchiveServerURL string) *GetOptions {
+	t.Helper()
+	options := NewGetOptions()
+	options.RESTConfig = &rest.Config{
+		Host: kubernetesServerURL,
+	}
+	options.KubeArchiveHost = kubeArchiveServerURL
+	options.AllNamespaces = true
+	options.Resource = "pods"
+	options.GroupVersion = "v1"
+	options.IsCoreResource = true
+	options.APIPath = "/api/v1/pods"
+
+	// Set up bearer token to avoid a nil pointer in getKubeArchiveResources
+	token := "test-token"
+	options.kubeFlags.BearerToken = &token
+
+	return options
+}
+
+// setupTestEnvironmentCommon handles common setup: creates CA file, creates test options, returns cleanup
+func setupTestEnvironmentCommon(t *testing.T, mockKubernetesServer, mockKubeArchiveServer *httptest.Server) (*GetOptions, func()) {
+	t.Helper()
+
+	// Create CA certificate file
+	err := os.WriteFile("ca.crt", []byte(""), 0600)
+	require.NoError(t, err)
+
+	// Create test options
+	options := createTestOptionsWithTwoServers(t, mockKubernetesServer.URL, mockKubeArchiveServer.URL)
+
+	// Return cleanup function
+	cleanup := func() {
+		os.Remove("ca.crt")
+		mockKubernetesServer.Close()
+		mockKubeArchiveServer.Close()
+	}
+
+	return options, cleanup
+}
+
+// setupTestEnvironment handles test setup: creates CA file, mock servers, and test options
+// Returns cleanup function that should be deferred
+func setupTestEnvironment(t *testing.T, kubernetesPodName, kubeArchivePodName, kubernetesTimestamp, kubeArchiveTimestamp string) (*GetOptions, func()) {
+	t.Helper()
+
+	// Create mock servers
+	mockKubernetesServer := createMockServer(t, kubernetesPodName, kubernetesTimestamp)
+	mockKubeArchiveServer := createMockServer(t, kubeArchivePodName, kubeArchiveTimestamp)
+
+	return setupTestEnvironmentCommon(t, mockKubernetesServer, mockKubeArchiveServer)
+}
+
+// setupTestEnvironmentWithErrorServers creates test environment with error servers for testing failure scenarios
+func setupTestEnvironmentWithErrorServers(t *testing.T, kubernetesError, kubeArchiveError bool) (*GetOptions, func()) {
+	t.Helper()
+
+	// Create appropriate servers based on error flags
+	var mockKubernetesServer *httptest.Server
+	if kubernetesError {
+		mockKubernetesServer = createMockErrorServer(t)
+	} else {
+		mockKubernetesServer = createMockServer(t, "", "") // Empty list, no timestamp
+	}
+
+	var mockKubeArchiveServer *httptest.Server
+	if kubeArchiveError {
+		mockKubeArchiveServer = createMockErrorServer(t)
+	} else {
+		mockKubeArchiveServer = createMockServer(t, "", "") // Empty list, no timestamp
+	}
+
+	return setupTestEnvironmentCommon(t, mockKubernetesServer, mockKubeArchiveServer)
+}
+
+func TestRunOutputFormats(t *testing.T) {
+	// Calculate the dynamic timestamp for table test (5 minutes ago)
+	dynamicTimestamp := time.Now().Add(-5 * time.Minute).Format(time.RFC3339)
+
+	testCases := []struct {
+		name                 string
+		outputFormat         string
+		expectedOutputFile   string
+		needsNormalization   bool
+		kubernetesTimestamp  string
+		kubeArchiveTimestamp string
+	}{
+		{
+			name:                 "table",
+			outputFormat:         "",
+			expectedOutputFile:   "expected_table_output.txt",
+			needsNormalization:   false,
+			kubernetesTimestamp:  dynamicTimestamp,
+			kubeArchiveTimestamp: dynamicTimestamp,
+		},
+		{
+			name:                 "json",
+			outputFormat:         "json",
+			expectedOutputFile:   "expected_json_output.json",
+			needsNormalization:   true,
+			kubernetesTimestamp:  "2025-07-08T09:54:00Z",
+			kubeArchiveTimestamp: "2025-07-08T09:54:00Z",
+		},
+		{
+			name:                 "yaml",
+			outputFormat:         "yaml",
+			expectedOutputFile:   "expected_yaml_output.yaml",
+			needsNormalization:   true,
+			kubernetesTimestamp:  "2025-07-08T09:54:00Z",
+			kubeArchiveTimestamp: "2025-07-08T09:54:00Z",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			options, cleanup := setupTestEnvironment(t, "test-pod-1", "archived-pod-1", tc.kubernetesTimestamp, tc.kubeArchiveTimestamp)
+			defer cleanup()
+
+			// Set output format if specified
+			if tc.outputFormat != "" {
+				options.OutputFormat = &tc.outputFormat
+			}
+
+			// Capture output
+			var buf bytes.Buffer
+			options.Out = &buf
+
+			// Call the Run function directly
+			err := options.Run()
+			require.NoError(t, err)
+
+			// Compare with expected output
+			expectedOutput := loadExpectedOutput(t, tc.expectedOutputFile)
+			actualOutput := buf.String()
+
+			if tc.needsNormalization {
+				// Normalize both expected and actual output for JSON/YAML
+				if tc.outputFormat == "json" {
+					expectedNormalized := normalizeJSON(t, expectedOutput)
+					actualNormalized := normalizeJSON(t, strings.TrimSpace(actualOutput))
+					assert.Equal(t, expectedNormalized, actualNormalized)
+				} else if tc.outputFormat == "yaml" {
+					expectedNormalized := normalizeYAML(t, expectedOutput)
+					actualNormalized := normalizeYAML(t, strings.TrimSpace(actualOutput))
+					assert.Equal(t, expectedNormalized, actualNormalized)
+				}
+			} else {
+				// Direct comparison for table output
+				assert.Equal(t, expectedOutput, actualOutput)
+			}
+		})
+	}
+}
+
+func TestRunErrorHandling(t *testing.T) {
+	testCases := []struct {
+		name                string
+		kubernetesError     bool
+		kubeArchiveError    bool
+		expectedErrorString string
+	}{
+		{
+			name:                "kubernetes server error",
+			kubernetesError:     true,
+			kubeArchiveError:    false,
+			expectedErrorString: "error retrieving resources from the cluster",
+		},
+		{
+			name:                "kubearchive server error",
+			kubernetesError:     false,
+			kubeArchiveError:    true,
+			expectedErrorString: "error retrieving resources from the KubeArchive API",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			options, cleanup := setupTestEnvironmentWithErrorServers(t, tc.kubernetesError, tc.kubeArchiveError)
+			defer cleanup()
+
+			// Capture output
+			var buf bytes.Buffer
+			options.Out = &buf
+
+			// Call the Run function directly and expect an error
+			err := options.Run()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErrorString)
+		})
+	}
 }

--- a/pkg/cmd/testdata/expected_json_output.json
+++ b/pkg/cmd/testdata/expected_json_output.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "creationTimestamp": "2025-07-08T09:54:00Z",
+        "name": "test-pod-1",
+        "namespace": "default"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "creationTimestamp": "2025-07-08T09:54:00Z",
+        "name": "archived-pod-1",
+        "namespace": "default"
+      }
+    }
+  ],
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  }
+}

--- a/pkg/cmd/testdata/expected_table_output.txt
+++ b/pkg/cmd/testdata/expected_table_output.txt
@@ -1,0 +1,3 @@
+NAME             AGE
+test-pod-1       5m
+archived-pod-1   5m

--- a/pkg/cmd/testdata/expected_yaml_output.yaml
+++ b/pkg/cmd/testdata/expected_yaml_output.yaml
@@ -1,0 +1,19 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+items:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      creationTimestamp: "2025-07-08T09:54:00Z"
+      name: test-pod-1
+      namespace: default
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      creationTimestamp: "2025-07-08T09:54:00Z"
+      name: archived-pod-1
+      namespace: default
+kind: List
+metadata:
+  resourceVersion: ""


### PR DESCRIPTION
Add output format for JSON, YAML and default table.

Assisted-by: Cursor

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #299, related #288 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

The KubeArchive API doesn't support table format so in this PR I'm just going with the default parameters: `NAME` and `AGE`.
I used cursor to help me understand and implement how could we use the code and the printers already available
in kubectl to avoid repeating code while keeping shorter and with less functionality.
The code is a mix of their suggestions with my manual modifications.
The tests are more of a several iteration process but only code created by Cursor.

This is a PR that covers almost the same as https://github.com/kubearchive/kubearchive/pull/977.
I am creating it because I wanted to explore a different approach a tried to use more of the provided functionality 
of kubectl instead of adding it manually.

The idea is that we choose one or another.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
