### PR TITLE
Refactor SinkFilter object to separate cluster and local configurations.

### DIFF
--- a/cmd/operator/api/v1/sinkfilter_types.go
+++ b/cmd/operator/api/v1/sinkfilter_types.go
@@ -17,6 +17,7 @@ var SinkFilterGVR = schema.GroupVersionResource{Group: "kubearchive.org", Versio
 // SinkFilterSpec defines the desired state of SinkFilter resource
 type SinkFilterSpec struct {
 	Namespaces map[string][]KubeArchiveConfigResource `json:"namespaces" yaml:"namespaces"`
+	Cluster    []KubeArchiveConfigResource            `json:"cluster,omitempty" yaml:"cluster,omitempty"`
 }
 
 // SinkFilterStatus defines the observed state of SinkFilter resource

--- a/cmd/operator/internal/controller/clusterkubearchiveconfig_controller_test.go
+++ b/cmd/operator/internal/controller/clusterkubearchiveconfig_controller_test.go
@@ -71,11 +71,11 @@ var _ = Describe("KubeArchiveConfig Controller", func() {
 			By("Reconciling the created resource")
 			for _, op := range []string{"create", "add-resource", "remove-resource", "delete"} {
 				By(op)
-				if op == "update-add-resouce" {
+				if op == "add-resource" {
 					Expect(k8sClient.Get(ctx, clusterKACName, ckac)).To(Succeed())
 					ckac.Spec.Resources = append(ckac.Spec.Resources, podResource)
 					Expect(k8sClient.Update(ctx, ckac)).To(Succeed())
-				} else if op == "update-remove-resource" {
+				} else if op == "remove-resource" {
 					Expect(k8sClient.Get(ctx, clusterKACName, ckac)).To(Succeed())
 					ckac.Spec.Resources = []kubearchivev1.KubeArchiveConfigResource{jobResource}
 					Expect(k8sClient.Update(ctx, ckac)).To(Succeed())
@@ -93,18 +93,17 @@ var _ = Describe("KubeArchiveConfig Controller", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				// Check that SinkFilters exists and has the namespace in it.
 				sf := &kubearchivev1.SinkFilter{}
 				err = k8sClient.Get(ctx, installSFName, sf)
 				Expect(err).NotTo(HaveOccurred())
-				if op == "update-add-resouce" {
-					Expect(len(sf.Spec.Namespaces)).To(Equal(2))
-					Expect(sf.Spec.Namespaces).Should(HaveKey(constants.SinkFilterGlobalNamespace))
-				} else if op == "update-remove-resource" {
-					Expect(len(sf.Spec.Namespaces)).To(Equal(1))
-					Expect(sf.Spec.Namespaces).Should(HaveKey(constants.SinkFilterGlobalNamespace))
+				if op == "create" {
+					Expect(len(sf.Spec.Cluster)).To(Equal(1))
+				} else if op == "add-resource" {
+					Expect(len(sf.Spec.Cluster)).To(Equal(2))
+				} else if op == "remove-resource" {
+					Expect(len(sf.Spec.Cluster)).To(Equal(1))
 				} else if op == "delete" {
-					Expect(len(sf.Spec.Namespaces)).To(Equal(0))
+					Expect(len(sf.Spec.Cluster)).To(Equal(0))
 				}
 			}
 		})

--- a/docs/modules/ROOT/pages/design/operator.adoc
+++ b/docs/modules/ROOT/pages/design/operator.adoc
@@ -83,18 +83,20 @@ This type inherits all functionality from `KubeArchiveConfig` but has cluster-wi
 *Short Names:* `sf`, `sfs` +
 *GVR:* `kubearchive.org/v1/sinkfilters`
 
-The `SinkFilter` resource controls dynamic Kubernetes resource watching and CloudEvent generation. It defines which resources should be monitored in specified namespaces and automatically creates watches for those resources.
+The `SinkFilter` resource controls dynamic Kubernetes resource watching and CloudEvent generation. It defines which resources should be monitored, both at the cluster level and in specific namespaces, and automatically creates watches for those resources.
 
 [source,go]
 ----
 type SinkFilterSpec struct {
+    Cluster    []KubeArchiveConfigResource            `json:"cluster,omitempty" yaml:"cluster,omitempty"`
     Namespaces map[string][]KubeArchiveConfigResource `json:"namespaces" yaml:"namespaces"`
 }
 ----
 
 **Fields:**
 
-* `spec.namespaces` - Map of namespace names to resource configurations
+* `spec.cluster` - Array of resource configurations for cluster-wide monitoring (from `ClusterKubeArchiveConfig`)
+* `spec.namespaces` - Map of namespace names to resource configurations (from namespace-scoped `KubeArchiveConfig` resources)
 * Each namespace entry contains an array of `KubeArchiveConfigResource` definitions
 
 **Example:**
@@ -106,21 +108,33 @@ metadata:
   name: sink-filters
   namespace: kubearchive
 spec:
+  cluster:
+  - selector:
+      apiVersion: v1
+      kind: ConfigMap
+    archiveWhen: "true"
+  - selector:
+      apiVersion: v1
+      kind: Secret
+    archiveWhen: "metadata.name != 'default'"
   namespaces:
     "production":
     - selector:
         apiVersion: v1
         kind: Pod
+      archiveWhen: "true"
     - selector:
         apiVersion: apps/v1
         kind: Deployment
-    "___global___":
+      archiveWhen: "true"
+    "staging":
     - selector:
         apiVersion: v1
-        kind: ConfigMap
+        kind: Pod
+      archiveWhen: "object.status.phase == 'Running'"
 ----
 
-NOTE: The special namespace `___global___` indicates cluster-wide resource monitoring.
+NOTE: The `SinkFilter` is automatically managed by the operator. Resources in the `cluster` field are populated from `ClusterKubeArchiveConfig` and apply across all namespaces, while resources in the `namespaces` map are populated from namespace-scoped `KubeArchiveConfig` resources.
 
 === Vacuum Configuration Types
 
@@ -266,13 +280,13 @@ The `ClusterKubeArchiveConfigReconciler` manages cluster-scoped archiving config
    - Creates cluster-level RBAC resources (ClusterRoles and ClusterRoleBindings)
    - Handles cluster-scoped ServiceAccount management
 
-2. **Global SinkFilter Coordination**
-   - Updates `SinkFilter` resources with cluster-wide resource monitoring requirements
-   - Manages the special `___global___` namespace designation for cluster resources
+2. **SinkFilter Cluster Field Management**
+   - Updates the `cluster` field in `SinkFilter` resources with cluster-wide resource monitoring requirements
+   - Maintains separation between cluster-scoped and namespace-scoped configurations
 
 3. **Namespace Integration**
    - Coordinates with namespace-specific configurations
-   - Provides fallback policies for namespaces without specific configurations
+   - Provides global policies that complement namespace-specific configurations
 
 ==== RBAC Permissions
 
@@ -318,11 +332,14 @@ The `SinkFilterReconciler` is the most complex controller, responsible for dynam
 ----
 type WatchInfo struct {
     GVR             schema.GroupVersionResource
-    KindSelector    sourcesv1.APIVersionKindSelector
-    Namespaces      map[string]struct{}
+    KindSelector    kubearchivev1.APIVersionKind
+    ClusterCel      *filters.CelExpressions
+    Namespaces      map[string]filters.CelExpressions
     StopCh          chan struct{}
     WatchInterface  watch.Interface
     ResourceVersion string
+    Queue           workqueue.TypedRateLimitingInterface[watch.Event]
+    WorkerWg        sync.WaitGroup
 }
 ----
 
@@ -330,10 +347,13 @@ type WatchInfo struct {
 
 * `GVR` - GroupVersionResource for the watched resource type
 * `KindSelector` - APIVersion and Kind specification
-* `Namespaces` - Set of namespaces this watch monitors
+* `ClusterCel` - Compiled CEL expressions for cluster-scoped filtering (from `ClusterKubeArchiveConfig`)
+* `Namespaces` - Map of namespace names to their compiled CEL expressions for namespace-scoped filtering
 * `StopCh` - Channel for signaling watch termination
 * `WatchInterface` - Active Kubernetes watch interface
 * `ResourceVersion` - Last processed resource version for efficient resumption
+* `Queue` - Rate-limited workqueue for processing watch events asynchronously
+* `WorkerWg` - WaitGroup for tracking active worker goroutines
 
 ===== Watch Management
 


### PR DESCRIPTION
Assisted-by: Cursor-AI

Split out cluster configuration from namespace configuration in the SinkFilter object.

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1476 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
