### PR TITLE
Fix token precedence in the CLI

### DIFF
--- a/pkg/cmd/config/testdata/test-config-with-token.yaml
+++ b/pkg/cmd/config/testdata/test-config-with-token.yaml
@@ -1,0 +1,8 @@
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+clusters:
+    test-cluster:
+        server_url: https://test-cluster:6443
+        host: https://kubearchive.test.com
+        token: config-file-token

--- a/pkg/cmd/retriever.go
+++ b/pkg/cmd/retriever.go
@@ -118,6 +118,16 @@ func (opts *KARetrieverOptions) CompleteRetriever() error {
 		opts.token = *opts.kubeFlags.BearerToken
 	}
 
+	// Load token from persistent config if not already set by --token flag or env var
+	if opts.token == "" {
+		cm := config.NewFileConfigManager()
+		if loadErr := cm.LoadConfig(opts.k8sRESTConfig); loadErr == nil {
+			if cc, ccErr := cm.GetCurrentClusterConfig(); ccErr == nil && cc != nil && cc.Token != "" {
+				opts.token = cc.Token
+			}
+		}
+	}
+
 	if opts.token == "" && opts.k8sRESTConfig.BearerToken != "" {
 		opts.token = opts.k8sRESTConfig.BearerToken
 	}

--- a/pkg/cmd/retriever_test.go
+++ b/pkg/cmd/retriever_test.go
@@ -332,6 +332,54 @@ func TestCompleteRetriever(t *testing.T) {
 			expectCertData:      true,
 			expectError:         false,
 		},
+		{ // #nosec G101 - test token
+			name: "token from config file wins over kubeconfig",
+			setup: func(opts *KARetrieverOptions) {
+				opts.host = "https://localhost:8081"
+			},
+			env: map[string]string{
+				"KUBECTL_KA_CONFIG_PATH": filepath.Join("config", "testdata", "test-config-with-token.yaml"),
+			},
+			connectivityFails:   false,
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "config-file-token",
+			expectedK9eInsecure: false,
+			expectCertData:      false,
+			expectError:         false,
+		},
+		{
+			name: "token precedence - env var wins over config file",
+			setup: func(opts *KARetrieverOptions) {
+				opts.host = "https://localhost:8081"
+			},
+			env: map[string]string{
+				"KUBECTL_PLUGIN_KA_TOKEN": "env-token",
+				"KUBECTL_KA_CONFIG_PATH":  filepath.Join("config", "testdata", "test-config-with-token.yaml"),
+			},
+			connectivityFails:   false,
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "env-token",
+			expectedK9eInsecure: false,
+			expectCertData:      false,
+			expectError:         false,
+		},
+		{
+			name: "token precedence - kubectl flag wins over config file",
+			setup: func(opts *KARetrieverOptions) {
+				testToken := "kubectl-token" // #nosec G101 - this is a test token
+				opts.kubeFlags.BearerToken = &testToken
+				opts.host = "https://localhost:8081"
+			},
+			env: map[string]string{
+				"KUBECTL_KA_CONFIG_PATH": filepath.Join("config", "testdata", "test-config-with-token.yaml"),
+			},
+			connectivityFails:   false,
+			expectedK9eHost:     "https://localhost:8081",
+			expectedK9eToken:    "kubectl-token",
+			expectedK9eInsecure: false,
+			expectCertData:      false,
+			expectError:         false,
+		},
 		{
 			name: "certificate error",
 			setup: func(opts *KARetrieverOptions) {


### PR DESCRIPTION
Assisted by: Claude CLI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1780  <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Fixed token priority in CLI. The persisted token is used even if there is a token in kubeconfig file.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
