### PR TITLE
sink only writes resources to db from namespaces configured by users

### DIFF
--- a/cmd/sink/filters/testdata/sf-archive-on-delete.yaml
+++ b/cmd/sink/filters/testdata/sf-archive-on-delete.yaml
@@ -1,0 +1,41 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: kubearchive.org/v1
+kind: SinkFilters
+metadata:
+  name: sink-filters
+  namespace: kubearchive
+spec:
+  Namespaces:
+    ___global___:
+      - selector:
+          apiversion: batch/v1
+          kind: CronJob
+          labelselector: null
+        archivewhen: ""
+        deletewhen: ""
+        archiveondelete: "true"
+      - selector:
+          apiversion: batch/v1
+          kind: Job
+          labelselector: null
+        archivewhen: ""
+        deletewhen: ""
+        archiveondelete: "true"
+      - selector:
+          apiversion: v1
+          kind: Pod
+          labelselector: null
+        archivewhen: ""
+        deletewhen: ""
+        archiveondelete: "true"
+    pods-archive:
+      - selector:
+          apiversion: v1
+          kind: Pod
+          labelselector: null
+        archivewhen: ""
+        deletewhen: ""
+        archiveondelete: "true"
+    pods-noarchive: []

--- a/cmd/sink/filters/testdata/sf-archive.yaml
+++ b/cmd/sink/filters/testdata/sf-archive.yaml
@@ -1,0 +1,41 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: kubearchive.org/v1
+kind: SinkFilters
+metadata:
+  name: sink-filters
+  namespace: kubearchive
+spec:
+  Namespaces:
+    ___global___:
+      - selector:
+          apiversion: batch/v1
+          kind: CronJob
+          labelselector: null
+        archivewhen: "true"
+        deletewhen: ""
+        archiveondelete: ""
+      - selector:
+          apiversion: batch/v1
+          kind: Job
+          labelselector: null
+        archivewhen: "true"
+        deletewhen: ""
+        archiveondelete: ""
+      - selector:
+          apiversion: v1
+          kind: Pod
+          labelselector: null
+        archivewhen: "true"
+        deletewhen: ""
+        archiveondelete: ""
+    pods-archive:
+      - selector:
+          apiversion: v1
+          kind: Pod
+          labelselector: null
+        archivewhen: "true"
+        deletewhen: ""
+        archiveondelete: ""
+    pods-noarchive: []

--- a/cmd/sink/filters/testdata/sf-delete.yaml
+++ b/cmd/sink/filters/testdata/sf-delete.yaml
@@ -1,0 +1,41 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: kubearchive.org/v1
+kind: SinkFilters
+metadata:
+  name: sink-filters
+  namespace: kubearchive
+spec:
+  Namespaces:
+    ___global___:
+      - selector:
+          apiversion: batch/v1
+          kind: CronJob
+          labelselector: null
+        archivewhen: ""
+        deletewhen: "true"
+        archiveondelete: ""
+      - selector:
+          apiversion: batch/v1
+          kind: Job
+          labelselector: null
+        archivewhen: ""
+        deletewhen: "true"
+        archiveondelete: ""
+      - selector:
+          apiversion: v1
+          kind: Pod
+          labelselector: null
+        archivewhen: ""
+        deletewhen: "true"
+        archiveondelete: ""
+    pods-archive:
+      - selector:
+          apiversion: v1
+          kind: Pod
+          labelselector: null
+        archivewhen: ""
+        deletewhen: "true"
+        archiveondelete: ""
+    pods-noarchive: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1293 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Add a check in the sink when executing filters to make sure that resources that match the global filters only get written to the database if the resource is from a namespace that kubearchive is configured to watch.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
