### PR TITLE
Add kubectl archive config

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,19 +118,25 @@ After you make changes to the code use the script to redeploy KubeArchive:
 
 1. Get the Certificate Authority (CA) from the `kubearchive-api-server-tls` secret:
     ```bash
-    kubectl get -n kubearchive secrets kubearchive-api-server-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+    kubectl get -n kubearchive secrets kubearchive-api-server-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > ~/.config/kubectl/archive/ca.crt
     ```
 
-1. Run the CLI:
+1. Export the `KUBECTL_PLUGIN_ARCHIVE_CERT_PATH` with the `ca.crt` file path
     ```bash
-    go run cmd/kubectl-archive/main.go get batch/v1 jobs --token $(kubectl create -n test token default)
+    export KUBECTL_PLUGIN_ARCHIVE_CERT_PATH=~/.config/kubectl/archive/ca.crt
     ```
-   **NOTE**: For this to work the `test/users/test-user.yaml` must be applied.
+
+1. Export the `KUBECTL_PLUGIN_ARCHIVE_TOKEN` with the token of a service account with the proper permissions
+
+    ```bash
+    bash test/users/test-user.yml
+    export KUBECTL_PLUGIN_ARCHIVE_TOKEN=$(kubectl create token -n test default)
+    ```
 
 1. Generate a new job, and run again:
     ```bash
     kubectl create job my-job --image=busybox
-    go run cmd/kubectl-archive/main.go get batch/v1 jobs --token $(kubectl create -n test token default)
+    go run cmd/kubectl-archive/main.go get batch/v1 jobs
     ```
 
 ## Running integration tests

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,6 +3,9 @@
 ** xref:getting-started/kubearchive-api.adoc[]
 ** xref:getting-started/configuration.adoc[]
 
+* CLI
+** xref:cli/configuration.adoc[Configuration]
+
 * Configuration
 ** xref:configuration/kubearchiveconfig.adoc[KubeArchiveConfig CRD]
 ** xref:configuration/global-filters.adoc[Global Filters]

