### PR TITLE
Fix CEL duration validation in operator

### DIFF
--- a/cmd/operator/api/v1/clusterkubearchiveconfig_webhook_test.go
+++ b/cmd/operator/api/v1/clusterkubearchiveconfig_webhook_test.go
@@ -121,6 +121,28 @@ func TestClusterKubeArchiveConfigValidateDurationString(t *testing.T) {
 			validated:       false,
 			expectedError:   "invalid duration string 'duration('invalid-time')'",
 		},
+		{
+			name:            "Valid duration string with nested parenthesis",
+			archiveWhen:     "duration(string(true ? (41 > 30 ? 720 : 1 * 24) : 120) + \"h\")",
+			deleteWhen:      "",
+			archiveOnDelete: "",
+			validated:       true,
+		},
+		{
+			name:            "Invalid duration string with nested parenthesis",
+			archiveWhen:     "duration(string(true ? (41 > 30 ? 720 : 1 * 24) : 120))",
+			deleteWhen:      "",
+			archiveOnDelete: "",
+			validated:       false,
+			expectedError:   "duration(string(true ? (41 > 30 ? 720 : 1 * 24) : 120))",
+		},
+		{
+			name:            "Valid multiple duration strings with nested parenthesis",
+			archiveWhen:     "duration(string(true ? (41 > 30 ? 720 : 1 * 24) : 120) + \"h\") + duration(string(true ? (41 > 30 ? 720 : 1 * 24) : 120) + \"h\")",
+			deleteWhen:      "",
+			archiveOnDelete: "",
+			validated:       true,
+		},
 	}
 	validator := ClusterKubeArchiveConfigCustomValidator{kubearchiveResourceName: k9eResourceName}
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1562 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Fix bug where operator would reject valid KubeArchiveConfigs ClusterKubeArchiveConfigs when CEL expressions had parenthesis nested inside calls to duration
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Change the logic in the operator's admission webhook from using a regular expression to parsing the duration calls so that it properly handles parenthesis nested in the duration call.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
