### PR TITLE
Show information about archived and live resources

### DIFF
--- a/docs/modules/ROOT/pages/cli/usage.adoc
+++ b/docs/modules/ROOT/pages/cli/usage.adoc
@@ -23,7 +23,7 @@ For detailed configuration information, see xref:cli/configuration.adoc[CLI Conf
 
 == get Command
 
-Retrieve Kubernetes resources from both the live cluster and KubeArchive. Results are merged and displayed together.
+Retrieve Kubernetes resources from both the live cluster and KubeArchive. The command merges and displays results together.
 
 === Syntax
 
@@ -34,7 +34,7 @@ kubectl ka get [RESOURCE[.VERSION[.GROUP]]] [flags]
 
 === Resource Specification
 
-Resources can be specified in multiple formats:
+You can specify resources in multiple formats:
 
 * `pods` - Resource name only (discovers version and group automatically)
 * `jobs.batch` - Resource with group (discovers preferred version)
@@ -65,13 +65,28 @@ For example, `pods`, `pod`, `po` resolve to the Pod resource.
 |Label selector to filter resources
 |(none)
 
+|`--in-cluster`
+|Include resources from the live Kubernetes cluster
+|`true`
+
+|`--archived`
+|Include resources from KubeArchive
+|`true`
+
 |===
+
+[NOTE]
+====
+Providing `--in-cluster` shows only in-cluster resources.
+Providing `--archived` shows only archived resources.
+Providing both or neither flag shows all resources.
+====
 
 === Examples
 
 [source,bash]
 ----
-# Get pods from current namespace
+# Get pods from current namespace (shows both live and archived)
 kubectl ka get pods
 
 # Get pods from all namespaces
@@ -82,17 +97,23 @@ kubectl ka get po my-pod -n my-ns -o yaml
 
 # Get deployments with multiple labels
 kubectl ka get deployments -l 'tier=frontend,env in (staging,production)'
+
+# Get only live cluster resources (no archive query)
+kubectl ka get pods --in-cluster
+
+# Get only archived resources (no cluster query)
+kubectl ka get pods --archived
 ----
 
 [NOTE]
 ====
-The plugin merges results from both live cluster and KubeArchive, so you'll see both current and archived resources
-in the output. Archived resources may have different timestamps and status information.
+The plugin merges results from both live cluster and KubeArchive, showing availability indicators for each resource.
+The command deduplicates resources with the same UID from both sources and shows them once with both availability flags set.
 ====
 
 [WARNING]
 ====
-Label selectors (`-l`) cannot be used together with specifying a resource name. Use either a label selector to filter
+You cannot use label selectors (`-l`) together with specifying a resource name. Use either a label selector to filter
 multiple resources (`kubectl ka get pods -l app=nginx`) OR specify a specific resource name
 (`kubectl ka get pod nginx-pod`), but not both.
 ====
@@ -112,13 +133,13 @@ The command supports direct pod logs and logs from resources that own pods (like
 [IMPORTANT]
 ====
 **Pod Selection**: When multiple pods match the search criteria (e.g., from deployments or label selectors),
-the most recent pod will be selected automatically.
+the command automatically selects the most recent pod.
 ====
 
 [WARNING]
 ====
-**Container Selection**: If no container is specified with `-c` and the pod has multiple containers,
-a random container may be selected. Always specify the container name for predictable results.
+**Container Selection**: If you do not specify a container with `-c` and the pod has multiple containers,
+the command may select a random container. Always specify the container name for predictable results.
 ====
 
 [NOTE]
@@ -179,7 +200,7 @@ commands and flags.
 
 [NOTE]
 ====
-Resource names and types are not yet supported for autocompletion.
+Autocompletion does not yet support resource names and types.
 ====
 
 === Syntax

--- a/pkg/cmd/testdata/expected_deduplication_output.txt
+++ b/pkg/cmd/testdata/expected_deduplication_output.txt
@@ -1,2 +1,2 @@
-NAME            AGE
-duplicate-pod   5m
+NAME            IN-CLUSTER   ARCHIVED   AGE
+duplicate-pod   yes          yes        5m

--- a/pkg/cmd/testdata/expected_only_in_archive.txt
+++ b/pkg/cmd/testdata/expected_only_in_archive.txt
@@ -1,0 +1,2 @@
+NAME               IN-CLUSTER   ARCHIVED   AGE
+archive-only-pod   no           yes        5m

--- a/pkg/cmd/testdata/expected_only_in_cluster.txt
+++ b/pkg/cmd/testdata/expected_only_in_cluster.txt
@@ -1,0 +1,2 @@
+NAME               IN-CLUSTER   ARCHIVED   AGE
+cluster-only-pod   yes          no         5m

--- a/pkg/cmd/testdata/expected_table_output.txt
+++ b/pkg/cmd/testdata/expected_table_output.txt
@@ -1,3 +1,3 @@
-NAME             AGE
-archived-pod-1   5m
-test-pod-1       5m
+NAME             IN-CLUSTER   ARCHIVED   AGE
+archived-pod-1   no           yes        5m
+test-pod-1       yes          no         5m


### PR DESCRIPTION
Assisted-by: Cursor AI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1382 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Added `--in-cluster` and `--archived` options to kubectl ka get command.
Added "in cluster" and "archived" columns in standard table output format for kubectl ka get command.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

The output is changed to show if the resource is only available in the cluster, in kubearchive or both.
I've added an `--in-cluster` filter analogue to the `archived` one.

Draft mode until I also include the related docs.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
