### PR TITLE
Return 404 if /apis/ has empty group

### DIFF
--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -56,6 +56,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 		abort.Abort(context, labelFiltersErr, http.StatusBadRequest)
 	}
 
+	if strings.HasPrefix(context.Request.URL.Path, "/apis/") && group == "" {
+		abort.Abort(context, errors.New(http.StatusText(http.StatusNotFound)), http.StatusNotFound)
+		return
+	}
+
 	apiVersion := version
 	if group != "" {
 		apiVersion = fmt.Sprintf("%s/%s", group, version)
@@ -99,6 +104,11 @@ func (c *Controller) GetLogURL(context *gin.Context) {
 	namespace := context.Param("namespace")
 	name := context.Param("name")
 	containerName := context.Query("container")
+
+	if strings.HasPrefix(context.Request.URL.Path, "/apis/") && group == "" {
+		abort.Abort(context, errors.New(http.StatusText(http.StatusNotFound)), http.StatusNotFound)
+		return
+	}
 
 	apiVersion := version
 	if group != "" {

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -161,6 +161,13 @@ func TestGetResourcesLogURLS(t *testing.T) {
 			expectedCode: http.StatusOK,
 			expectedBody: fmt.Sprintf("\"%s-%s\"", testLogUrls[0].Url, testLogJsonPath),
 		},
+		{
+			name:         "my-pod",
+			api:          "/apis//v1/namespaces/ns/pods/my-pod/log",
+			isCore:       true,
+			expectedCode: http.StatusNotFound,
+			expectedBody: "{\"message\":\"Not Found\"}",
+		},
 	}
 
 	for _, test := range tests {
@@ -218,6 +225,13 @@ func TestGetResources(t *testing.T) {
 			isCore:            true,
 			expectedCode:      http.StatusOK,
 			expectedResources: coreResources,
+		},
+		{
+			name:              "namespaced pods",
+			api:               "/apis//v1/namespaces/test/pods",
+			isCore:            true,
+			expectedCode:      http.StatusNotFound,
+			expectedResources: nil,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1296 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Now the API returns 404 if /apis/ has an empty group (/apis//v1/<resource>`, note the `//`).
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

Kubernetes returns "404 page not found", to reproduce:

```
$ kubectl proxy &
$ curl localhost:8001/apis/v1/namespaces/default/pods
404 page not found
```

I went with the default 404 message.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