--- a/docs/modules/ROOT/pages/cli/configuration.adoc
+++ b/docs/modules/ROOT/pages/cli/configuration.adoc
@@ -1,0 +1,94 @@
+= CLI Configuration
+
+The kubectl-archive plugin supports configuration through environment variables and CLI flags, following the same pattern as kubectl and other plugins.
+
+== Configuration Precedence
+
+Configuration values are resolved in the following order (highest to lowest priority):
+
+. *Plugin CLI Flags* - Plugin-specific command line arguments
+. *Environment Variables* - System environment variables
+. *Default Values* - Built-in defaults
+
+== Global Configuration Parameters
+
+All configuration can be set using environment variables with the prefix `KUBECTL_PLUGIN_ARCHIVE_`:
+
+[cols="1,2,1,1"]
+|===
+|Environment Variable |Description |Default |CLI Flag
+
+|`KUBECTL_PLUGIN_ARCHIVE_HOST`
+|KubeArchive API host:port
+|`https://localhost:8081`
+|`--host`
+
+|`KUBECTL_PLUGIN_ARCHIVE_CERT_PATH`
+|Path to KubeArchive API certificate file
+|(none)
+|`--kubearchive-certificate-authority`
+
+|`KUBECTL_PLUGIN_ARCHIVE_TLS_INSECURE`
+|Skip TLS certificate verification for the KubeArchive API server
+|`false`
+|`--kubearchive-insecure-skip-tls-verify`
+
+|`KUBECTL_PLUGIN_ARCHIVE_TOKEN`
+|Bearer token for KubeArchive API authentication
+|(from kubeconfig)
+|(uses kubectl's `--token` flag)
+
+|===
+
+== Authentication
+
+The KubeArchive API only supports bearer token authentication.
+
+If your kubeconfig uses client certificates or other authentication methods,
+you must provide a bearer token from a service account in the cluster
+with sufficient permissions to perform the requested operations (`get`, `list`, `logs`).
+
+== Certificate Handling
+
+The plugin uses separate certificate handling for Kubernetes and KubeArchive APIs:
+
+=== KubeArchive API Certificate
+
+The KubeArchive API certificate is configured independently from the Kubernetes cluster certificate.
+The `--kubearchive-certificate-authority`, `--kubearchive-insecure-skip-tls-verify` flags and their
+environment variables provides the certificate necessary configuration for the CLI.
+
+=== Kubernetes Cluster Certificate
+
+The Kubernetes cluster certificate continues to use kubectl's standard
+`--certificate-authority`, `--insecure-skip-tls-verify` flags.
+
+== Examples
+
+=== Use a bearer token for a service account
+
+[source,bash]
+----
+KUBECTL_PLUGIN_ARCHIVE_TOKEN=$(kubectl -n test create token default) kubectl archive get v1 pods
+----
+
+=== Use insecure TLS for KubeArchive API
+
+[source,bash]
+----
+kubectl archive get v1 pods --kubearchive-insecure-skip-tls-verify
+----
+
+=== Use a certificate file for KubeArchive API
+
+[source,bash]
+----
+KUBECTL_PLUGIN_ARCHIVE_CERT_PATH="/path/to/ca.crt" kubectl archive get v1 pods
+----
+
+=== Use a host different from a portforwarded one
+
+[source,bash]
+----
+KUBECTL_PLUGIN_ARCHIVE_HOST="https://kubearchive.apps.example.com" kubectl archive get v1 pods
+----

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.12.0
 	go.opentelemetry.io/contrib/instrumentation/host v0.62.0
@@ -132,7 +133,6 @@ require (
 	github.com/rickb777/plural v1.2.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.5 // indirect
-	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.15 // indirect
 	github.com/tklauser/numcpus v0.10.0 // indirect

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -1,0 +1,20 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// loadGoldenFile loads content from a golden file in testdata
+func loadGoldenFile(t *testing.T, filename string) string {
+	t.Helper()
+	path := filepath.Join("testdata", filename)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "Failed to read golden file: %s", path)
+	return string(content)
+}

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,0 +1,178 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+package config
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+)
+
+type API int
+
+const (
+	Kubernetes API = iota
+	KubeArchive
+)
+
+type ArchiveCLICommand interface {
+	Complete() error
+	AddFlags(flags *pflag.FlagSet)
+	GetFromAPI(api API, path string) ([]byte, error)
+	GetNamespace() (string, error)
+}
+
+type ArchiveOptions struct {
+	host            string
+	tlsInsecure     bool
+	certificatePath string
+	kubeFlags       *genericclioptions.ConfigFlags
+	K8sRESTConfig   *rest.Config
+	K9eRESTConfig   *rest.Config
+}
+
+// NewArchiveOptions loads config from env vars and sets defaults
+func NewArchiveOptions() *ArchiveOptions {
+	opts := &ArchiveOptions{
+		host:            "https://localhost:8081",
+		certificatePath: "",
+		kubeFlags:       genericclioptions.NewConfigFlags(true),
+	}
+	if v := os.Getenv("KUBECTL_PLUGIN_ARCHIVE_HOST"); v != "" {
+		opts.host = v
+	}
+	if v := os.Getenv("KUBECTL_PLUGIN_ARCHIVE_CERT_PATH"); v != "" {
+		opts.certificatePath = v
+	}
+	if v := os.Getenv("KUBECTL_PLUGIN_ARCHIVE_TLS_INSECURE"); v != "" {
+		opts.tlsInsecure, _ = strconv.ParseBool(v)
+	}
+	return opts
+}
+
+// GetFromAPI HTTP GET request to the given endpoint
+func (opts *ArchiveOptions) GetFromAPI(api API, path string) ([]byte, error) {
+	var restConfig *rest.Config
+	var host string
+
+	switch api {
+	case Kubernetes:
+		restConfig = opts.K8sRESTConfig
+		host = opts.K8sRESTConfig.Host
+	case KubeArchive:
+		restConfig = opts.K9eRESTConfig
+		host = opts.host
+	}
+
+	client, err := rest.HTTPClientFor(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the HTTP client from the REST config: %w", err)
+	}
+	url := fmt.Sprintf("%s%s", host, path)
+	response, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error on GET to '%s': %w", url, err)
+	}
+	defer response.Body.Close()
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing the body: %w", err)
+	}
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("unable to get '%s': unauthorized", url)
+	}
+
+	if response.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("unable to get '%s': not found", url)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unable to get '%s': unknown error: %s (%d)", url, string(bodyBytes), response.StatusCode)
+	}
+
+	return bodyBytes, nil
+}
+
+// GetCertificateData get the certificate from a file path if set
+func (opts *ArchiveOptions) getCertificateData() ([]byte, error) {
+	if opts.certificatePath != "" {
+		certData, err := os.ReadFile(opts.certificatePath)
+		if err == nil {
+			// Successfully loaded local certificate
+			return certData, nil
+		}
+
+		return nil, fmt.Errorf("failed to load certificate from path and no secret info available: %w", err)
+	}
+
+	return nil, nil
+}
+
+// GetNamespace get the provided namespace or the namespace used in kubeconfig context
+func (opts *ArchiveOptions) GetNamespace() (string, error) {
+	if opts.kubeFlags.Namespace != nil && *opts.kubeFlags.Namespace != "" {
+		return *opts.kubeFlags.Namespace, nil
+	}
+	if rawLoader := opts.kubeFlags.ToRawKubeConfigLoader(); rawLoader != nil {
+		ns, _, nsErr := rawLoader.Namespace()
+		if nsErr != nil {
+			return "", fmt.Errorf("error retrieving namespace from kubeconfig context: %w", nsErr)
+		}
+		opts.kubeFlags.Namespace = &ns
+		return ns, nil
+	}
+	return "", fmt.Errorf("unable to retrieve namespace from kubeconfig context")
+}
+
+// Complete resolve the final values considering the values of the kubectl builtin flags
+func (opts *ArchiveOptions) Complete() error {
+	restConfig, err := opts.kubeFlags.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("error creating the REST configuration: %w", err)
+	}
+	opts.K8sRESTConfig = restConfig
+
+	certData, err := opts.getCertificateData()
+	if err != nil {
+		return fmt.Errorf("failed to get certificate data: %w", err)
+	}
+
+	var token string
+	if opts.kubeFlags.BearerToken != nil && *opts.kubeFlags.BearerToken != "" {
+		token = *opts.kubeFlags.BearerToken
+	} else if t := os.Getenv("KUBECTL_PLUGIN_ARCHIVE_TOKEN"); t != "" {
+		token = t
+	} else {
+		token = opts.K8sRESTConfig.BearerToken
+	}
+
+	opts.K9eRESTConfig = &rest.Config{
+		Host:        opts.host,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: opts.tlsInsecure,
+		},
+	}
+	if certData != nil {
+		opts.K9eRESTConfig.CAData = certData
+		opts.K9eRESTConfig.Insecure = false
+	}
+
+	return nil
+}
+
+// AddFlags adds all archive-related flags to the given flag set
+func (opts *ArchiveOptions) AddFlags(flags *pflag.FlagSet) {
+	opts.kubeFlags.AddFlags(flags)
+	flags.StringVar(&opts.host, "host", opts.host, "host where the KubeArchive API Server is listening.")
+	flags.BoolVar(&opts.tlsInsecure, "kubearchive-insecure-skip-tls-verify", opts.tlsInsecure, "Allow insecure requests to the KubeArchive API.")
+	flags.StringVar(&opts.certificatePath, "kubearchive-certificate-authority", opts.certificatePath, "Path to the certificate authority file.")
+}

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -1,0 +1,387 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+)
+
+// withMultipleEnv sets multiple environment variables for the duration of the test.
+func withMultipleEnv(t *testing.T, envVars map[string]string, testFunc func()) {
+	t.Helper()
+	for k, v := range envVars {
+		t.Setenv(k, v)
+	}
+	testFunc()
+}
+
+func TestNewArchiveOptions(t *testing.T) {
+	testCases := []struct {
+		name             string
+		envVars          map[string]string
+		expectedHost     string
+		expectedCert     string
+		expectedInsecure bool
+	}{
+		{
+			name:             "defaults",
+			envVars:          map[string]string{},
+			expectedHost:     "https://localhost:8081",
+			expectedCert:     "",
+			expectedInsecure: false,
+		},
+		{
+			name: "environment variables",
+			envVars: map[string]string{
+				"KUBECTL_PLUGIN_ARCHIVE_HOST":         "https://env-host:7070",
+				"KUBECTL_PLUGIN_ARCHIVE_CERT_PATH":    "/path/to/env/cert.crt",
+				"KUBECTL_PLUGIN_ARCHIVE_TLS_INSECURE": "true",
+			},
+			expectedHost:     "https://env-host:7070",
+			expectedCert:     "/path/to/env/cert.crt",
+			expectedInsecure: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			withMultipleEnv(t, tc.envVars, func() {
+				opts := NewArchiveOptions()
+				assert.Equal(t, tc.expectedHost, opts.host)
+				assert.Equal(t, tc.expectedCert, opts.certificatePath)
+				assert.Equal(t, tc.expectedInsecure, opts.tlsInsecure)
+			})
+		})
+	}
+}
+
+func TestAddFlagsAndPrecedence(t *testing.T) {
+	testCases := []struct {
+		name             string
+		envVars          map[string]string
+		flagValues       map[string]string
+		expectedHost     string
+		expectedCert     string
+		expectedInsecure bool
+	}{
+		{
+			name:             "flags only",
+			envVars:          map[string]string{},
+			flagValues:       map[string]string{"host": "https://flag-host:9090"},
+			expectedHost:     "https://flag-host:9090",
+			expectedCert:     "",
+			expectedInsecure: false,
+		},
+		{
+			name:             "env vars only",
+			envVars:          map[string]string{"KUBECTL_PLUGIN_ARCHIVE_HOST": "https://env-host:7070"},
+			flagValues:       map[string]string{},
+			expectedHost:     "https://env-host:7070",
+			expectedCert:     "",
+			expectedInsecure: false,
+		},
+		{
+			name:             "flags override env vars",
+			envVars:          map[string]string{"KUBECTL_PLUGIN_ARCHIVE_HOST": "https://env-host:7070"},
+			flagValues:       map[string]string{"host": "https://flag-host:9090"},
+			expectedHost:     "https://flag-host:9090",
+			expectedCert:     "",
+			expectedInsecure: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			withMultipleEnv(t, tc.envVars, func() {
+				opts := NewArchiveOptions()
+
+				if len(tc.flagValues) > 0 {
+					flags := pflag.NewFlagSet("test", pflag.ExitOnError)
+					opts.AddFlags(flags)
+
+					for flagName, flagValue := range tc.flagValues {
+						flag := flags.Lookup(flagName)
+						require.NotNil(t, flag)
+						require.NoError(t, flag.Value.Set(flagValue))
+					}
+				}
+
+				assert.Equal(t, tc.expectedHost, opts.host)
+				assert.Equal(t, tc.expectedCert, opts.certificatePath)
+				assert.Equal(t, tc.expectedInsecure, opts.tlsInsecure)
+			})
+		})
+	}
+}
+
+func TestComplete(t *testing.T) {
+	kubeconfigPath := filepath.Join("testdata", "kubeconfig.yaml")
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	testCases := []struct {
+		name                string
+		setup               func(opts *ArchiveOptions)
+		env                 map[string]string
+		expectedK9eHost     string
+		expectedK9eToken    string
+		expectedK9eInsecure bool
+		expectCertData      bool
+		expectError         bool
+		errorContains       string
+	}{
+		{
+			name:                "default configuration",
+			setup:               func(opts *ArchiveOptions) {},
+			env:                 map[string]string{},
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "k8s-config-token",
+			expectedK9eInsecure: false,
+			expectCertData:      false,
+			expectError:         false,
+		},
+		{
+			name: "token precedence - kubectl flag wins",
+			setup: func(opts *ArchiveOptions) {
+				testToken := "kubectl-token" // #nosec G101 - this is a test token
+				opts.kubeFlags.BearerToken = &testToken
+			},
+			env: map[string]string{
+				"KUBECTL_PLUGIN_ARCHIVE_TOKEN": "env-token",
+			},
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "kubectl-token",
+			expectedK9eInsecure: false,
+			expectCertData:      false,
+			expectError:         false,
+		},
+		{
+			name:  "token from environment variable",
+			setup: func(opts *ArchiveOptions) {},
+			env: map[string]string{
+				"KUBECTL_PLUGIN_ARCHIVE_TOKEN": "env-token",
+			},
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "env-token",
+			expectedK9eInsecure: false,
+			expectCertData:      false,
+			expectError:         false,
+		},
+		{
+			name: "certificate path with TLS override",
+			setup: func(opts *ArchiveOptions) {
+				opts.tlsInsecure = true
+				opts.certificatePath = filepath.Join("testdata", "test-cert.crt")
+			},
+			env:                 map[string]string{},
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "k8s-config-token",
+			expectedK9eInsecure: false, // Certificate overrides insecure setting
+			expectCertData:      true,
+			expectError:         false,
+		},
+		{
+			name: "certificate error",
+			setup: func(opts *ArchiveOptions) {
+				opts.certificatePath = "/nonexistent/cert.crt"
+			},
+			env:           map[string]string{},
+			expectError:   true,
+			errorContains: "failed to load certificate from path",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			withMultipleEnv(t, tc.env, func() {
+				opts := NewArchiveOptions()
+				if tc.setup != nil {
+					tc.setup(opts)
+				}
+
+				err := opts.Complete()
+				if tc.expectError {
+					assert.Error(t, err)
+					if tc.errorContains != "" {
+						assert.Contains(t, err.Error(), tc.errorContains)
+					}
+					return
+				}
+
+				require.NoError(t, err)
+				assert.NotNil(t, opts.K8sRESTConfig)
+				assert.NotNil(t, opts.K9eRESTConfig)
+				assert.Equal(t, tc.expectedK9eHost, opts.K9eRESTConfig.Host)
+				assert.Equal(t, tc.expectedK9eToken, opts.K9eRESTConfig.BearerToken)
+				assert.Equal(t, tc.expectedK9eInsecure, opts.K9eRESTConfig.Insecure)
+
+				if tc.expectCertData {
+					assert.NotNil(t, opts.K9eRESTConfig.CAData)
+					assert.NotEmpty(t, opts.K9eRESTConfig.CAData)
+				} else {
+					assert.Nil(t, opts.K9eRESTConfig.CAData)
+				}
+			})
+		})
+	}
+}
+
+func TestGetNamespace(t *testing.T) {
+	testCases := []struct {
+		name          string
+		useKubeconfig bool
+		setup         func(opts *ArchiveOptions)
+		expectedNs    string
+		expectError   bool
+	}{
+		{
+			name: "namespace from flags",
+			setup: func(opts *ArchiveOptions) {
+				ns := "test-namespace"
+				opts.kubeFlags.Namespace = &ns
+			},
+			expectedNs:  "test-namespace",
+			expectError: false,
+		},
+		{
+			name:          "namespace from kubeconfig",
+			useKubeconfig: true,
+			setup:         func(opts *ArchiveOptions) {},
+			expectedNs:    "kubeconfig-namespace",
+			expectError:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.useKubeconfig {
+				kubeconfigPath := filepath.Join("testdata", "kubeconfig.yaml")
+				t.Setenv("KUBECONFIG", kubeconfigPath)
+			}
+
+			opts := &ArchiveOptions{
+				kubeFlags: genericclioptions.NewConfigFlags(true),
+			}
+			if tc.setup != nil {
+				tc.setup(opts)
+			}
+
+			ns, err := opts.GetNamespace()
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedNs, ns)
+			}
+		})
+	}
+}
+
+func TestGetFromAPI(t *testing.T) {
+	testCases := []struct {
+		name           string
+		api            API
+		path           string
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		expectedBody   string
+		expectError    bool
+		errorContains  string
+		unreachable    bool
+	}{
+		{
+			name: "successful request",
+			api:  Kubernetes,
+			path: "/api/v1/pods",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"kind":"PodList"}`))
+			},
+			expectedBody: `{"kind":"PodList"}`,
+			expectError:  false,
+		},
+		{
+			name: "unauthorized response",
+			api:  KubeArchive,
+			path: "/api/v1/secrets",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			expectError:   true,
+			errorContains: "unauthorized",
+		},
+		{
+			name: "not found response",
+			api:  Kubernetes,
+			path: "/api/v1/nonexistent",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			expectError:   true,
+			errorContains: "not found",
+		},
+		{
+			name: "server error with body",
+			api:  KubeArchive,
+			path: "/api/v1/error",
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`Error details`))
+			},
+			expectError:   true,
+			errorContains: "unknown error: Error details (500)",
+		},
+		{
+			name:          "network error",
+			api:           Kubernetes,
+			path:          "/test",
+			unreachable:   true,
+			expectError:   true,
+			errorContains: "error on GET to",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var server *httptest.Server
+			var serverURL string
+
+			if tc.unreachable {
+				serverURL = "http://unreachable:12345"
+			} else {
+				server = httptest.NewServer(http.HandlerFunc(tc.serverResponse))
+				defer server.Close()
+				serverURL = server.URL
+			}
+
+			opts := &ArchiveOptions{
+				host: serverURL,
+				K8sRESTConfig: &rest.Config{
+					Host: serverURL,
+				},
+				K9eRESTConfig: &rest.Config{
+					Host: serverURL,
+				},
+			}
+
+			result, err := opts.GetFromAPI(tc.api, tc.path)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedBody, string(result))
+			}
+		})
+	}
+}

--- a/pkg/cmd/config/testdata/kubeconfig.yaml
+++ b/pkg/cmd/config/testdata/kubeconfig.yaml
@@ -1,0 +1,20 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test-cluster
+    cluster:
+      server: https://test-cluster:6443
+contexts:
+  - name: test-context
+    context:
+      cluster: test-cluster
+      user: test-user
+      namespace: kubeconfig-namespace
+current-context: test-context
+users:
+  - name: test-user
+    user:
+      token: k8s-config-token

--- a/pkg/cmd/config/testdata/test-cert.crt
+++ b/pkg/cmd/config/testdata/test-cert.crt
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+
+-----END CERTIFICATE-----

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -5,42 +5,33 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 
+	"github.com/kubearchive/kubearchive/pkg/cmd/config"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
-	"k8s.io/client-go/rest"
 )
 
 type GetOptions struct {
-	AllNamespaces bool
-	APIPath       string
-	Resource      string
-	GroupVersion  string
-	Token         string
-
-	KubeArchiveHost string
-
-	RESTConfig         *rest.Config
-	kubeFlags          *genericclioptions.ConfigFlags
+	genericiooptions.IOStreams
+	config.ArchiveCLICommand
+	AllNamespaces      bool
+	APIPath            string
+	Resource           string
+	GroupVersion       string
 	OutputFormat       *string
 	JSONYamlPrintFlags *genericclioptions.JSONYamlPrintFlags
 	IsValidOutput      bool
-	genericiooptions.IOStreams
 }
 
 func NewGetOptions() *GetOptions {
 	outputFormat := ""
 	return &GetOptions{
-		kubeFlags:          genericclioptions.NewConfigFlags(true),
-		KubeArchiveHost:    "https://localhost:8081",
 		OutputFormat:       &outputFormat,
 		JSONYamlPrintFlags: genericclioptions.NewJSONYamlPrintFlags(),
 		IOStreams: genericiooptions.IOStreams{
@@ -48,6 +39,7 @@ func NewGetOptions() *GetOptions {
 			Out:    os.Stdout,
 			ErrOut: os.Stderr,
 		},
+		ArchiveCLICommand: config.NewArchiveOptions(),
 	}
 }
 
@@ -64,7 +56,6 @@ func NewGetCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error completing the args: %w", err)
 			}
-
 			err = o.Run()
 			if err != nil {
 				return fmt.Errorf("error running the command: %w", err)
@@ -74,22 +65,31 @@ func NewGetCmd() *cobra.Command {
 		},
 	}
 
-	o.kubeFlags.AddFlags(cmd.Flags())
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	cmd.Flags().StringVar(&o.KubeArchiveHost, "kubearchive-host", o.KubeArchiveHost, fmt.Sprintf("Host where the KubeArchive API Server is listening. Defaults to '%s'", o.KubeArchiveHost))
-	cmd.Flags().StringVarP(o.OutputFormat, "output", "o", *o.OutputFormat, fmt.Sprintf(`Output format. One of: (%s).`, strings.Join(o.JSONYamlPrintFlags.AllowedFormats(), ", ")))
+	o.AddFlags(cmd.Flags())
 	o.JSONYamlPrintFlags.AddFlags(cmd)
+	cmd.Flags().StringVarP(o.OutputFormat, "output", "o", *o.OutputFormat, fmt.Sprintf(`Output format. One of: (%s).`, strings.Join(o.JSONYamlPrintFlags.AllowedFormats(), ", ")))
 
 	return cmd
 }
 
 func (o *GetOptions) Complete(args []string) error {
+	err := o.ArchiveCLICommand.Complete()
+	if err != nil {
+		return fmt.Errorf("error completing the args: %w", err)
+	}
+
 	o.GroupVersion = args[0]
 
 	o.Resource = args[1]
 	APIPathWithoutRoot := fmt.Sprintf("%s/%s", o.GroupVersion, o.Resource)
-	if *o.kubeFlags.Namespace != "" {
-		APIPathWithoutRoot = fmt.Sprintf("%s/namespaces/%s/%s", o.GroupVersion, *o.kubeFlags.Namespace, o.Resource)
+
+	if !o.AllNamespaces {
+		namespace, nsErr := o.GetNamespace()
+		if nsErr != nil {
+			return nsErr
+		}
+		APIPathWithoutRoot = fmt.Sprintf("%s/namespaces/%s/%s", o.GroupVersion, namespace, o.Resource)
 	}
 
 	o.APIPath = fmt.Sprintf("/apis/%s", APIPathWithoutRoot)
@@ -97,41 +97,12 @@ func (o *GetOptions) Complete(args []string) error {
 		o.APIPath = fmt.Sprintf("/api/%s", APIPathWithoutRoot)
 	}
 
-	config, err := o.kubeFlags.ToRESTConfig()
-	if err != nil {
-		return fmt.Errorf("error creating the REST configuration: %w", err)
-	}
-
-	o.RESTConfig = config
-
 	return nil
 }
 
-func (o *GetOptions) getResources(host string) ([]runtime.Object, error) {
-	url := fmt.Sprintf("%s%s", host, o.APIPath)
-
-	client, err := rest.HTTPClientFor(o.RESTConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating the HTTP client from the REST config: %w", err)
-	}
-
-	response, err := client.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("error on GET to '%s': %w", url, err)
-	}
-	defer response.Body.Close()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error deserializing the body: %w", err)
-	}
-
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET to '%s' returned with code '%d' and body: %s", url, response.StatusCode, string(bodyBytes))
-	}
-
+func (o *GetOptions) parseResourcesFromBytes(bodyBytes []byte) ([]runtime.Object, error) {
 	var list unstructured.UnstructuredList
-	err = json.Unmarshal(bodyBytes, &list)
+	err := json.Unmarshal(bodyBytes, &list)
 	if err != nil {
 		return nil, fmt.Errorf("error deserializing the body into unstructured.UnstructuredList: %w", err)
 	}
@@ -145,21 +116,21 @@ func (o *GetOptions) getResources(host string) ([]runtime.Object, error) {
 	return runtimeObjects, nil
 }
 
-func (o *GetOptions) getKubeArchiveResources() ([]runtime.Object, error) {
-	o.RESTConfig.CAData = nil      // Remove CA data from the Kubeconfig
-	o.RESTConfig.CAFile = "ca.crt" // This expects you to have extracted the CA, see DEVELOPMENT.md
-	o.RESTConfig.BearerToken = *o.kubeFlags.BearerToken
-
-	return o.getResources(o.KubeArchiveHost)
-}
-
 func (o *GetOptions) Run() error {
-	clusterResources, err := o.getResources(o.RESTConfig.Host)
+	bodyBytes, getErr := o.GetFromAPI(config.Kubernetes, o.APIPath)
+	if getErr != nil {
+		return fmt.Errorf("error retrieving the resources from Kubernetes API server: %w", getErr)
+	}
+	clusterResources, err := o.parseResourcesFromBytes(bodyBytes)
 	if err != nil {
 		return fmt.Errorf("error retrieving resources from the cluster: %w", err)
 	}
 
-	kubearchiveResources, err := o.getKubeArchiveResources()
+	bodyBytes, getErr = o.GetFromAPI(config.KubeArchive, o.APIPath)
+	if getErr != nil {
+		return fmt.Errorf("error retrieving the resources from KubeArchive API server: %w", getErr)
+	}
+	kubearchiveResources, err := o.parseResourcesFromBytes(bodyBytes)
 	if err != nil {
 		return fmt.Errorf("error retrieving resources from the KubeArchive API: %w", err)
 	}
@@ -167,13 +138,11 @@ func (o *GetOptions) Run() error {
 	objs = append(objs, clusterResources...)
 	objs = append(objs, kubearchiveResources...)
 
-	// Handle JSON/YAML output differently - create a List object
 	if o.OutputFormat != nil && *o.OutputFormat != "" {
 		printer, printerErr := o.JSONYamlPrintFlags.ToPrinter(*o.OutputFormat)
 		if printerErr != nil {
 			return fmt.Errorf("error getting printer: %w", printerErr)
 		}
-		// Create a List containing all objects
 		list := &unstructured.UnstructuredList{
 			Object: map[string]interface{}{
 				"kind":       "List",
@@ -190,12 +159,10 @@ func (o *GetOptions) Run() error {
 			}
 		}
 
-		// Print the list once
 		if printErr := printer.PrintObj(list, o.Out); printErr != nil {
 			return fmt.Errorf("error printing list: %w", printErr)
 		}
 	} else {
-		// For table output, print each object individually
 		printer := printers.NewTablePrinter(printers.PrintOptions{})
 		tabWriter := printers.GetNewTabWriter(o.Out)
 		defer tabWriter.Flush()

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -6,31 +6,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/kubearchive/kubearchive/pkg/cmd/config"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/rest"
 )
 
 type LogsOptions struct {
+	config.ArchiveCLICommand
 	ContainerName string
 	Name          string
 	Resource      string
 	GroupVersion  string
 	LabelSelector string
-
-	Token string
-
-	KubeArchiveHost string
-	KubeArchiveCA   string
-
-	RESTConfig *rest.Config
-	kubeFlags  *genericclioptions.ConfigFlags
 }
 
 var logsLong = `Print the logs for a container in a pod or specified resource from KubeArchive.
@@ -54,9 +44,7 @@ kubectl archive logs tekton.dev/v1 taskrun my-task
 
 func NewLogsOptions() *LogsOptions {
 	return &LogsOptions{
-		kubeFlags:       genericclioptions.NewConfigFlags(true),
-		KubeArchiveHost: "https://localhost:8081",
-		KubeArchiveCA:   "ca.crt",
+		ArchiveCLICommand: config.NewArchiveOptions(),
 	}
 }
 
@@ -85,26 +73,18 @@ func NewLogCmd() *cobra.Command {
 		},
 	}
 
-	o.kubeFlags.AddFlags(cmd.Flags())
+	o.AddFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&o.ContainerName, "container", "c", o.ContainerName, "Name of the container to retrieve the logs from.")
 	cmd.Flags().StringVarP(&o.LabelSelector, "selector", "l", o.LabelSelector, "Selector (label query) to filter on, supports '=', '==', '!=', 'in', 'notin'.(e.g. -l key1=value1,key2=value2,key3 in (value3)). Matching objects must satisfy all of the specified label constraints.")
