### PR TITLE
Add a test to assist with the log forwarding issues

### DIFF
--- a/integrations/logging/loki/README.md
+++ b/integrations/logging/loki/README.md
@@ -33,12 +33,8 @@ Run the log generators to create logs:
     ```bash
     kubectl port-forward -n grafana-loki service/grafana 3000:80
     ```
-1. Determine the `admin` password for Grafana:
-    ```bash
-    echo `kubectl -n grafana-loki get secret grafana -o jsonpath='{.data.admin-password}' | base64 --decode`
-    ```
-1. In your browser, navigate to `http://localhost:3000`, using the username `admin` and the password retrieved
-   in the previous step to login.
+
+1. In your browser, navigate to `http://localhost:3000`, using `admin`/`password` credentials.
 
 1. Go to `Explore` and select `Loki`. Then write a query (e.g. `{pod="generate-log-1-29110151-kc2n9", container="generate1"}`).
 
@@ -56,7 +52,7 @@ Run the log generators to create logs:
    ```bash
    curl -u admin:password http://localhost:3100/loki/api/v1/query_range \
     -H "X-Scope-OrgID: kubearchive" \
-    --data-urlencode 'query={pod_id="<pod-id>", container="<container-name>"} | json | line_format "{{.message}}"' \
+    --data-urlencode 'query={stream="<pod-id>-<container-name>"}"' \
     --data-urlencode 'start=2025-05-07T00:00:00Z' \
     --data-urlencode 'end=2025-05-07T23:00:00Z' \
     --data-urlencode 'limit=10' | jq '.data.result.[].values.[].[1]'

--- a/integrations/logging/loki/install.sh
+++ b/integrations/logging/loki/install.sh
@@ -101,7 +101,7 @@ if [ "${VECTOR}" == "True" ]; then
   echo "Using Loki endpoint: ${LOKI_ENDPOINT}"
 
   #Deploy Vector to loki namespace
-  helm install kubearchive-vector vector/vector \
+  helm upgrade --install kubearchive-vector vector/vector \
     --namespace ${NAMESPACE} \
     --set "customConfig.sinks.loki.endpoint=${LOKI_ENDPOINT}" \
     --values values.vector.yaml

--- a/integrations/logging/loki/patch-logging-configmap.yaml
+++ b/integrations/logging/loki/patch-logging-configmap.yaml
@@ -10,5 +10,5 @@ data:
   START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
   END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('72h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 3 days since start timestamp
   # END: "cel:(status.?containerStatuses.?filter(c, c.name == '{CONTAINER_NAME}')?[0].?state.?terminated.?finishedAt != optional.none()) ? timestamp(status.containerStatuses.filter(c, c.name == '{CONTAINER_NAME}')[0].state.terminated.finishedAt) : int(now()+duration('5m'))*1000000000"
-  LOG_URL: "http://loki-gateway.grafana-loki.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bpod_id%3D%22{POD_ID}%22%2C%20container%3D%22{CONTAINER_NAME}%22%7D%20%7C%20json%20%7C%20line_format%20%22%7B%7B.message%7D%7D%22&start={START}&end={END}&direction=forward "
+  LOG_URL: "http://loki-gateway.grafana-loki.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{POD_ID}-{CONTAINER_NAME}%22%7D&start={START}&end={END}&direction=forward&limit=10000 "
   LOG_URL_JSONPATH: "$.data.result[*].values[*][1]"

--- a/integrations/logging/loki/values.grafana.yaml
+++ b/integrations/logging/loki/values.grafana.yaml
@@ -1,6 +1,9 @@
 # Copyright KubeArchive Authors
 # SPDX-License-Identifier: Apache-2.0
 ---
+adminUser: admin
+adminPassword: password # notsecret
+
 datasources:
   datasources.yaml:
     apiVersion: 1

--- a/integrations/logging/loki/values.loki.yaml
+++ b/integrations/logging/loki/values.loki.yaml
@@ -8,10 +8,12 @@ loki:
     ingestion_rate_mb: 10
     ingestion_burst_size_mb: 20
     max_streams_per_user: 0
-    max_line_size: 256000
+    max_line_size: 1048576  # Increased from 256000 to 1MB
     reject_old_samples: true
     reject_old_samples_max_age: 168h
     discover_service_name: []
+    max_entries_limit_per_query: 100000
+    increment_duplicate_timestamp: true
   # Enable authentication for basic auth support
   auth_enabled: true
   basic_auth:
@@ -99,8 +101,6 @@ compactor:
 
 indexGateway:
   replicas: 1
-  maxUnavailable: 0
-  affinity: {}
 
 ruler:
   replicas: 1
@@ -115,7 +115,7 @@ bloomPlanner:
 bloomBuilder:
   replicas: 0
 
-# Gateway configuration for load balancing
+# Gateway configuration for load balancing - configured for kind cluster
 gateway:
   enabled: true
   replicas: 1
@@ -126,6 +126,15 @@ gateway:
   service:
     type: ClusterIP
     port: 80
+  # Configure nginx resolver for kind cluster (CoreDNS)
+  nginxConfig:
+    resolver: "kube-dns.kube-system.svc.cluster.local."
+
+# DISABLE MEMCACHED COMPONENTS
+chunksCache:
+  enabled: false
+resultsCache:
+  enabled: false
 
 # Enable Minio deployment within Loki chart
 minio:

--- a/integrations/logging/loki/values.vector.yaml
+++ b/integrations/logging/loki/values.vector.yaml
@@ -35,8 +35,8 @@ customConfig:
         - k8s_logs
       group_by:
         - file
-      flush_period_ms: 2000
-      end_every_period_ms: 2000
+      max_events: 100
+      expire_after_ms: 10000
       merge_strategies:
         message: concat_newline
     remap_app_logs:
@@ -64,8 +64,8 @@ customConfig:
         }
         # Basic data sanitization to prevent 400 errors
         # Truncate very long messages
-        if length(.message) > 32768 {
-          .message = slice!(.message, 0, 32768) + "...[TRUNCATED]"
+        if length(.message) > 1048576 {
+          .message = slice!(.message, 0, 1048576) + "...[TRUNCATED]"
         }
         # Clean up temporary fields
         del(.tmp)
@@ -75,7 +75,7 @@ customConfig:
       inputs: ["remap_app_logs"]
       endpoint: http://loki-gateway.grafana-loki.svc.cluster.local
       encoding:
-        codec: "json"
+        codec: "text"
       auth:
         strategy: "basic"
         user: "${LOKI_USERNAME}"
@@ -93,8 +93,7 @@ customConfig:
         timeout_secs: 5
         max_bytes: 1048576  # 1MB
       labels:
-        pod_id: "{{`{{ pod_id }}`}}"
-        container: "{{`{{ container }}`}}"
+        stream: "{{`{{ pod_id }}-{{ container }}`}}"
 image:
   repository: quay.io/kubearchive/vector
   tag: 0.46.1-distroless-libc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1335 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

With this test I've seen that when using vector+loki along with a "reduce" manipulation of the kubernetes logs by vector to be sent in batches to loki we need to specify the batch size per entry counts and not per time.
This means that we need to use `max_events` property instead of `flush_period_ms`.
The reason behind this is that with timing and a large amount of logs we will likely send to loki entries that have larger size than it expects and the logs then may be rejected.

This needs to be handled along with the proper truncation of very long messages being aware that we are not truncating one log entry but a concatenated amount of log entries so we could potentially miss information if we don't do it correctly.

With the provided configuration the new test function logs are stored in loki in batches of 100 messages (the max limit) and kubearchive is able to retrieve them complete and ordered.

Extra stuff addressed in the issue:

- The logs forwarded as text and not as json. This improves performance and the logs shouldn't be necessary in a json format.
- Incremented the maximum line size received in loki, considering that each line can gather up to 100 entries now.
- Allow the entries per query to be larger
- Enable the `increment_duplicate_timestamp` to make sure that the logs aren't disordered. In case the timestamp of two entries is the same, loki should apply a slight increment to the most recent one to make sure that both batches don't share the same timestamp. BTW, I wasn't able to reproduce having the same timestamp at nanosecond precission but I think it's a good idea to have it.
- Disable cached components for simplicity in our development environment
- Set up hardcoded credentials for grafana in development to improve the easy of use while developing
- Make the install.sh script rerunnable with `helm upgrade --install` instead of `helm install`
- Use only one label to ensure one stream per pod+container. This helps keeping the logs ordered in a distributed loki.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
