### PR TITLE
Fix deleteWhen for Jobs in the CronJob log generator.

### DIFF
--- a/test/log-generators/cronjobs/kaconf.yaml
+++ b/test/log-generators/cronjobs/kaconf.yaml
@@ -15,7 +15,7 @@ spec:
         apiVersion: batch/v1
         kind: Job
       archiveWhen: has(status.startTime)
-      deleteWhen: timestamp(status.completionTime) < now() - duration("5m")
+      deleteWhen: has(status.completionTime)
     - selector:
         apiVersion: v1
         kind: Pod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Change the `deleteWhen` on the `Job` so that jobs are deleted when completed. This will also mean that `Pods` are also archived and deleted.
Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1375 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
