### PR TITLE
Change the error returned when no logs are found

### DIFF
--- a/cmd/api/logging/logging.go
+++ b/cmd/api/logging/logging.go
@@ -6,6 +6,7 @@ package logging
 import (
 	"bufio"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -141,9 +142,8 @@ func LogRetrieval() gin.HandlerFunc {
 		}
 
 		if !logsReturned {
-			abort.Abort(c, fmt.Errorf("no parsed logs for the json path: %s from logs in %s",
-				jsonPathParser.String(), logUrl),
-				http.StatusNotFound)
+			slog.Error("no logs on loki", "jsonPath", jsonPathParser.String(), "url", logUrl)
+			abort.Abort(c, errors.New("no logs found for the requested resource"), http.StatusNotFound)
 		}
 	}
 }

--- a/cmd/api/logging/logging_test.go
+++ b/cmd/api/logging/logging_test.go
@@ -104,7 +104,7 @@ func TestLogRetrievalSuccess(t *testing.T) {
 					assert.Equal(t, res.Body.String(), "log-example1\nlog-example2\n")
 				} else {
 					assert.Equal(t, http.StatusNotFound, res.Code)
-					assert.Contains(t, res.Body.String(), "no parsed logs for the json path:")
+					assert.Contains(t, res.Body.String(), "no logs found for the requested resource")
 				}
 			} else {
 				assert.Equal(t, http.StatusNotFound, res.Code)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1450 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Change the error string when logs are not found to a more generic and friendly version.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
