### PR TITLE
Fix the set up PR for external contributors

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - name: Assign reviewers by label
         id: assign-reviewers
-        uses: totallymoney/assign-reviewers-by-labels-action@v1
+        uses: totallymoney/assign-reviewers-by-labels-action@v1.2.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/copy-labels.yml
+++ b/.github/workflows/copy-labels.yml
@@ -29,11 +29,22 @@ jobs:
     name: Add assignee to the PR
     if: github.actor != 'kubearchive-renovate[bot]'
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
+      - name: Check if user can be assigned
+        id: check-assignable
+        run: |
+          # Check if user is a member of the organization or a collaborator
+          if gh api "repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}" > /dev/null 2>&1; then
+            echo "can_assign=true" >> $GITHUB_OUTPUT
+            echo "User ${{ github.event.pull_request.user.login }} can be assigned"
+          else
+            echo "can_assign=false" >> $GITHUB_OUTPUT
+            echo "User ${{ github.event.pull_request.user.login }} cannot be assigned (external contributor)"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add assignee to the PR
         id: add-assignee
-        if: ${{ github.event.pull_request.assignee == null }}
+        if: ${{ github.event.pull_request.assignee == null && steps.check-assignable.outputs.can_assign == 'true' }}
         run: gh pr edit ${PR_ID} --add-assignee ${AUTHOR}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1219  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

I've also updated the version of the action that add reviewers based on labels. The new version
has more debug messages that can help troubleshoot potential issues in the future.
I wasn't able to troubleshoot what was the problem in [here](https://github.com/kubearchive/kubearchive/actions/runs/16468223952/job/46642107193)

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
