### PR TITLE
Make trace sampling rate configurable

### DIFF
--- a/docs/modules/ROOT/pages/configuration/observability.adoc
+++ b/docs/modules/ROOT/pages/configuration/observability.adoc
@@ -70,14 +70,26 @@ and control the observability behavior:
 ** "enabled": always send traces and metrics. Useful for observability in development.
 ** "delegated": always send metrics but send traces only when the incoming request sent its traces (see
 link:https://www.w3.org/TR/trace-context-2/#sampled-flag[W3 Trace Context `sampled` flag]).
+* `OTEL_TRACES_SAMPLER_ARG`: a floating point number between 0.0 and 1.0 that is used as the sampling rate for
+  traces. If `KUBEARCHIVE_OTEL_MODE` is set to "delegated" the sampling rate is applied to traces where the root span
+  originiates from KubeArchive. Spans for traces started by other services are sent only if the trace is marked as
+  sampled. The default value is 1.0. (see
+link:https://opentelemetry.io/docs/concepts/sampling/[explainer on sampling]).
 Useful for observability in production.
 * `OTEL_EXPORTER_OTLP_ENDPOINT`: an OTLP compatible endpoint where traces are
     sent. By default it is set to an empty string.
 * `KUBEARCHIVE_OTLP_SEND_LOGS`: if set to "true" logs are sent to the
-    `OTEL_EXPOTER_OTLP_ENDPOINT` and not printed to stdout. Defaults to
+    `OTEL_EXPORTER_OTLP_ENDPOINT` and not printed to stdout. Defaults to
     "false", so logs are printed on stdout by default. When enabled, a single log line
     is printed to stdout informing that logs will be redirected.
 
 To change these environment variables values, edit or patch KubeArchive's
 components: `deployments/kubearchive-api-server`, `deployments/kubearchive-sink`
 and `deployments/kubearchive-operator`.
+
+[TIP]
+====
+On clusters with really high activity we recommend setting `KUBEARCHIVE_OTEL_MODE` to "delegated" and
+`OTEL_TRACES_SAMPLER_ARG` to "0.1". With this configuration, only 10% of new traces created by KubeArchive are
+exported, but all traces from requests will respect the sampling decision of the requester.
+====


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1529 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Introduced configuration for Open Telemetry trace sampling using OTEL_TRACES_SAMPLER_ARG environment variable. See https://kubearchive.github.io/kubearchive/main/configuration/observability.html#_configuring_observability for more information
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Adds an environment variable `OTEL_TRACES_SAMPLER_ARG` which if set and `KUBEARCHIVE_OTEL_MODE` is set to delegated will be used for the sampling rate of traces where the root span is created by the operator (any of the controllers), api, or sink. If `KUBEARCHIVE_OTEL_MODE` is set to `enabled` `OTEL_TRACES_SAMPLER_ARG` will set the sampling rate for all spans created by KubeArchive.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
