### PR TITLE
Add field selector filter

### DIFF
--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -23,7 +23,7 @@ var testResources = fake.CreateTestResources()
 var testLogUrls = fake.CreateTestLogUrls()
 var testLogJsonPath = "$."
 var nonCoreResources = testResources[:1]
-var coreResources = testResources[1:2]
+var coreResources = testResources[1:3]
 
 type List struct {
 	Items []*unstructured.Unstructured
@@ -172,6 +172,60 @@ func TestGetResourcesLogURLS(t *testing.T) {
 
 			assert.Equal(t, test.expectedCode, res.Code)
 			assert.Equal(t, test.expectedBody, res.Body.String())
+		})
+	}
+}
+
+func TestFieldSelectorQueryParameter(t *testing.T) {
+	router := setupRouter(fake.NewFakeDatabase(testResources, testLogUrls, testLogJsonPath), false)
+	tests := []struct {
+		name          string
+		fieldSelector string
+		expected      int
+	}{
+		{
+			name:          "empty field selector",
+			fieldSelector: "",
+			expected:      200,
+		},
+		{
+			name:          "valid metadata.name equals",
+			fieldSelector: "metadata.name=test-pod",
+			expected:      404, // Now handled as name parameter, but no such resource exists
+		},
+		{
+			name:          "valid status.phase equals",
+			fieldSelector: "status.phase=Running",
+			expected:      200,
+		},
+		{
+			name:          "valid metadata.name not equals",
+			fieldSelector: "metadata.name!=test-pod",
+			expected:      200,
+		},
+		{
+			name:          "valid spec.nodeName equals",
+			fieldSelector: "spec.nodeName=worker-1",
+			expected:      200,
+		},
+		{
+			name:          "multiple field filters",
+			fieldSelector: "metadata.name=test-pod,status.phase=Running",
+			expected:      404, // Now handled as name parameter, but no such resource exists
+		},
+		{
+			name:          "invalid field selector - in operator not supported",
+			fieldSelector: "metadata.name in (value1,value2)",
+			expected:      400,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/apis/apps/v1/namespaces/default/deployments?fieldSelector="+url.QueryEscape(tt.fieldSelector), nil)
+			router.ServeHTTP(res, req)
+
+			assert.Equal(t, tt.expected, res.Code)
 		})
 	}
 }

