### PR TITLE
Support retrieval by name in CLI

### DIFF
--- a/cmd/kubectl-ka/main.go
+++ b/cmd/kubectl-ka/main.go
@@ -30,8 +30,9 @@ func main() {
 
 func NewRootCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "kubectl-ka",
-		Short: "kubectl plugin to interact with KubeArchive",
+		Use:           "kubectl-ka",
+		Short:         "kubectl plugin to interact with KubeArchive",
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Hello from the root cmd")
 			return nil

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -452,7 +452,7 @@ func TestGetFromAPI(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 			},
 			expectError:   true,
-			errorContains: "unauthorized",
+			errorContains: "HTTP 401",
 		},
 		{
 			name: "not found response",
@@ -462,7 +462,7 @@ func TestGetFromAPI(t *testing.T) {
 				w.WriteHeader(http.StatusNotFound)
 			},
 			expectError:   true,
-			errorContains: "not found",
+			errorContains: "HTTP 404",
 		},
 		{
 			name: "server error with body",
@@ -473,7 +473,7 @@ func TestGetFromAPI(t *testing.T) {
 				_, _ = w.Write([]byte(`Error details`))
 			},
 			expectError:   true,
-			errorContains: "unknown error: Error details (500)",
+			errorContains: "Error details (500)",
 		},
 		{
 			name:          "network error",
@@ -508,15 +508,15 @@ func TestGetFromAPI(t *testing.T) {
 				},
 			}
 
-			result, err := opts.GetFromAPI(tc.api, tc.path)
+			result, apiErr := opts.GetFromAPI(tc.api, tc.path)
 
 			if tc.expectError {
-				assert.Error(t, err)
+				assert.NotNil(t, apiErr)
 				if tc.errorContains != "" {
-					assert.Contains(t, err.Error(), tc.errorContains)
+					assert.Contains(t, apiErr.Error(), tc.errorContains)
 				}
 			} else {
-				assert.NoError(t, err)
+				assert.Nil(t, apiErr)
 				assert.Equal(t, tc.expectedBody, string(result))
 			}
 		})

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -43,6 +43,9 @@ func normalizeYAML(t *testing.T, yamlStr string) string {
 
 // createPodListJSON creates a PodList JSON with the given pod name and timestamp
 func createPodListJSON(podName, timestamp string) string {
+	// Generate a unique UID for each pod name
+	uid := fmt.Sprintf("%s-uid-12345678-1234-1234-1234-123456789abc", podName)
+
 	podList := map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "PodList",
@@ -56,7 +59,40 @@ func createPodListJSON(podName, timestamp string) string {
 				"metadata": map[string]interface{}{
 					"name":              podName,
 					"namespace":         "default",
+					"uid":               uid,
 					"creationTimestamp": timestamp,
+				},
+			},
+		},
+	}
+
+	jsonBytes, _ := json.Marshal(podList)
+	return string(jsonBytes)
+}
+
+// createPodListJSONWithStatus creates a Pod list JSON with the given pod name, timestamp, and status
+func createPodListJSONWithStatus(podName, timestamp, status string) string {
+	// Use the same UID for both live and archived versions to test deduplication
+	uid := "duplicate-pod-uid-12345678-1234-1234-1234-123456789abc"
+
+	podList := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"metadata": map[string]interface{}{
+			"resourceVersion": "",
+		},
+		"items": []map[string]interface{}{
+			{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"name":              podName,
+					"namespace":         "default",
+					"uid":               uid,
+					"creationTimestamp": timestamp,
+				},
+				"status": map[string]interface{}{
+					"phase": status,
 				},
 			},
 		},
