### PR TITLE
Return 404 when resource do not exist

### DIFF
--- a/cmd/api/discovery/apiresources.go
+++ b/cmd/api/discovery/apiresources.go
@@ -61,7 +61,7 @@ func GetAPIResource(client rest.Interface, cache *cache.Cache) gin.HandlerFunc {
 		}
 		abort.Abort(c,
 			fmt.Errorf("unable to find the API resource %s in the Kubernetes cluster", resourceName),
-			http.StatusBadRequest)
+			http.StatusNotFound)
 	}
 }
 

--- a/cmd/api/discovery/apiresources_test.go
+++ b/cmd/api/discovery/apiresources_test.go
@@ -60,21 +60,21 @@ func TestGetAPIResource(t *testing.T) {
 			group:        "invalid",
 			version:      validVersion,
 			resource:     validResource,
-			expectedCode: http.StatusBadRequest,
+			expectedCode: http.StatusNotFound,
 		},
 		{
 			name:         "Invalid version",
 			group:        validGroup,
 			version:      "v2",
 			resource:     validResource,
-			expectedCode: http.StatusBadRequest,
+			expectedCode: http.StatusNotFound,
 		},
 		{
 			name:         "Invalid resource name",
 			group:        validGroup,
 			version:      validVersion,
 			resource:     "invalid",
-			expectedCode: http.StatusBadRequest,
+			expectedCode: http.StatusNotFound,
 		},
 		{
 			name:         "Valid resource",
@@ -93,7 +93,9 @@ func TestGetAPIResource(t *testing.T) {
 			response := ""
 			if err != nil {
 				response = err.Error()
-				status = http.StatusBadRequest
+				// 404 is the correct behaviour
+				// to check run `kubect proxy` and query /api/v2, /apis/bach/v1, /api/v1/pops
+				status = http.StatusNotFound
 			} else {
 				bodyBytes, err := json.Marshal(apiResources)
 				if err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -67,9 +67,9 @@ func NewServer(k8sClient kubernetes.Interface, controller routers.Controller, ca
 			cacheExpirations.Authorized, cacheExpirations.Unauthorized))
 		group.Use(auth.Impersonation(k8sClient.AuthorizationV1().SubjectAccessReviews(), cache,
 			cacheExpirations.Authorized, cacheExpirations.Unauthorized))
+		group.Use(discovery.GetAPIResource(k8sClient.Discovery().RESTClient(), cache))
 		group.Use(auth.RBACAuthorization(k8sClient.AuthorizationV1().SubjectAccessReviews(), cache,
 			cacheExpirations.Authorized, cacheExpirations.Unauthorized))
-		group.Use(discovery.GetAPIResource(k8sClient.Discovery().RESTClient(), cache))
 		group.Use(pagination.Middleware())
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1295 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Changes response code when a resource does not exist in the cluster from 400 to 404.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