--- a/pkg/database/fake/database_generated_test.go
+++ b/pkg/database/fake/database_generated_test.go
@@ -72,14 +72,14 @@ func TestQueryResourcesWithoutNamespace(t *testing.T) {
 			name:     "Matching resources",
 			kind:     existingKind,
 			version:  existingVersion,
-			expected: testResources[1:2],
+			expected: testResources[1:3], // Now includes both Pods
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := NewFakeDatabase(testResources, testLogUrls, testJsonPath)
-			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, "", "", "", "", &models.LabelFilters{}, 100)
+			filteredResources, _, _, err := db.QueryResources(context.Background(), tt.kind, tt.version, "", "", "", "", &models.LabelFilters{}, nil, 100)
 			expected := make([]string, 0)
 			if len(tt.expected) != 0 {
 				for _, resource := range tt.expected {
@@ -135,15 +135,15 @@ func TestQueryResources(t *testing.T) {
 			kind:      existingKind,
 			version:   existingVersion,
 			namespace: existingNamespace,
-			expected:  testResources[1:2],
+			expected:  testResources[1:3], // Includes both Pods
 		},
 	}
 	db := NewFakeDatabase(testResources, testLogUrls, testJsonPath)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, tt.namespace,
-				"", "", "", &models.LabelFilters{}, 100)
+			filteredResources, _, _, err := db.QueryResources(context.Background(), tt.kind, tt.version, tt.namespace,
+				"", "", "", &models.LabelFilters{}, nil, 100)
 			expected := make([]string, 0)
 			if len(tt.expected) != 0 {
 				for _, resource := range tt.expected {
@@ -224,15 +224,15 @@ func TestQueryNamespacedResourceByName(t *testing.T) {
 			resourceName: existingName,
 			testData:     testResources,
 			err:          nil,
-			expected:     testResources[1:],
+			expected:     testResources[1:2], // Only the first Pod with name "test"
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := NewFakeDatabase(tt.testData, testLogUrls, testJsonPath)
-			filteredResources, _, _, err := db.QueryResources(context.TODO(), tt.kind, tt.version, tt.namespace,
-				tt.resourceName, "", "", &models.LabelFilters{}, 100)
+			filteredResources, _, _, err := db.QueryResources(context.Background(), tt.kind, tt.version, tt.namespace,
+				tt.resourceName, "", "", &models.LabelFilters{}, nil, 100)
 			expected := make([]string, 0)
 			if tt.expected != nil {
 				for _, exp := range tt.expected {

--- a/pkg/database/interfaces/database.go
+++ b/pkg/database/interfaces/database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubearchive/kubearchive/pkg/models"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 )
 
 type WriteResourceResult uint
@@ -21,8 +22,10 @@ const (
 )
 
 type DBReader interface {
-	QueryResources(ctx context.Context, kind, apiVersion, namespace,
-		name, continueId, continueDate string, labelFilters *models.LabelFilters, limit int) ([]string, int64, string, error)
+	QueryResources(
+		ctx context.Context, kind, apiVersion, namespace, name, continueId, continueDate string,
+		labelFilters *models.LabelFilters, fieldReqs []fields.Requirement, limit int,
+	) ([]string, int64, string, error)
 	QueryLogURL(ctx context.Context, kind, apiVersion, namespace, name, containerName string) (string, string, error)
 	Ping(ctx context.Context) error
 	QueryDatabaseSchemaVersion(ctx context.Context) (string, error)
@@ -33,7 +36,10 @@ type DBReader interface {
 type DBWriter interface {
 	// WriteResource writes the logs (when the resource is a Pod) and the resource into their respective tables
 	// The log entries related to the resource are deleted first to prevent duplicates
-	WriteResource(ctx context.Context, k8sObj *unstructured.Unstructured, data []byte, lastUpdated time.Time, jsonPath string, logs ...models.LogTuple) (WriteResourceResult, error)
+	WriteResource(
+		ctx context.Context, k8sObj *unstructured.Unstructured, data []byte,
+		lastUpdated time.Time, jsonPath string, logs ...models.LogTuple,
+	) (WriteResourceResult, error)
 	Ping(ctx context.Context) error
 	QueryDatabaseSchemaVersion(ctx context.Context) (string, error)
 	CloseDB() error

--- a/pkg/database/sql/facade/filter.go
+++ b/pkg/database/sql/facade/filter.go
@@ -23,6 +23,7 @@ type DBFilter interface {
 	InLabelFilter(cond sqlbuilder.Cond, labels map[string][]string, clause *sqlbuilder.WhereClause) string
 	NotInLabelFilter(cond sqlbuilder.Cond, labels map[string][]string, clause *sqlbuilder.WhereClause) string
 
+	JsonPathPredicateCheck(cond sqlbuilder.Cond, field, operator, value string) string
 	ContainerNameFilter(cond sqlbuilder.Cond, containerName string) string
 }
 


### PR DESCRIPTION
Implement Kubernetes field selector.
It doesn't have specific restrictions for fields.

Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #568 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Add field selector filter to the KubeArchive API
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

This feature isn't supporting the UID filter, I created a separate issue for that: https://github.com/kubearchive/kubearchive/issues/1228

My proposed implementation applies a JSONPATH query filter. This is very generic and it isn't optimized.
I am not restricting to different field selectors as Kubernetes does for CRDs or builtin resources.

Note that a potential kubernetes user could always modify the schma to add a specific index and optimize a 
specific field selector filter if it's something needed.

Even if the postgresql and mariadb (untested) are coded to support different operators (like `>` or `<`), the initial validation in the `routes` only allowes the operators used in the kubernetes API: equality and inequality.

WIP:
- [ ] Documentation for the new feature
- [ ] Integration tests

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
