### PR TITLE
Introduce 'uid' endpoints to the API

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -83,11 +83,17 @@ func NewServer(k8sClient kubernetes.Interface, controller routers.Controller, ca
 	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType/:name", controller.GetResources)
 	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType/:name/log",
 		logging.SetLoggingHeaders(), controller.GetLogURL, logging.LogRetrieval())
+	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType/uid/:uid", controller.GetResourceByUID)
+	apisGroup.GET("/:group/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
+		logging.SetLoggingHeaders(), controller.GetLogURL, logging.LogRetrieval())
 
 	apiGroup.GET("/:version/:resourceType", controller.GetResources)
 	apiGroup.GET("/:version/namespaces/:namespace/:resourceType", controller.GetResources)
 	apiGroup.GET("/:version/namespaces/:namespace/:resourceType/:name", controller.GetResources)
 	apiGroup.GET("/:version/namespaces/:namespace/:resourceType/:name/log",
+		logging.SetLoggingHeaders(), controller.GetLogURL, logging.LogRetrieval())
+	apiGroup.GET("/:version/namespaces/:namespace/:resourceType/uid/:uid", controller.GetResourceByUID)
+	apiGroup.GET("/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
 		logging.SetLoggingHeaders(), controller.GetLogURL, logging.LogRetrieval())
 
 	return &Server{

--- a/docs/modules/ROOT/pages/reference/api.adoc
+++ b/docs/modules/ROOT/pages/reference/api.adoc
@@ -1,8 +1,11 @@
 = API reference
 
-This document contains the endpoints and features supported
-by the KubeArchive API. It also lists the query parameters each
-endpoint supports.
+The design of the KubeArchive API makes it offer the same experience
+than the Kubernetes API, so it is compatible with the tools that
+call the Kubernetes API. In addition, the KubeArchive API provides
+some features that make sense for databases: search by `uid`, search
+using wildcard, ... This document contains the endpoints, query paramaters
+and features the KubeArchive API supports.
 
 == General Features
 
@@ -171,6 +174,8 @@ Examples:
 
 == Individual Resources
 
+=== By Name
+
 [source,text]
 ----
 /apis/:group/:version/namespaces/:namespace/:resourceType/:name
@@ -185,12 +190,32 @@ Examples:
 /api/v1/namespaces/default/pods/busybox-tooling
 ----
 
+=== By UID
+
+[source,text]
+----
+/apis/:group/:version/namespaces/:namespace/:resourceType/uid/:uid
+/api/:version/namespaces/:namespace/:resourceType/uid/:uid
+----
+
+Examples:
+
+[source,text]
+----
+/apis/batch/v1/namespaces/default/cronjobs/uid/ee275be0-cd4c-4aad-b8c3-710670f9c8e5
+/api/v1/namespaces/default/pods/uid/1d39c207-e5f9-4ba1-8fa9-49bb2f8545f3
+----
+
 === Logs
+
+Retrieving logs is supported in both "by name" and "by uid" endpoints:
 
 [source,text]
 ----
 /apis/:group/:version/namespaces/:namespace/:resourceType/:name/log
 /api/:version/namespaces/:namespace/:resourceType/:name/log
+/apis/:group/:version/namespaces/:namespace/:resourceType/uid/:uid/log
+/api/:version/namespaces/:namespace/:resourceType/uid/:uid/log
 ----
 
 Examples:
@@ -199,6 +224,8 @@ Examples:
 ----
 /apis/batch/v1/namespaces/default/cronjobs/cleanup-tasks/log
 /api/v1/namespaces/default/pods/busybox-tooling/log
+/apis/batch/v1/namespaces/default/cronjobs/uid/94620f8e-3623-46ce-b6e6-d21342ed1857/log
+/api/v1/namespaces/default/pods/uid/ea68b462-9725-4e67-a96f-b4b9d3bed25c/log
 ----
 
 Parameters allowed:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
 	github.com/huandu/go-sqlbuilder v1.38.1
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
@@ -94,7 +95,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect

--- a/pkg/database/fake/database_generated_test.go
+++ b/pkg/database/fake/database_generated_test.go
@@ -350,7 +350,7 @@ func TestQueryLogURLs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := NewFakeDatabase(testResources, testLogUrls, testJsonPath)
-			url, jsonPath, _ := db.QueryLogURL(context.Background(), tt.kind, "", "", "", "")
+			url, jsonPath, _ := db.QueryLogURLByName(context.Background(), tt.kind, "", "", "", "")
 			assert.Equal(t, tt.expected, url)
 			assert.Equal(t, testJsonPath, jsonPath)
 		})

--- a/pkg/database/interfaces/database.go
+++ b/pkg/database/interfaces/database.go
@@ -24,7 +24,9 @@ type DBReader interface {
 	QueryResources(ctx context.Context, kind, apiVersion, namespace,
 		name, continueId, continueDate string, labelFilters *models.LabelFilters,
 		creationTimestampAfter, creationTimestampBefore *time.Time, limit int) ([]models.Resource, error)
-	QueryLogURL(ctx context.Context, kind, apiVersion, namespace, name, containerName string) (string, string, error)
+	QueryResourceByUID(ctx context.Context, kind, apiVersion, namespace, uid string) (*models.Resource, error)
+	QueryLogURLByName(ctx context.Context, kind, apiVersion, namespace, name, containerName string) (string, string, error)
+	QueryLogURLByUID(ctx context.Context, kind, apiVersion, namespace, uid, containerName string) (string, string, error)
 	Ping(ctx context.Context) error
 	QueryDatabaseSchemaVersion(ctx context.Context) (string, error)
 	CloseDB() error

--- a/test/log-generators/cronjobs/sa.yaml
+++ b/test/log-generators/cronjobs/sa.yaml
@@ -1,0 +1,44 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubearchive-view
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubearchive-view
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubearchive-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubearchive-view
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-view
+    namespace: generate-logs-cronjobs

--- a/test/main.go
+++ b/test/main.go
@@ -233,6 +233,21 @@ func GetPodName(t testing.TB, clientset *kubernetes.Clientset, namespace, prefix
 	return podName
 }
 
+func GetResource(t testing.TB, token string, url string, extraHeaders map[string][]string) (*unstructured.Unstructured, error) {
+	body, err := getUrl(t, token, url, extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	var resource unstructured.Unstructured
+	err = json.Unmarshal(body, &resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resource, nil
+}
+
 func GetUrl(t testing.TB, token string, url string, extraHeaders map[string][]string) (*unstructured.UnstructuredList, error) {
 	body, err := getUrl(t, token, url, extraHeaders)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1228 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Introduces new endpoints `/uid/` to retrieve resources and logs by resource `uid`.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* I added these tests to the "normal operation" integration test because our number of integration tests is exploding and we are repeating over and over the same (create namespace, generate some data, inspect it). Given that test already does that, we just reuse the data generated.
* I need to introduce unit tests for this.
* I introduced a ServiceAccount in the generate-logs-cronjobs namespace for an easier experience when testing using `curl`.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
