### PR TITLE
Fix impersonation test state handling

### DIFF
--- a/config/templates/api_server/api_server.yaml
+++ b/config/templates/api_server/api_server.yaml
@@ -80,6 +80,8 @@ spec:
               value: "1m"
             - name: KUBEARCHIVE_LOGGING_DIR
               value: /data/logging
+            - name: AUTH_IMPERSONATE
+              value: "false"
           ports:
             - containerPort: 8081
               name: server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1230 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* I decided to use a default value for the AUTH_IMPERSONATE on the manifests, so we simplify a bit the test and we can go back to the previous state. WIthout the variable going back to the original state meant to delete the environment variable, which we didn't have a function for. Now we can reuse the `setImpersonation` function to achieve it.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