@@ -70,8 +106,8 @@ func createPodListJSON(podName, timestamp string) string {
 type MockKACLICommand struct {
 	k8sResponse      string
 	k9eResponse      string
-	k8sError         error
-	k9eError         error
+	k8sError         *config.APIError
+	k9eError         *config.APIError
 	completeError    error
 	namespaceValue   string
 	namespaceError   error
@@ -90,7 +126,7 @@ func (m *MockKACLICommand) ResolveResourceSpec(resourceSpec string) (*config.Res
 	return m.mockResourceInfo, nil
 }
 
-func (m *MockKACLICommand) GetFromAPI(api config.API, _ string) ([]byte, error) {
+func (m *MockKACLICommand) GetFromAPI(api config.API, _ string) ([]byte, *config.APIError) {
 	switch api {
 	case config.Kubernetes:
 		if m.k8sError != nil {
@@ -103,7 +139,7 @@ func (m *MockKACLICommand) GetFromAPI(api config.API, _ string) ([]byte, error) 
 		}
 		return []byte(m.k9eResponse), nil
 	default:
-		return nil, fmt.Errorf("unknown API type")
+		return nil, &config.APIError{StatusCode: 500, URL: "unknown-api", Message: "unknown API type", Body: ""}
 	}
 }
 
@@ -143,6 +179,7 @@ func TestGetComplete(t *testing.T) {
 	testCases := []struct {
 		name            string
 		allNamespaces   bool
+		labelSelector   string
 		args            []string
 		resourceInfo    *config.ResourceInfo
 		expectedApiPath string
@@ -155,7 +192,7 @@ func TestGetComplete(t *testing.T) {
 			allNamespaces: false,
 			args:          []string{"pods"},
 			resourceInfo: &config.ResourceInfo{
-				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod",
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
 			},
 			expectedApiPath: "/api/v1/namespaces/default/pods",
 		},
@@ -164,7 +201,7 @@ func TestGetComplete(t *testing.T) {
 			allNamespaces: false,
 			args:          []string{"jobs.v1.batch"},
 			resourceInfo: &config.ResourceInfo{
-				Resource: "jobs", Version: "v1", Group: "batch", GroupVersion: "batch/v1", Kind: "Job",
+				Resource: "jobs", Version: "v1", Group: "batch", GroupVersion: "batch/v1", Kind: "Job", Namespaced: true,
 			},
 			expectedApiPath: "/apis/batch/v1/namespaces/default/jobs",
 		},
@@ -173,7 +210,7 @@ func TestGetComplete(t *testing.T) {
 			allNamespaces: false,
 			args:          []string{"deployments.apps"},
 			resourceInfo: &config.ResourceInfo{
-				Resource: "deployments", Version: "v1", Group: "apps", GroupVersion: "apps/v1", Kind: "Deployment",
+				Resource: "deployments", Version: "v1", Group: "apps", GroupVersion: "apps/v1", Kind: "Deployment", Namespaced: true,
 			},
 			expectedApiPath: "/apis/apps/v1/namespaces/default/deployments",
 		},
@@ -182,7 +219,7 @@ func TestGetComplete(t *testing.T) {
 			allNamespaces: false,
 			args:          []string{"deploy"},
 			resourceInfo: &config.ResourceInfo{
-				Resource: "deployments", Version: "v1", Group: "apps", GroupVersion: "apps/v1", Kind: "Deployment",
+				Resource: "deployments", Version: "v1", Group: "apps", GroupVersion: "apps/v1", Kind: "Deployment", Namespaced: true,
 			},
 			expectedApiPath: "/apis/apps/v1/namespaces/default/deployments", // Should use actual resource name
 		},
@@ -191,7 +228,7 @@ func TestGetComplete(t *testing.T) {
 			allNamespaces: false,
 			args:          []string{"pod"},
 			resourceInfo: &config.ResourceInfo{
-				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod",
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
 			},
 			expectedApiPath: "/api/v1/namespaces/default/pods", // Should use actual resource name
 		},
@@ -200,16 +237,60 @@ func TestGetComplete(t *testing.T) {
 			allNamespaces: true,
 			args:          []string{"pods"},
 			resourceInfo: &config.ResourceInfo{
-				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod",
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
 			},
 			expectedApiPath: "/api/v1/pods",
+		},
+		{
+			name:          "core resource with name",
+			allNamespaces: false,
+			args:          []string{"pods", "my-pod"},
+			resourceInfo: &config.ResourceInfo{
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
+			},
+			expectedApiPath: "/api/v1/namespaces/default/pods/my-pod",
+		},
+		{
+			name:          "non-core resource with name",
+			allNamespaces: false,
+			args:          []string{"deployments.apps", "my-deployment"},
+			resourceInfo: &config.ResourceInfo{
+				Resource: "deployments", Version: "v1", Group: "apps", GroupVersion: "apps/v1", Kind: "Deployment", Namespaced: true,
+			},
+			expectedApiPath: "/apis/apps/v1/namespaces/default/deployments/my-deployment",
+		},
+		{
+			name:          "all namespaces with name (should still include name)",
+			allNamespaces: true,
+			args:          []string{"pods", "my-pod"},
+			resourceInfo: &config.ResourceInfo{
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
+			},
+			expectedApiPath: "/api/v1/pods/my-pod",
+		},
+		{
+			name:          "with label selector",
+			allNamespaces: false,
+			labelSelector: "app=nginx",
+			args:          []string{"pods"},
+			resourceInfo: &config.ResourceInfo{
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
+			},
+			expectedApiPath: "/api/v1/namespaces/default/pods?labelSelector=app%3Dnginx",
+		},
+		{
+			name:          "name and label selector together",
+			labelSelector: "app=nginx",
+			args:          []string{"pods", "my-pod"},
+			expectError:   true,
+			errorContains: "cannot specify both a resource name and a label selector",
 		},
 		{
 			name:          "complete error",
 			args:          []string{"pods"},
 			mockError:     fmt.Errorf("mock complete failed"),
 			expectError:   true,
-			errorContains: "error completing the args: mock complete failed",
+			errorContains: "mock complete failed",
 		},
 	}
 
@@ -219,6 +300,7 @@ func TestGetComplete(t *testing.T) {
 			mockCli := NewMockKACLICommand(tc.mockError, tc.resourceInfo)
 			options = NewTestGetOptions(mockCli)
 			options.AllNamespaces = tc.allNamespaces
+			options.LabelSelector = tc.labelSelector
 
 			err := options.Complete(tc.args)
 
@@ -239,8 +321,8 @@ func TestGetComplete(t *testing.T) {
 func TestRun(t *testing.T) {
 	testCases := []struct {
 		name               string
-		k8sError           error
-		k9eError           error
+		k8sError           *config.APIError
+		k9eError           *config.APIError
 		outputFormat       string
 		expectError        bool
 		errorContains      string
@@ -267,29 +349,90 @@ func TestRun(t *testing.T) {
 			needsNormalization: true,
 		},
 		{
-			name:          "API error",
-			k8sError:      fmt.Errorf("connection failed"),
+			name:               "deduplication - live cluster priority",
+			outputFormat:       "",
+			expectedOutputFile: "expected_deduplication_output.txt",
+			useDynamicTime:     true,
+		},
+		{
+			name:          "no resources found in namespace",
 			expectError:   true,
-			errorContains: "error retrieving the resources from Kubernetes API server",
+			errorContains: "no resources found in default namespace",
+		},
+		{
+			name:          "no resources found all namespaces",
+			expectError:   true,
+			errorContains: "no resources found",
+		},
+		{
+			name: "API error",
+			k8sError: &config.APIError{
+				StatusCode: 500,
+				URL:        "mock-k8s-url",
+				Message:    "connection failed",
+				Body:       "",
+			},
+			k9eError: &config.APIError{
+				StatusCode: 500,
+				URL:        "mock-k9e-url",
+				Message:    "network timeout",
+				Body:       "",
+			},
+			expectError:   true,
+			errorContains: "connection failed",
 		},
 		{
 			name:          "invalid output format",
 			outputFormat:  "invalid",
 			expectError:   true,
-			errorContains: "error getting printer",
+			errorContains: "unable to match a printer suitable for the output format",
 		},
 		{
 			name:          "invalid JSON response",
 			outputFormat:  "",
 			expectError:   true,
-			errorContains: "error retrieving resources from the cluster",
+			errorContains: "error parsing resources from the cluster",
+		},
+		{
+			name: "both APIs not found",
+			k8sError: &config.APIError{
+				StatusCode: 404,
+				URL:        "https://k8s/api/v1/pods",
+				Message:    "unable to get 'https://k8s/api/v1/pods': not found",
+				Body:       "",
+			},
+			k9eError: &config.APIError{
+				StatusCode: 404,
+				URL:        "https://ka/api/v1/pods",
+				Message:    "unable to get 'https://ka/api/v1/pods': not found",
+				Body:       "",
+			},
+			expectError:   true,
+			errorContains: "no resources found in Kubernetes or KubeArchive",
+		},
+		{
+			name: "kubernetes forbidden, kubearchive not found",
+			k8sError: &config.APIError{
+				StatusCode: 403,
+				URL:        "https://k8s/api/v1/clusterrolebindings",
+				Message:    "clusterrolebindings.rbac.authorization.k8s.io is forbidden: User \"manon\" cannot list resource \"clusterrolebindings\" in API group \"rbac.authorization.k8s.io\" at the cluster scope",
+				Body:       "",
+			},
+			k9eError: &config.APIError{
+				StatusCode: 404,
+				URL:        "https://ka/api/v1/clusterrolebindings",
+				Message:    "unable to get 'https://ka/api/v1/clusterrolebindings': not found",
+				Body:       "",
+			},
+			expectError:   true,
+			errorContains: "clusterrolebindings.rbac.authorization.k8s.io is forbidden: User \"manon\" cannot list resource \"clusterrolebindings\"",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var k8sResponse, k9eResponse string
-			if !tc.expectError || tc.name == "invalid JSON response" || tc.name == "invalid output format" {
+			if !tc.expectError || tc.name == "invalid JSON response" || tc.name == "invalid output format" || tc.name == "no resources found in namespace" || tc.name == "no resources found all namespaces" || tc.name == "deduplication - live cluster priority" {
 				var timestamp string
 				if tc.useDynamicTime {
 					timestamp = time.Now().Add(-5 * time.Minute).Format(time.RFC3339)
@@ -299,7 +442,16 @@ func TestRun(t *testing.T) {
 
 				if tc.name == "invalid JSON response" {
 					k8sResponse = `invalid json`
-					k9eResponse = createPodListJSON("archived-pod-1", timestamp)
+					k9eResponse = `invalid json`
+				} else if tc.name == "no resources found in namespace" || tc.name == "no resources found all namespaces" {
+					// Return empty lists from both APIs
+					k8sResponse = `{"apiVersion": "v1", "kind": "PodList", "metadata": {"resourceVersion": ""}, "items": []}`
+					k9eResponse = `{"apiVersion": "v1", "kind": "PodList", "metadata": {"resourceVersion": ""}, "items": []}`
+				} else if tc.name == "deduplication - live cluster priority" {
+					// Both APIs return the same pod name but with different statuses
+					// The live cluster version should be kept (Running status)
+					k8sResponse = createPodListJSONWithStatus("duplicate-pod", timestamp, "Running")
+					k9eResponse = createPodListJSONWithStatus("duplicate-pod", timestamp, "Succeeded")
 				} else {
 					k8sResponse = createPodListJSON("test-pod-1", timestamp)
 					k9eResponse = createPodListJSON("archived-pod-1", timestamp)
@@ -317,6 +469,11 @@ func TestRun(t *testing.T) {
 			opts := NewTestGetOptions(mockCLI)
 			opts.APIPath = "/api/v1/pods"
 			opts.OutputFormat = &tc.outputFormat
+
+			// Set AllNamespaces flag for the all-namespaces test case
+			if tc.name == "no resources found all namespaces" {
+				opts.AllNamespaces = true
+			}
 
 			var outBuf bytes.Buffer
 			opts.IOStreams = genericiooptions.IOStreams{Out: &outBuf}

--- a/pkg/cmd/testdata/expected_deduplication_output.txt
+++ b/pkg/cmd/testdata/expected_deduplication_output.txt
@@ -1,0 +1,2 @@
+NAME            AGE
+duplicate-pod   5m

--- a/pkg/cmd/testdata/expected_json_output.json
+++ b/pkg/cmd/testdata/expected_json_output.json
@@ -6,8 +6,9 @@
       "kind": "Pod",
       "metadata": {
         "creationTimestamp": "2025-07-08T09:54:00Z",
-        "name": "test-pod-1",
-        "namespace": "default"
+        "name": "archived-pod-1",
+        "namespace": "default",
+        "uid": "archived-pod-1-uid-12345678-1234-1234-1234-123456789abc"
       }
     },
     {
@@ -15,8 +16,9 @@
       "kind": "Pod",
       "metadata": {
         "creationTimestamp": "2025-07-08T09:54:00Z",
-        "name": "archived-pod-1",
-        "namespace": "default"
+        "name": "test-pod-1",
+        "namespace": "default",
+        "uid": "test-pod-1-uid-12345678-1234-1234-1234-123456789abc"
       }
     }
   ],

--- a/pkg/cmd/testdata/expected_table_output.txt
+++ b/pkg/cmd/testdata/expected_table_output.txt
@@ -1,3 +1,3 @@
 NAME             AGE
-test-pod-1       5m
 archived-pod-1   5m
+test-pod-1       5m

--- a/pkg/cmd/testdata/expected_yaml_output.yaml
+++ b/pkg/cmd/testdata/expected_yaml_output.yaml
@@ -7,14 +7,16 @@ items:
     kind: Pod
     metadata:
       creationTimestamp: "2025-07-08T09:54:00Z"
-      name: test-pod-1
+      name: archived-pod-1
       namespace: default
+      uid: archived-pod-1-uid-12345678-1234-1234-1234-123456789abc
   - apiVersion: v1
     kind: Pod
     metadata:
       creationTimestamp: "2025-07-08T09:54:00Z"
-      name: archived-pod-1
+      name: test-pod-1
       namespace: default
+      uid: test-pod-1-uid-12345678-1234-1234-1234-123456789abc
 kind: List
 metadata:
   resourceVersion: ""


### PR DESCRIPTION
Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1379  , resolves #1380, related #227 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Added retrieval of resources by name in CLI
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* Added the retrieval by name
* Added the support for labels (that was already supported for logs)
* Validate if labels and name aren't provided at the same time in both `get` and `logs` commands
* Fine-tune the errors: prevent duplicated errors, show proper errors for unauth and not found cases
* Prevent duplicated resources by uuid, in case of duplication retrieve the Kubernetes resource (not the archived)
* Sort by creationTimestamp by default and use alphabetic name sorting as a secondary criteria
* Fix a bug in the discovery client: we now check if the resources are clusterscoped or not

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
