### PR TITLE
Add more performant index

### DIFF
--- a/integrations/database/postgresql/migrations/04_btree_name_idx.down.sql
+++ b/integrations/database/postgresql/migrations/04_btree_name_idx.down.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS resource_kind_namespace_idx ON public.resource
+    USING btree (kind, api_version, namespace);
+
+DROP INDEX IF EXISTS resource_kind_namespace_name_idx;
+
+DROP INDEX IF EXISTS name_idx;
+
+CREATE INDEX IF NOT EXISTS name_idx ON resource USING GIN (name gist_trgm_ops);

--- a/integrations/database/postgresql/migrations/04_btree_name_idx.up.sql
+++ b/integrations/database/postgresql/migrations/04_btree_name_idx.up.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS resource_kind_namespace_name_idx ON public.resource
+    USING btree (kind, api_version, namespace, name);
+
+DROP INDEX IF EXISTS resource_kind_namespace_idx;
+
+DROP INDEX IF EXISTS name_idx;
+
+CREATE INDEX IF NOT EXISTS name_idx ON resource USING GIN (name gin_trgm_ops);
+

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubearchive/kubearchive/pkg/database/sql"
 )
 
-var CurrentDatabaseSchemaVersion = "3"
+var CurrentDatabaseSchemaVersion = "4"
 var RegisteredDatabases = map[string]interfaces.Database{
 	"postgresql": sql.NewPostgreSQLDatabase(),
 	"mariadb":    sql.NewMariaDBDatabase(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1459  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Increased performance for resource search by name
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

The index can be created CONCURRENTLY to avoid locking the table but the migration process inherently creates a transaction for each version so it can be rolledback.

Info about CONCURRENTLY: https://www.bytebase.com/blog/postgres-create-index-concurrently/ 

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
