### PR TITLE
Add creationTimestamp filters in API

### DIFF
--- a/docs/modules/ROOT/pages/reference/api.adoc
+++ b/docs/modules/ROOT/pages/reference/api.adoc
@@ -37,6 +37,38 @@ Parameters allowed:
 * `continue`: token to access the next page of the pagination. Retrieve it at `.metadata.continue`
 of the returned `List` resource. An empty string if there are no more pages remaining.
 * `labelSelector`: allows filtering resources based on label filtering.
+* `creationTimestampAfter`: filters resources created after the specified timestamp (RFC3339 format, e.g., `2023-01-01T12:00:00Z`).
+* `creationTimestampBefore`: filters resources created before the specified timestamp (RFC3339 format, e.g., `2023-12-31T23:59:59Z`).
+
+=== Timestamp Filters
+
+The API supports filtering resources by their creation timestamp using RFC3339 format:
+
+After timestamp::
+    `creationTimestampAfter=2023-01-01T12:00:00Z`
+Before timestamp::
+    `creationTimestampBefore=2023-12-31T23:59:59Z`
+Both filters::
+    `creationTimestampAfter=2023-01-01T12:00:00Z&creationTimestampBefore=2023-12-31T23:59:59Z`
+
+[NOTE]
+====
+Timestamp filters can be combined with other filters (labelSelector, pagination) and will be applied as AND conditions.
+====
+
+Examples:
+
+[source,text]
+----
+/api/v1/namespaces/default/pods?creationTimestampAfter=2023-06-01T00:00:00Z <1>
+/apis/apps/v1/namespaces/production/deployments?creationTimestampBefore=2023-12-31T23:59:59Z <2>
+/api/v1/pods?creationTimestampAfter=2023-01-01T00:00:00Z&creationTimestampBefore=2023-01-31T23:59:59Z <3>
+/api/v1/namespaces/default/pods?creationTimestampAfter=2023-06-01T00:00:00Z&labelSelector=app=frontend <4>
+----
+<1> Filter pods created after a specific date
+<2> Filter deployments created before a specific date
+<3> Filter resources created within a date range
+<4> Combine timestamp filters with label selectors
 
 === Label Selector
 

