### PR TITLE
Pass pod name as a resource attribute

### DIFF
--- a/config/templates/api_server/api_server.yaml
+++ b/config/templates/api_server/api_server.yaml
@@ -68,6 +68,10 @@ spec:
               value: "false"
             - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
               value: "false"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/config/templates/operator/operator.yaml
+++ b/config/templates/operator/operator.yaml
@@ -47,6 +47,10 @@ spec:
               value: "false"
             - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
               value: "false"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/config/templates/sink/sink.yaml
+++ b/config/templates/sink/sink.yaml
@@ -61,6 +61,10 @@ spec:
               value: "false"
             - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
               value: "false"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/integrations/observability/grafana/otel-collector-grafana.yaml
+++ b/integrations/observability/grafana/otel-collector-grafana.yaml
@@ -19,6 +19,11 @@ receivers:
 
 processors:
   batch:
+  transform:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["pod"], resource.attributes["k8s.pod.name"])
 
 exporters:
   otlphttp/metrics:
@@ -42,7 +47,7 @@ service:
       exporters: [otlphttp/traces]
     metrics:
       receivers: [otlp, prometheus/collector]
-      processors: [batch]
+      processors: [batch, transform]
       exporters: [otlphttp/metrics]
     logs:
       receivers: [otlp]

--- a/integrations/observability/grafana/resources.yaml
+++ b/integrations/observability/grafana/resources.yaml
@@ -93,9 +93,9 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector:latest
+          image: otel/opentelemetry-collector-contrib:latest
           command:
-            - "/otelcol"
+            - "/otelcol-contrib"
             - "--config=/conf/otel-collector-config.yaml"
           ports:
             - containerPort: 4318

--- a/integrations/observability/prometheus-operator/monitoring-otel-collector.yaml
+++ b/integrations/observability/prometheus-operator/monitoring-otel-collector.yaml
@@ -76,9 +76,9 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
         - name: otel-collector
-          image: quay.io/kubearchive/opentelemetry-collector:0.123.0
+          image: quay.io/kubearchive/opentelemetry-collector-contrib:0.141.0
           command:
-            - '/otelcol'
+            - '/otelcol-contrib'
             - '--config=/conf/otel-collector-config.yaml'
           ports:
             - containerPort: 4318

--- a/integrations/observability/prometheus-operator/otel-collector-config.yaml
+++ b/integrations/observability/prometheus-operator/otel-collector-config.yaml
@@ -9,6 +9,11 @@ receivers:
 
 processors:
   batch:
+  transform:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["pod"], resource.attributes["k8s.pod.name"])
 
 exporters:
   prometheus:
@@ -21,7 +26,7 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [batch, transform]
       exporters: [prometheus]
     traces:
       receivers: [otlp]

--- a/pkg/observability/trace.go
+++ b/pkg/observability/trace.go
@@ -49,6 +49,7 @@ func Start(serviceName string) error {
 		resource.WithFromEnv(),
 		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
+			semconv.K8SPodName(os.Getenv("POD_NAME")),
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1542 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Introduced `k8s.pod.name` as a resource attribute for telemetry. See our integrations/observability folder for examples on how to use it.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

* Our setup with Prometheus make it so we lose the original pod name, this helps with that. When passing the pod name as a resource attribute the Otel collector can promote it to the pod name being pulled by prometheus.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
