### PR TITLE
avoid updating Namespaces if not needed

### DIFF
--- a/cmd/operator/internal/controller/kubearchiveconfig_controller.go
+++ b/cmd/operator/internal/controller/kubearchiveconfig_controller.go
@@ -405,6 +405,11 @@ func (r *KubeArchiveConfigReconciler) reconcileNamespace(ctx context.Context, ka
 		return nil, err
 	}
 
+	// if the label is already present, we can skip the update
+	if l, ok := ns.Labels[ApiServerSourceLabelName]; ok && l == ApiServerSourceLabelValue {
+		return ns, nil
+	}
+
 	ns.Labels[ApiServerSourceLabelName] = ApiServerSourceLabelValue
 	err = r.Client.Update(ctx, ns)
 	if err != nil {
@@ -425,6 +430,11 @@ func (r *KubeArchiveConfigReconciler) removeNamespaceLabel(ctx context.Context, 
 	if err != nil {
 		log.Error(err, "Failed to get Namespace "+kaconfig.Namespace)
 		return err
+	}
+
+	// if the label is not present, we can skip the update
+	if _, ok := ns.Labels[ApiServerSourceLabelName]; !ok {
+		return nil
 	}
 
 	delete(ns.Labels, ApiServerSourceLabelName)


### PR DESCRIPTION
Resolves #1218 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Fixed a bug where the namespaces monitored by KubeArchive were updated without need, causing pressure on the Kubernetes API on a large number of namespaces.
```

When the Namespace is already in the correct shape, we can spare the request to the APIServer.

<!--
## Notes for Reviewers

Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