--- a/pkg/database/fake/database_generated_test.go
+++ b/pkg/database/fake/database_generated_test.go
@@ -79,7 +79,7 @@ func TestQueryResourcesWithoutNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := NewFakeDatabase(testResources, testLogUrls, testJsonPath)
-			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, "", "", "", "", &models.LabelFilters{}, 100)
+			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, "", "", "", "", &models.LabelFilters{}, nil, nil, 100)
 			expected := make([]string, 0)
 			if len(tt.expected) != 0 {
 				for _, resource := range tt.expected {
@@ -143,7 +143,7 @@ func TestQueryResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, tt.namespace,
-				"", "", "", &models.LabelFilters{}, 100)
+				"", "", "", &models.LabelFilters{}, nil, nil, 100)
 			expected := make([]string, 0)
 			if len(tt.expected) != 0 {
 				for _, resource := range tt.expected {
@@ -232,7 +232,7 @@ func TestQueryNamespacedResourceByName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := NewFakeDatabase(tt.testData, testLogUrls, testJsonPath)
 			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, tt.namespace,
-				tt.resourceName, "", "", &models.LabelFilters{}, 100)
+				tt.resourceName, "", "", &models.LabelFilters{}, nil, nil, 100)
 			expected := make([]string, 0)
 			if tt.expected != nil {
 				for _, exp := range tt.expected {

--- a/pkg/database/interfaces/database.go
+++ b/pkg/database/interfaces/database.go
@@ -22,7 +22,8 @@ const (
 
 type DBReader interface {
 	QueryResources(ctx context.Context, kind, apiVersion, namespace,
-		name, continueId, continueDate string, labelFilters *models.LabelFilters, limit int) ([]string, int64, string, error)
+		name, continueId, continueDate string, labelFilters *models.LabelFilters,
+		creationTimestampAfter, creationTimestampBefore *time.Time, limit int) ([]string, int64, string, error)
 	QueryLogURL(ctx context.Context, kind, apiVersion, namespace, name, containerName string) (string, string, error)
 	Ping(ctx context.Context) error
 	QueryDatabaseSchemaVersion(ctx context.Context) (string, error)

--- a/pkg/database/sql/facade/filter.go
+++ b/pkg/database/sql/facade/filter.go
@@ -3,7 +3,11 @@
 
 package facade
 
-import "github.com/huandu/go-sqlbuilder"
+import (
+	"time"
+
+	"github.com/huandu/go-sqlbuilder"
+)
 
 // DBFilter encapsulates all the filter functions that must be implemented by the drivers
 // All its functions share the same signature
@@ -12,6 +16,8 @@ type DBFilter interface {
 	NamespaceFilter(cond sqlbuilder.Cond, ns string) string
 	NameFilter(cond sqlbuilder.Cond, name string) string
 	CreationTSAndIDFilter(cond sqlbuilder.Cond, continueDate, continueId string) string
+	CreationTimestampAfterFilter(cond sqlbuilder.Cond, timestamp time.Time) string
+	CreationTimestampBeforeFilter(cond sqlbuilder.Cond, timestamp time.Time) string
 	OwnerFilter(cond sqlbuilder.Cond, ownersUuids []string) string
 	UuidsFilter(cond sqlbuilder.Cond, uuids []string) string
 	UuidFilter(cond sqlbuilder.Cond, uuid string) string

--- a/pkg/database/sql/mariadb.go
+++ b/pkg/database/sql/mariadb.go
@@ -63,6 +63,20 @@ func (mariaDBFilter) CreationTSAndIDFilter(cond sqlbuilder.Cond, continueDate, c
 	)
 }
 
+func (mariaDBFilter) CreationTimestampAfterFilter(cond sqlbuilder.Cond, timestamp time.Time) string {
+	return fmt.Sprintf(
+		"CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime) > %s",
+		cond.Var(timestamp.Format("2006-01-02 15:04:05")),
+	)
+}
+
+func (mariaDBFilter) CreationTimestampBeforeFilter(cond sqlbuilder.Cond, timestamp time.Time) string {
+	return fmt.Sprintf(
+		"CONVERT(JSON_VALUE(data, '$.metadata.creationTimestamp'), datetime) < %s",
+		cond.Var(timestamp.Format("2006-01-02 15:04:05")),
+	)
+}
+
 func (mariaDBFilter) OwnerFilter(cond sqlbuilder.Cond, uuids []string) string {
 	return fmt.Sprintf(
 		"JSON_OVERLAPS(JSON_EXTRACT(data, '$.metadata.ownerReferences.**.uid'), JSON_ARRAY(%s))",

--- a/pkg/database/sql/postgresql.go
+++ b/pkg/database/sql/postgresql.go
@@ -66,6 +66,20 @@ func (postgreSQLFilter) CreationTSAndIDFilter(cond sqlbuilder.Cond, continueDate
 	)
 }
 
+func (postgreSQLFilter) CreationTimestampAfterFilter(cond sqlbuilder.Cond, timestamp time.Time) string {
+	return fmt.Sprintf(
+		"data->'metadata'->>'creationTimestamp' > %s",
+		cond.Var(timestamp.Format(time.RFC3339)),
+	)
+}
+
+func (postgreSQLFilter) CreationTimestampBeforeFilter(cond sqlbuilder.Cond, timestamp time.Time) string {
+	return fmt.Sprintf(
+		"data->'metadata'->>'creationTimestamp' < %s",
+		cond.Var(timestamp.Format(time.RFC3339)),
+	)
+}
+
 func (postgreSQLFilter) OwnerFilter(cond sqlbuilder.Cond, owners []string) string {
 	return fmt.Sprintf(
 		"jsonb_path_query_array(data->'metadata'->'ownerReferences', '$[*].uid') ?| %s",

--- a/test/integration/timestamp_filter_test.go
+++ b/test/integration/timestamp_filter_test.go
@@ -1,0 +1,195 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/kubearchive/kubearchive/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestTimestampFiltering(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+	port := test.PortForwardApiServer(t, clientset)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaceName,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "fedora",
+					Command: []string{"sleep", "1"},
+					Image:   "quay.io/fedora/fedora-minimal:latest",
+				},
+			},
+		},
+	}
+
+	// Create 3 pods with real time gaps (2 minutes apart)
+	podTimes := make([]time.Time, 3)
+	for i := 0; i < 3; i++ {
+		// Record the actual creation time
+		podTimes[i] = time.Now()
+
+		pod.SetName("pod-" + strconv.Itoa(i))
+		// Remove the artificial timestamp setting - let Kubernetes set the real creation time
+		pod.SetCreationTimestamp(metav1.Time{})
+
+		_, err := clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Wait 10 seconds between pod creations (except for the last pod)
+		if i < 2 {
+			t.Logf("Created pod-%d, waiting 10 seconds before creating next pod...", i)
+			time.Sleep(10 * time.Second)
+		}
+	}
+
+	// Wait for all pods to be archived
+	url := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods", port, namespaceName)
+	var allPods *unstructured.UnstructuredList
+	err := retry.Do(func() error {
+		var getUrlErr error
+		allPods, getUrlErr = test.GetUrl(t, token.Status.Token, url, map[string][]string{})
+		if getUrlErr != nil {
+			t.Fatal(getUrlErr)
+		}
+		if len(allPods.Items) >= 3 {
+			return nil
+		}
+		return errors.New("could not retrieve all Pods from the API")
+	}, retry.Attempts(240), retry.MaxDelay(4*time.Second))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("All pods were archived, starting timestamp filter tests...")
+
+	// Test cases for timestamp filtering
+	testCases := []struct {
+		name                      string
+		creationTimestampAfter    string
+		creationTimestampBefore   string
+		expectedPods              int
+		expectedStatusCode        int
+		shouldContainErrorMessage string
+	}{
+		{
+			name:                   "filter after first pod",
+			creationTimestampAfter: podTimes[1].UTC().Format(time.RFC3339),
+			expectedPods:           1, // only pod 2 (created after pod 1)
+			expectedStatusCode:     200,
+		},
+		{
+			name:                    "filter before last pod",
+			creationTimestampBefore: podTimes[2].UTC().Format(time.RFC3339),
+			expectedPods:            2, // pods 0, 1 (created before pod 2)
+			expectedStatusCode:      200,
+		},
+		{
+			name:                    "filter between pods",
+			creationTimestampAfter:  podTimes[0].UTC().Format(time.RFC3339),
+			creationTimestampBefore: podTimes[2].UTC().Format(time.RFC3339),
+			expectedPods:            1, // only pod 1 (created after pod 0 and before pod 2)
+			expectedStatusCode:      200,
+		},
+		{
+			name:                   "filter after all pods (now)",
+			creationTimestampAfter: time.Now().UTC().Format(time.RFC3339),
+			expectedPods:           0, // no pods should match
+			expectedStatusCode:     200,
+		},
+		{
+			name:                      "invalid order - before is earlier than after",
+			creationTimestampAfter:    podTimes[2].UTC().Format(time.RFC3339),
+			creationTimestampBefore:   podTimes[0].UTC().Format(time.RFC3339),
+			expectedStatusCode:        400,
+			shouldContainErrorMessage: "creationTimestampBefore must be after creationTimestampAfter",
+		},
+		{
+			name:                      "invalid order - same timestamps",
+			creationTimestampAfter:    podTimes[1].UTC().Format(time.RFC3339),
+			creationTimestampBefore:   podTimes[1].UTC().Format(time.RFC3339),
+			expectedStatusCode:        400,
+			shouldContainErrorMessage: "creationTimestampBefore must be after creationTimestampAfter",
+		},
+		{
+			name:                      "invalid timestamp format - after",
+			creationTimestampAfter:    "invalid-timestamp",
+			expectedStatusCode:        400,
+			shouldContainErrorMessage: "invalid creationTimestampAfter format",
+		},
+		{
+			name:                      "invalid timestamp format - before",
+			creationTimestampBefore:   "invalid-timestamp",
+			expectedStatusCode:        400,
+			shouldContainErrorMessage: "invalid creationTimestampBefore format",
+		},
+		{
+			name:                   "RFC3339Nano format support",
+			creationTimestampAfter: time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano),
+			expectedPods:           3, // should return all pods since timestamp is 2 hours ago
+			expectedStatusCode:     200,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build URL with query parameters
+			testURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods", port, namespaceName)
+			queryParams := []string{}
+
+			if tc.creationTimestampAfter != "" {
+				queryParams = append(queryParams, fmt.Sprintf("creationTimestampAfter=%s", tc.creationTimestampAfter))
+			}
+			if tc.creationTimestampBefore != "" {
+				queryParams = append(queryParams, fmt.Sprintf("creationTimestampBefore=%s", tc.creationTimestampBefore))
+			}
+
+			if len(queryParams) > 0 {
+				testURL += "?" + strings.Join(queryParams, "&")
+			}
+
+			t.Logf("Testing URL: %s", testURL)
+
+			if tc.expectedStatusCode == 200 {
+				result, err := test.GetUrl(t, token.Status.Token, testURL, map[string][]string{})
+				if err != nil {
+					t.Fatalf("Failed to get URL: %v", err)
+				}
+				assert.Equal(t, tc.expectedPods, len(result.Items), "Number of returned pods should match expected")
+			} else {
+				_, err := test.GetUrl(t, token.Status.Token, testURL, map[string][]string{})
+				assert.Error(t, err, "Expected an error for invalid request")
+
+				errorMsg := err.Error()
+				expectedStatusStr := fmt.Sprintf("%d", tc.expectedStatusCode)
+				assert.Contains(t, errorMsg, expectedStatusStr, "Error should contain expected status code")
+			}
+		})
+	}
+}

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -12,11 +12,15 @@ bash test/performance/run.sh
 
 **Note**: this requires at least Python 3.10
 
