### PR TITLE
Fix --archived and --in-cluster CLI flags

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -67,7 +68,7 @@ func NewGetCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := o.Complete(args); err != nil {
+			if err := o.Complete(cmd.Flags(), args); err != nil {
 				return err
 			}
 			return o.Run()
@@ -85,7 +86,7 @@ func NewGetCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *GetOptions) Complete(args []string) error {
+func (o *GetOptions) Complete(flags *pflag.FlagSet, args []string) error {
 	err := o.CompleteRetriever()
 	if err != nil {
 		return err
@@ -104,6 +105,12 @@ func (o *GetOptions) Complete(args []string) error {
 	// Validate that at least one flag is true
 	if !o.InCluster && !o.Archived {
 		return fmt.Errorf("at least one of --in-cluster or --archived must be true")
+	}
+	if flags.Changed("archived") && o.Archived {
+		o.InCluster = false
+	}
+	if flags.Changed("in-cluster") && o.InCluster {
+		o.Archived = false
 	}
 
 	// Parse and resolve resource specification using discovery


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1512  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Fix `--in-cluster` and `--archived` flags used without explicit value
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