-	cmd.Flags().StringVar(&o.KubeArchiveHost, "kubearchive-host", o.KubeArchiveHost, fmt.Sprintf("Host where the KubeArchive API Server is listening. Defaults to '%s'", o.KubeArchiveHost))
-	cmd.Flags().StringVar(&o.KubeArchiveCA, "kubearchive-ca", o.KubeArchiveCA, fmt.Sprintf("CA file to be used when contacting the KubeArchive API. Defaults to '%s'", o.KubeArchiveCA))
 
 	return cmd
 }
 
 func (o *LogsOptions) Complete(args []string) error {
-	config, err := o.kubeFlags.ToRESTConfig()
+	err := o.ArchiveCLICommand.Complete()
 	if err != nil {
-		return fmt.Errorf("error creating the REST configuration: %w", err)
+		return fmt.Errorf("error completing the args: %w", err)
 	}
-	o.RESTConfig = config
-
-	if *o.kubeFlags.Namespace == "" {
-		*o.kubeFlags.Namespace = "default"
-	}
-
 	switch len(args) {
 	case 0:
 		if o.LabelSelector == "" {
@@ -143,60 +123,21 @@ func (o *LogsOptions) Complete(args []string) error {
 	return nil
 }
 
-func (o *LogsOptions) getEndpoint(url string) ([]byte, error) {
-	client, err := rest.HTTPClientFor(o.RESTConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating the HTTP client from the REST config: %w", err)
-	}
-	response, err := client.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("error on GET to '%s': %w", url, err)
-	}
-	defer response.Body.Close()
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error deserializing the body: %w", err)
-	}
-
-	if response.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("unable to get '%s': unauthorized", url)
-	}
-
-	if response.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("unable to get '%s': not found", url)
-	}
-
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unable to get '%s': unknown error: %s (%d)", url, string(bodyBytes), response.StatusCode)
-	}
-
-	return bodyBytes, nil
-}
-
-func (o *LogsOptions) getKubeArchiveEndpoint(endpoint string) ([]byte, error) {
-	o.RESTConfig.CAData = nil // Remove CA data from the Kubeconfig
-	if o.KubeArchiveCA != "" {
-		o.RESTConfig.CAFile = o.KubeArchiveCA // This expects you to have extracted the CA, see DEVELOPMENT.md
-	} else {
-		o.RESTConfig.Insecure = true
-	}
-	o.RESTConfig.BearerToken = *o.kubeFlags.BearerToken
-
-	url := fmt.Sprintf("%s%s", o.KubeArchiveHost, endpoint)
-	return o.getEndpoint(url)
-}
-
 func (o *LogsOptions) Run(cmd *cobra.Command) error {
 	apiPrefix := "/apis"
 	if strings.HasPrefix(o.GroupVersion, "v1") {
 		apiPrefix = "/api"
 	}
 
+	ns, nsErr := o.GetNamespace()
+	if nsErr != nil {
+		return fmt.Errorf("error getting namespace: %w", nsErr)
+	}
+
 	names := make([]string, 0)
 	if o.LabelSelector != "" {
-		apiPath := fmt.Sprintf("%s/%s/namespaces/%s/%s?labelSelector=%s", apiPrefix, o.GroupVersion, *o.kubeFlags.Namespace, o.Resource, url.QueryEscape(o.LabelSelector))
-		bodyBytes, err := o.getKubeArchiveEndpoint(apiPath)
+		apiPath := fmt.Sprintf("%s/%s/namespaces/%s/%s?labelSelector=%s", apiPrefix, o.GroupVersion, ns, o.Resource, url.QueryEscape(o.LabelSelector))
+		bodyBytes, err := o.GetFromAPI(config.KubeArchive, apiPath)
 		if err != nil {
 			return fmt.Errorf("error while retrieving resources with labelSelector: %w", err)
 		}
@@ -208,7 +149,7 @@ func (o *LogsOptions) Run(cmd *cobra.Command) error {
 		}
 
 		if len(list.Items) == 0 {
-			return fmt.Errorf("no resources found in the %s namespace", *o.kubeFlags.Namespace)
+			return fmt.Errorf("no resources found in the %s namespace", ns)
 		}
 
 		for _, resource := range list.Items {
@@ -219,12 +160,12 @@ func (o *LogsOptions) Run(cmd *cobra.Command) error {
 	}
 
 	for _, name := range names {
-		apiPath := fmt.Sprintf("%s/%s/namespaces/%s/%s/%s/log", apiPrefix, o.GroupVersion, *o.kubeFlags.Namespace, o.Resource, name)
+		apiPath := fmt.Sprintf("%s/%s/namespaces/%s/%s/%s/log", apiPrefix, o.GroupVersion, ns, o.Resource, name)
 		if o.ContainerName != "" {
 			apiPath = fmt.Sprintf("%s?container=%s", apiPath, o.ContainerName)
 		}
 
-		kubearchiveLog, err := o.getKubeArchiveEndpoint(apiPath)
+		kubearchiveLog, err := o.GetFromAPI(config.KubeArchive, apiPath)
 		if err != nil {
 			return fmt.Errorf("error retrieving resources from the KubeArchive API: %w", err)
 		}

--- a/pkg/cmd/testdata/expected_yaml_output.yaml
+++ b/pkg/cmd/testdata/expected_yaml_output.yaml
@@ -1,5 +1,6 @@
 # Copyright KubeArchive Authors
 # SPDX-License-Identifier: Apache-2.0
+---
 apiVersion: v1
 items:
   - apiVersion: v1


### PR DESCRIPTION
Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1168 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

This was tested on development environment and on konflux staging:

```bash
# Development
kubectl get -n kubearchive secrets kubearchive-api-server-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
KUBECTL_PLUGIN_ARCHIVE_SKIP_CERT=ca.crt KUBECTL_PLUGIN_ARCHIVE_TOKEN=$(kubectl create -n test token default) go run cmd/kubectl-archive/main.go get v1 pods -n test

# Konflux Staging with port-forward
go run cmd/kubectl-archive/main.go get v1 pods -n product-kubearchive --kubearchive-insecure-skip-tls-verify

# Konflux Staging with Route
KUBECTL_PLUGIN_ARCHIVE_HOST=https://kubearchive-api-server-product-kubearchive.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com go run cmd/kubectl-archive/main.go get v1 pods -n product-kubearchive
```

I've refactored the code to use the flags provided by built-in kubectl and avoid repeating them.

As an extra thing outside from the issue I've used the `--all-namespaces` flag that wasn't properly used.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