-The tests are run with [Locust](https://docs.locust.io/en/stable/) in order and they
+The tests are run with [Locust](https://docs.locust.io/en/stable/) in order, and they
 are the following:
 
 1. `create`: (Sink) POST / to create Pods from a template, aprox ~3k Pods are inserted
-1. `get`: (API) GET /api/v1/pods
+1. `get`: (API) GET /api/v1/pods with various query patterns including:
+   - Basic pod retrieval
+   - Timestamp filtering with `creationTimestampAfter`
+   - Timestamp filtering with `creationTimestampBefore`
+   - Timestamp range filtering with both parameters
 
 The results of the tests are on `./perf-results/`, relative to the root of the repository.
 Their name reference the test where they come from, currently `get-*.csv` and `create-*.csv`

--- a/test/performance/locustfile.py
+++ b/test/performance/locustfile.py
@@ -1,7 +1,7 @@
 # Copyright KubeArchive Authors
 # SPDX-License-Identifier: Apache-2.0
 import urllib3, os, json
-from datetime import datetime
+from datetime import datetime, timedelta
 from string import Template
 from uuid import uuid4
 from pathlib import Path
@@ -18,12 +18,44 @@ if token == "":
 with open(Path(__file__).parent / "pod.json") as fd:
     template = Template(fd.read())
 
+# Fixed timestamps to ensure consistent parameter values across all executions
+FIXED_TIMESTAMP_AFTER = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+FIXED_TIMESTAMP_BEFORE = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
 
 class GetPods(HttpUser):
     @task
     def get_pods(self):
+        # Get pods without filters
         self.client.get(
             "https://localhost:8081/api/v1/pods",
+            verify=False,
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
+    @task
+    def get_pods_with_timestamp_after(self):
+        # Get pods with fixed creationTimestampAfter filter
+        self.client.get(
+            f"https://localhost:8081/api/v1/pods?creationTimestampAfter={FIXED_TIMESTAMP_AFTER}",
+            verify=False,
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
+    @task
+    def get_pods_with_timestamp_before(self):
+        # Get pods with fixed creationTimestampBefore filter
+        self.client.get(
+            f"https://localhost:8081/api/v1/pods?creationTimestampBefore={FIXED_TIMESTAMP_BEFORE}",
+            verify=False,
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
+    @task
+    def get_pods_with_timestamp_range(self):
+        # Get pods with both fixed timestamp filters
+        self.client.get(
+            f"https://localhost:8081/api/v1/pods?creationTimestampAfter={FIXED_TIMESTAMP_AFTER}&creationTimestampBefore={FIXED_TIMESTAMP_BEFORE}",
             verify=False,
             headers={"Authorization": f"Bearer {token}"}
         )

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -37,6 +37,7 @@ START=$(date +%s)
 sleep 30
 kubectl port-forward -n kubearchive svc/kubearchive-sink 8082:80 &
 SINK_FORWARD_PID=$!
+# This step will take 10 minutes to run. To check if it's still running do: `ps aux | grep locust | grep -v grep`
 ./venv/bin/locust -f ${SCRIPT_DIR}/locustfile.py --headless --users 2 -r 2 -t 600s -H https://localhost:8081 --only-summary --processes -1 CreatePods --csv perf-results/create &> perf-results/create.txt
 kill $SINK_FORWARD_PID
 sleep 30


### PR DESCRIPTION
Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1193  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Adds creationTimestampBefore and creationTimestampAfter filters on resource endpoints
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

You can test the API call with this:

```
curl -k -H "Authorization: Bearer $(kubectl create token default -n test)" "https://localhost:8081/api/v1/pods?creationTimestampBefore=2025-07-16T15:19:00Z" | jq '.items|length'
```

You can try changing the date and compare it with the length without the filter after generating some activity with the cronjobs

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
