### PR TITLE
Add name with wildcard filter in API

### DIFF
--- a/docs/modules/ROOT/pages/reference/api.adoc
+++ b/docs/modules/ROOT/pages/reference/api.adoc
@@ -39,6 +39,7 @@ of the returned `List` resource. An empty string if there are no more pages rema
 * `labelSelector`: allows filtering resources based on label filtering.
 * `creationTimestampAfter`: filters resources created after the specified timestamp (RFC3339 format, e.g., `2023-01-01T12:00:00Z`).
 * `creationTimestampBefore`: filters resources created before the specified timestamp (RFC3339 format, e.g., `2023-12-31T23:59:59Z`).
+* `name`: allows filtering resources by name with wildcard support (see Name Filtering section below).
 
 === Timestamp Filters
 
@@ -105,6 +106,56 @@ The API call is:
 ----
 /api/v1/namespaces/default/pods?labelSelector=app%3Dkubearchive%2C+env+in+%28stage%2C+dev%29%2C+release%21%3Dstable
 ----
+====
+
+=== Name Filtering
+
+The `name` parameter supports wildcard pattern matching for filtering resources by name.
+The filtering is case-insensitive and supports the following wildcard patterns:
+
+Exact match::
+    `name=my-deployment` - Matches resources with exactly the name "my-deployment"
+
+Prefix match::
+    `name=test-*` - Matches resources whose names start with "test-"
+
+Suffix match::
+    `name=*-job` - Matches resources whose names end with "-job"
+
+Contains match::
+    `name=*e2e*` - Matches resources whose names contain "e2e" anywhere
+
+Examples:
+
+[source,text]
+----
+# Find all deployments containing "e2e" in their name
+/apis/apps/v1/namespaces/default/deployments?name=*e2e*
+
+# Find all pods starting with "test-"
+/api/v1/namespaces/default/pods?name=test-*
+
+# Find all services ending with "-api"
+/api/v1/namespaces/default/services?name=*-api
+
+# Exact match (same as before, no wildcards)
+/api/v1/namespaces/default/pods?name=my-exact-pod-name
+
+# Invalid: Both path and query name parameters (returns 400)
+/api/v1/namespaces/default/pods/existing-pod?name=*e2e*
+
+# Invalid: Wildcard in path parameter (returns 400)
+/api/v1/namespaces/default/pods/*e2e*
+----
+
+[NOTE]
+====
+- Wildcard queries return a list of matching resources with pagination support
+- Exact name queries (without wildcards) return a single resource object
+- Name filtering is case-insensitive: `*E2E*` matches "test-e2e-pod"
+- Name filtering can be combined with `labelSelector` for more precise filtering
+- Cannot specify both path name parameter and query name parameter (returns 400 Bad Request)
+- Wildcard characters (*) are not allowed in path parameters, use query parameters instead (returns 400 Bad Request)
 ====
 
 == Individual Resources

--- a/integrations/database/postgresql/migrations/02_name_idx.down.sql
+++ b/integrations/database/postgresql/migrations/02_name_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX name_idx;

--- a/integrations/database/postgresql/migrations/02_name_idx.up.sql
+++ b/integrations/database/postgresql/migrations/02_name_idx.up.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX name_idx ON resource USING GIST (name gist_trgm_ops);

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubearchive/kubearchive/pkg/database/sql"
 )
 
-var CurrentDatabaseSchemaVersion = "1"
+var CurrentDatabaseSchemaVersion = "2"
 var RegisteredDatabases = map[string]interfaces.Database{
 	"postgresql": sql.NewPostgreSQLDatabase(),
 	"mariadb":    sql.NewMariaDBDatabase(),

--- a/pkg/database/sql/facade/filter.go
+++ b/pkg/database/sql/facade/filter.go
@@ -15,6 +15,7 @@ type DBFilter interface {
 	KindApiVersionFilter(cond sqlbuilder.Cond, kind, apiVersion string) string
 	NamespaceFilter(cond sqlbuilder.Cond, ns string) string
 	NameFilter(cond sqlbuilder.Cond, name string) string
+	NameWildcardFilter(cond sqlbuilder.Cond, namePattern string) string
 	CreationTSAndIDFilter(cond sqlbuilder.Cond, continueDate, continueId string) string
 	CreationTimestampAfterFilter(cond sqlbuilder.Cond, timestamp time.Time) string
 	CreationTimestampBeforeFilter(cond sqlbuilder.Cond, timestamp time.Time) string
@@ -46,6 +47,10 @@ func (PartialDBFilterImpl) NamespaceFilter(cond sqlbuilder.Cond, ns string) stri
 
 func (PartialDBFilterImpl) NameFilter(cond sqlbuilder.Cond, name string) string {
 	return cond.Equal("name", name)
+}
+
+func (PartialDBFilterImpl) NameWildcardFilter(cond sqlbuilder.Cond, namePattern string) string {
+	return cond.Like("LOWER(name)", cond.Var(namePattern))
 }
 
 func (PartialDBFilterImpl) UuidsFilter(cond sqlbuilder.Cond, uuids []string) string {

--- a/pkg/database/sql/postgresql.go
+++ b/pkg/database/sql/postgresql.go
@@ -80,6 +80,10 @@ func (postgreSQLFilter) CreationTimestampBeforeFilter(cond sqlbuilder.Cond, time
 	)
 }
 
+func (postgreSQLFilter) NameWildcardFilter(cond sqlbuilder.Cond, namePattern string) string {
+	return fmt.Sprintf("name ILIKE %s", cond.Var(namePattern))
+}
+
 func (postgreSQLFilter) OwnerFilter(cond sqlbuilder.Cond, owners []string) string {
 	return fmt.Sprintf(
 		"jsonb_path_query_array(data->'metadata'->'ownerReferences', '$[*].uid') ?| %s",

--- a/test/integration/wildcard_name_filter_test.go
+++ b/test/integration/wildcard_name_filter_test.go
@@ -1,0 +1,190 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/kubearchive/kubearchive/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestWildcardNameFilteringIntegration(t *testing.T) {
+	t.Parallel()
+
+	clientset, dynamicClient := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+	port := test.PortForwardApiServer(t, clientset)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	testResources := []struct {
+		name string
+		gvr  schema.GroupVersionResource
+	}{
+		{
+			name: "test-123",
+			gvr:  schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		},
+		{
+			name: "test-456",
+			gvr:  schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		},
+		{
+			name: "other-resource",
+			gvr:  schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+		},
+	}
+
+	for _, res := range testResources {
+		t.Logf("Creating test resource: %s/%s", namespaceName, res.name)
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   res.gvr.Group,
+			Version: res.gvr.Version,
+			Kind:    "Pod",
+		})
+		obj.SetName(res.name)
+		obj.SetNamespace(namespaceName)
+
+		obj.Object["spec"] = map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "test",
+					"image": "nginx:latest",
+				},
+			},
+			"restartPolicy": "Never",
+		}
+
+		_, err := dynamicClient.Resource(res.gvr).Namespace(namespaceName).Create(context.TODO(), obj, metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Failed to create resource %s: %v (might already exist)", res.name, err)
+		}
+
+		defer func(gvr schema.GroupVersionResource, namespace, name string) {
+			err := dynamicClient.Resource(gvr).Namespace(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			if err != nil {
+				t.Logf("Failed to delete resource %s: %v", name, err)
+			}
+		}(res.gvr, namespaceName, res.name)
+	}
+
+	testCases := []struct {
+		name          string
+		endpoint      string
+		expectedNames []string
+		description   string
+	}{
+		{
+			name:          "wildcard contains test lowercase",
+			endpoint:      fmt.Sprintf("/api/v1/namespaces/%s/pods?name=*test*", namespaceName),
+			expectedNames: []string{"test-123", "test-456"},
+			description:   "Should match pods containing 'test'",
+		},
+		{
+			name:          "wildcard contains test uppercase",
+			endpoint:      fmt.Sprintf("/api/v1/namespaces/%s/pods?name=*TEST*", namespaceName),
+			expectedNames: []string{"test-123", "test-456"},
+			description:   "Should match pods containing 'TEST' (case insensitive)",
+		},
+		{
+			name:          "wildcard suffix 123",
+			endpoint:      fmt.Sprintf("/api/v1/namespaces/%s/pods?name=*123", namespaceName),
+			expectedNames: []string{"test-123"},
+			description:   "Should match pods ending with '123'",
+		},
+		{
+			name:          "wildcard no matches",
+			endpoint:      fmt.Sprintf("/api/v1/namespaces/%s/pods?name=*notfound*", namespaceName),
+			expectedNames: []string{},
+			description:   "Should return empty list when no matches",
+		},
+		{
+			name:          "validation error - conflicting parameters",
+			endpoint:      fmt.Sprintf("/api/v1/namespaces/%s/pods/test-123?name=*test*", namespaceName),
+			expectedNames: []string{}, // Not used for error cases
+			description:   "Should return 400 when both path and query name parameters are provided",
+		},
+		{
+			name:          "validation error - wildcard in path parameter",
+			endpoint:      fmt.Sprintf("/api/v1/namespaces/%s/pods/*test*", namespaceName),
+			expectedNames: []string{}, // Not used for error cases
+			description:   "Should return 400 when wildcard characters are used in path parameter",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing endpoint: %s", tc.endpoint)
+
+			url := fmt.Sprintf("https://localhost:%s%s", port, tc.endpoint)
+
+			if tc.name == "validation error - conflicting parameters" || tc.name == "validation error - wildcard in path parameter" {
+				_, err := test.GetUrl(t, token.Status.Token, url, nil)
+				assert.Error(t, err, tc.description)
+				assert.Contains(t, err.Error(), "400", tc.description)
+				return
+			}
+
+			retryErr := retry.Do(func() error {
+				result, getUrlErr := test.GetUrl(t, token.Status.Token, url, nil)
+				if getUrlErr != nil {
+					return getUrlErr
+				}
+
+				var actualNames []string
+				for _, item := range result.Items {
+					metadata := item.Object["metadata"].(map[string]interface{})
+					name := metadata["name"].(string)
+					actualNames = append(actualNames, name)
+				}
+
+				if len(actualNames) != len(tc.expectedNames) {
+					msg := fmt.Sprintf("expected %d pods, got %d", len(tc.expectedNames), len(actualNames))
+					t.Log(msg)
+					return errors.New(msg)
+				}
+
+				missingNames := []string{}
+				for _, expectedName := range tc.expectedNames {
+					found := false
+					for _, actualName := range actualNames {
+						if expectedName == actualName {
+							found = true
+							break
+						}
+					}
+					if !found {
+						missingNames = append(missingNames, expectedName)
+					}
+				}
+
+				if len(missingNames) > 0 {
+					msg := fmt.Sprintf("missing expected pods: %s", strings.Join(missingNames, ", "))
+					t.Log(msg)
+					return errors.New(msg)
+				}
+
+				t.Logf("Found expected pods for wildcard pattern: %v", actualNames)
+				return nil
+			}, retry.Attempts(240), retry.MaxDelay(4*time.Second))
+
+			if retryErr != nil {
+				t.Fatal(retryErr)
+			}
+		})
+	}
+}

--- a/test/performance/locustfile.py
+++ b/test/performance/locustfile.py
@@ -1,6 +1,6 @@
 # Copyright KubeArchive Authors
 # SPDX-License-Identifier: Apache-2.0
-import urllib3, os, json
+import urllib3, os, json, random
 from datetime import datetime, timedelta
 from string import Template
 from uuid import uuid4
@@ -60,15 +60,29 @@ class GetPods(HttpUser):
             headers={"Authorization": f"Bearer {token}"}
         )
 
+    @task
+    def get_pods_wildcard(self):
+        """Match pods containing '1' in their name"""
+        self.client.get(
+            "https://localhost:8081/api/v1/pods?name=*1*",
+            verify=False,
+            headers={"Authorization": f"Bearer {token}"}
+        )
+
 
 class CreatePods(HttpUser):
     @task
     def create_pod(self):
         now = datetime.now()
+
+        # Generate pod name with numeric suffix for wildcard testing
+        numeric_suffix = random.randint(1000000, 9999999)  # 7-digit number
+        pod_name = f"pod-{numeric_suffix}"
+
         data = template.substitute(dict(
             kind="Pod",
             version="v1",
-            pod_name="pod",
+            pod_name=pod_name,
             pod_uuid=uuid4(),
             owner_uuid=uuid4(),
             create_timestamp=now.strftime("%Y-%m-%dT%H:%M:%SZ"),


### PR DESCRIPTION
Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1194 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Add name filter with wildcards for resource list
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

We need to check if we should provide this feature along with a change in the schema for adding an index on the name field

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
