### PR TITLE
Check for valid duration strings in CEL expressions.

### DIFF
--- a/cmd/operator/api/v1/clusterkubearchiveconfig_webhook.go
+++ b/cmd/operator/api/v1/clusterkubearchiveconfig_webhook.go
@@ -95,18 +95,24 @@ func (ckaccv *ClusterKubeArchiveConfigCustomValidator) validateKAC(ckac *Cluster
 			_, err := cel.CompileCELExpr(resource.ArchiveWhen)
 			if err != nil {
 				errList = append(errList, err)
+			} else {
+				errList = append(errList, validateDurationString(resource.ArchiveWhen)...)
 			}
 		}
 		if resource.DeleteWhen != "" {
 			_, err := cel.CompileCELExpr(resource.DeleteWhen)
 			if err != nil {
 				errList = append(errList, err)
+			} else {
+				errList = append(errList, validateDurationString(resource.DeleteWhen)...)
 			}
 		}
 		if resource.ArchiveOnDelete != "" {
 			_, err := cel.CompileCELExpr(resource.ArchiveOnDelete)
 			if err != nil {
 				errList = append(errList, err)
+			} else {
+				errList = append(errList, validateDurationString(resource.ArchiveOnDelete)...)
 			}
 		}
 	}

--- a/pkg/cel/cel.go
+++ b/pkg/cel/cel.go
@@ -70,7 +70,7 @@ func CompileCELExpr(expr string) (*cel.Program, error) {
 // if the program returns a value that cannot be converted to bool, false is returned. Otherwise the bool
 // returned by the CEL program is returned.
 func ExecuteBooleanCEL(ctx context.Context, program cel.Program, obj *unstructured.Unstructured) bool {
-	val := ExecuteCEL(ctx, program, obj)
+	val, _ := ExecuteCEL(ctx, program, obj)
 	if val == nil {
 		return false
 	}
@@ -78,11 +78,11 @@ func ExecuteBooleanCEL(ctx context.Context, program cel.Program, obj *unstructur
 	return ok && boolVal
 }
 
-func ExecuteCEL(ctx context.Context, program cel.Program, obj *unstructured.Unstructured) ref.Val {
+func ExecuteCEL(ctx context.Context, program cel.Program, obj *unstructured.Unstructured) (ref.Val, error) {
 	tracer := otel.Tracer("kubearchive")
 	ctx, span := tracer.Start(ctx, "ExecuteCEL")
 	defer span.End()
 
-	val, _, _ := program.ContextEval(ctx, obj.Object)
-	return val
+	val, _, err := program.ContextEval(ctx, obj.Object)
+	return val, err
 }

--- a/pkg/logurls/logurls.go
+++ b/pkg/logurls/logurls.go
@@ -39,7 +39,7 @@ func GenerateLogURLs(ctx context.Context, cm map[string]interface{}, data *unstr
 		prgmPtr, ok := value.(*cel.Program)
 		if ok {
 			// We have a CEL expression. Evaluate it and use that value.
-			value = ocel.ExecuteCEL(ctx, *prgmPtr, data)
+			value, _ = ocel.ExecuteCEL(ctx, *prgmPtr, data)
 		}
 		m[key] = value
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->
Check for invalid duration strings when validating KubeArchive config files.
Sample `KubeArchiveConfig`:
```
---
apiVersion: kubearchive.org/v1
kind: KubeArchiveConfig
metadata:
  name: kubearchive
spec:
  resources:
    - archiveWhen: status.state != 'Completed'
      deleteWhen: timestamp(status.completionTime) < now() - duration("5xxx")
      selector:
        apiVersion: batch/v1
        kind: Job
```
Webhook validation output:
```
[gallen@gallen-thinkpadp1gen5 kubearchive] (issue-1404)$ kc apply -f kaconfig-1.yml
Error from server (Forbidden): error when creating "kaconfig-1.yml": admission webhook "vkubearchiveconfig.kb.io" denied the request: invalid duration string 'duration("5xxx")'
[gallen@gallen-thinkpadp1gen5 kubearchive] (issue-1404)$
```
## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1416 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
