### PR TITLE
increase timeout for sink readyz enpoint and use Get instead of List for SinkFilters

### DIFF
--- a/.github/workflows/copy-labels.yml
+++ b/.github/workflows/copy-labels.yml
@@ -29,6 +29,8 @@ jobs:
     name: Add assignee to the PR
     if: github.actor != 'kubearchive-renovate[bot]'
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
       - name: Check if user can be assigned
         id: check-assignable
         run: |

--- a/cmd/sink/routers/routers.go
+++ b/cmd/sink/routers/routers.go
@@ -310,8 +310,8 @@ func (c *Controller) Readyz(ctx *gin.Context) {
 		return
 	}
 
-	_, err = c.K8sClient.Resource(kubearchiveapi.SinkFilterGVR).Namespace(constants.KubeArchiveNamespace).List(ctx.Request.Context(), metav1.ListOptions{})
-	if err != nil {
+	_, err = c.K8sClient.Resource(kubearchiveapi.SinkFilterGVR).Namespace(constants.KubeArchiveNamespace).Get(ctx.Request.Context(), constants.SinkFilterResourceName, metav1.GetOptions{})
+	if err != nil && !errs.IsNotFound(err) {
 		abort.Abort(ctx, err, http.StatusServiceUnavailable)
 	}
 	ctx.JSON(http.StatusOK, gin.H{"message": "ready"})

--- a/config/templates/sink/sink.yaml
+++ b/config/templates/sink/sink.yaml
@@ -85,6 +85,7 @@ spec:
             httpGet:
               path: /readyz
               port: 8080
+            timeoutSeconds: 4
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1233  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Increase timeout for readyz because when the kubernetes api server is under pressure, it can take more than 1 second to respond. Switching from List to Get because Get is more performant
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
