### PR TITLE
Add discovery client to cli

### DIFF
--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -8,8 +8,11 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/pflag"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 )
@@ -21,11 +24,27 @@ const (
 	KubeArchive
 )
 
+// DiscoveryInterface defines the methods we need from the discovery client
+type DiscoveryInterface interface {
+	ServerGroups() (*v1.APIGroupList, error)
+	ServerGroupsAndResources() ([]*v1.APIGroup, []*v1.APIResourceList, error)
+}
+
+// ResourceInfo holds the resolved resource information from discovery
+type ResourceInfo struct {
+	Resource     string
+	Version      string
+	Group        string
+	GroupVersion string
+	Kind         string
+}
+
 type KACLICommand interface {
 	Complete() error
 	AddFlags(flags *pflag.FlagSet)
 	GetFromAPI(api API, path string) ([]byte, error)
 	GetNamespace() (string, error)
+	ResolveResourceSpec(resourceSpec string) (*ResourceInfo, error)
 }
 
 type KAOptions struct {
@@ -35,6 +54,7 @@ type KAOptions struct {
 	kubeFlags       *genericclioptions.ConfigFlags
 	K8sRESTConfig   *rest.Config
 	K9eRESTConfig   *rest.Config
+	discoveryClient DiscoveryInterface
 }
 
 // NewKAOptions loads config from env vars and sets defaults
@@ -140,6 +160,12 @@ func (opts *KAOptions) Complete() error {
 	}
 	opts.K8sRESTConfig = restConfig
 
+	client, err := opts.kubeFlags.ToDiscoveryClient()
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	opts.discoveryClient = client
+
 	certData, err := opts.getCertificateData()
 	if err != nil {
 		return fmt.Errorf("failed to get certificate data: %w", err)
@@ -175,4 +201,169 @@ func (opts *KAOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.host, "host", opts.host, "host where the KubeArchive API Server is listening.")
 	flags.BoolVar(&opts.tlsInsecure, "kubearchive-insecure-skip-tls-verify", opts.tlsInsecure, "Allow insecure requests to the KubeArchive API.")
 	flags.StringVar(&opts.certificatePath, "kubearchive-certificate-authority", opts.certificatePath, "Path to the certificate authority file.")
+}
+
+// ResolveResourceSpec resolves a resource specification using Kubernetes discovery API
+func (opts *KAOptions) ResolveResourceSpec(resourceSpec string) (*ResourceInfo, error) {
+	parts := strings.Split(resourceSpec, ".")
+
+	if len(parts) == 0 || parts[0] == "" {
+		return nil, fmt.Errorf("resource name cannot be empty")
+	}
+
+	if len(parts) > 3 {
+		return nil, fmt.Errorf("invalid resource specification format: %s", resourceSpec)
+	}
+
+	resourceName := parts[0]
+	var requestedVersion, requestedGroup string
+
+	switch len(parts) {
+	case 1:
+		// resource only - need to discover both version and group
+	case 2:
+		// resource.group - need to discover the version for the group
+		requestedGroup = parts[1]
+	case 3:
+		// resource.version.group - everything specified
+		requestedVersion = parts[1]
+		requestedGroup = parts[2]
+	}
+
+	// Find the resource using discovery
+	return opts.findResourceInfo(resourceName, requestedVersion, requestedGroup)
+}
+
+// findResourceInfo uses discovery to find the correct group, version, and kind for a resource
+func (opts *KAOptions) findResourceInfo(resourceName, requestedVersion, requestedGroup string) (*ResourceInfo, error) {
+	// Get all API resources
+	_, apiResourceLists, err := opts.discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover API resources: %w", err)
+	}
+
+	var candidates []*ResourceInfo
+
+	// Search through all API groups and versions
+	for _, apiResourceList := range apiResourceLists {
+		gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
+		if err != nil {
+			continue
+		}
+
+		// If a specific group is requested, skip other groups
+		if requestedGroup != "" && gv.Group != requestedGroup {
+			continue
+		}
+
+		// If a specific version is requested, skip other versions
+		if requestedVersion != "" && gv.Version != requestedVersion {
+			continue
+		}
+
+		// Look for the resource in this group/version
+		for _, apiResource := range apiResourceList.APIResources {
+			if opts.matchesResource(apiResource, resourceName) {
+				resourceInfo := &ResourceInfo{
+					Resource:     apiResource.Name, // Use the actual resource name, not the input
+					Version:      gv.Version,
+					Group:        gv.Group,
+					GroupVersion: apiResourceList.GroupVersion,
+					Kind:         apiResource.Kind,
+				}
+				candidates = append(candidates, resourceInfo)
+			}
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("resource %q not found", resourceName)
+	}
+
+	// If we have multiple candidates, prefer the one from the preferred version
+	if len(candidates) > 1 {
+		return opts.selectPreferredResource(opts.discoveryClient, candidates)
+	}
+
+	return candidates[0], nil
+}
+
+// matchesResource checks if an API resource matches the requested resource name
+func (opts *KAOptions) matchesResource(apiResource v1.APIResource, resourceName string) bool {
+	// Check exact match with resource name
+	if apiResource.Name == resourceName {
+		return true
+	}
+
+	// Check if it matches any of the short names
+	for _, shortName := range apiResource.ShortNames {
+		if shortName == resourceName {
+			return true
+		}
+	}
+
+	// Check singular name if available
+	if apiResource.SingularName != "" && apiResource.SingularName == resourceName {
+		return true
+	}
+
+	return false
+}
+
+// selectPreferredResource selects the preferred version from multiple candidates
+func (opts *KAOptions) selectPreferredResource(discoveryClient DiscoveryInterface, candidates []*ResourceInfo) (*ResourceInfo, error) {
+	// Group candidates by API group
+	groupMap := make(map[string][]*ResourceInfo)
+	for _, candidate := range candidates {
+		groupMap[candidate.Group] = append(groupMap[candidate.Group], candidate)
+	}
+
+	// For each group, find the preferred version
+	for group, groupCandidates := range groupMap {
+		if len(groupCandidates) == 1 {
+			return groupCandidates[0], nil
+		}
+
+		// Get the preferred version for this group
+		preferredVersion, err := opts.getPreferredVersion(discoveryClient, group)
+		if err != nil {
+			// If we can't determine preferred version, just use the first one
+			//lint:ignore nilerr fallback to the first apiresource we don't want to fail if there is no preferred
+			return groupCandidates[0], nil
+		}
+
+		// Find the candidate with the preferred version
+		for _, candidate := range groupCandidates {
+			if candidate.Version == preferredVersion {
+				return candidate, nil
+			}
+		}
+	}
+
+	// Fallback to first candidate
+	return candidates[0], nil
+}
+
+// getPreferredVersion gets the preferred version for a given API group
+func (opts *KAOptions) getPreferredVersion(discoveryClient DiscoveryInterface, group string) (string, error) {
+	if group == "" {
+		// Core API group always uses v1
+		return "v1", nil
+	}
+
+	// Get group information
+	groups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return "", fmt.Errorf("failed to get server groups: %w", err)
+	}
+
+	for _, apiGroup := range groups.Groups {
+		if apiGroup.Name == group {
+			if len(apiGroup.Versions) > 0 {
+				return apiGroup.PreferredVersion.Version, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("group %q not found", group)
 }


### PR DESCRIPTION
This allows following the
same syntax of kubectl

Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1002 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Adopted a new syntax for specifying resource types and names in the CLI to be consistent with kubectl's convention (e.g., `type/name`).
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
