### PR TITLE
Refactor schema migration process

### DIFF
--- a/config/templates/database/migration_job.yaml
+++ b/config/templates/database/migration_job.yaml
@@ -27,6 +27,9 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+          env:
+            - name: MIGRATION_VERSION
+              value: ""
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials

--- a/integrations/database/postgresql/main.go
+++ b/integrations/database/postgresql/main.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -31,7 +32,16 @@ func main() {
 		panic(err)
 	}
 
-	err = m.Up()
+	if targetVersion := os.Getenv("MIGRATION_VERSION"); targetVersion != "" {
+		v, errParse := strconv.ParseUint(targetVersion, 10, 32)
+		if errParse != nil {
+			panic(fmt.Sprintf("invalid MIGRATION_VERSION %q: %s", targetVersion, errParse))
+		}
+		fmt.Printf("Target migration version requested is %d. Starting migration...\n", v)
+		err = m.Migrate(uint(v))
+	} else {
+		err = m.Up()
+	}
 	if err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		panic(err)
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strconv"
 	"sync"
 
 	"github.com/kubearchive/kubearchive/pkg/database/env"
@@ -15,7 +16,16 @@ import (
 	"github.com/kubearchive/kubearchive/pkg/database/sql"
 )
 
-var CurrentDatabaseSchemaVersion = "4"
+type SchemaVersionRange struct {
+	Min int
+	Max int
+}
+
+var DatabaseSchemaVersions = map[string]SchemaVersionRange{
+	"postgresql": {Min: 4, Max: 4},
+	"mariadb":    {Min: 1, Max: 1},
+}
+
 var RegisteredDatabases = map[string]interfaces.Database{
 	"postgresql": sql.NewPostgreSQLDatabase(),
 	"mariadb":    sql.NewMariaDBDatabase(),
@@ -36,9 +46,7 @@ func newDatabase() (interfaces.Database, error) {
 	var err error
 
 	once.Do(func() {
-		slog.Info("Initializing database connection",
-			"expected_schema_version", CurrentDatabaseSchemaVersion,
-		)
+		slog.Info("Initializing database connection")
 
 		e, errEnv := env.NewDatabaseEnvironment()
 		if errEnv != nil {
@@ -87,23 +95,42 @@ func newDatabase() (interfaces.Database, error) {
 			return
 		}
 
+		versionRange, hasRange := DatabaseSchemaVersions[dbType]
+		if !hasRange {
+			err = fmt.Errorf("no schema version range defined for database type '%s'", dbType)
+			slog.Error("No schema version range defined", "type", dbType)
+			return
+		}
+
+		dbVersionInt, errParse := strconv.Atoi(dbVersion)
+		if errParse != nil {
+			err = fmt.Errorf("invalid database schema version '%s': expected an integer: %w", dbVersion, errParse)
+			slog.Error("Failed to parse database schema version",
+				"version", dbVersion,
+				"error", errParse.Error(),
+			)
+			return
+		}
+
 		slog.Info("Database schema version check",
-			"expected_version", CurrentDatabaseSchemaVersion,
-			"actual_version", dbVersion,
+			"min_version", versionRange.Min,
+			"max_version", versionRange.Max,
+			"actual_version", dbVersionInt,
 		)
 
-		if dbVersion != CurrentDatabaseSchemaVersion {
-			err = fmt.Errorf("expected database schema version '%s', found '%s'", CurrentDatabaseSchemaVersion, dbVersion)
-			slog.Error("Database schema version mismatch",
-				"expected_version", CurrentDatabaseSchemaVersion,
-				"actual_version", dbVersion,
+		if dbVersionInt < versionRange.Min || dbVersionInt > versionRange.Max {
+			err = fmt.Errorf("database schema version %d is outside accepted range [%d, %d]", dbVersionInt, versionRange.Min, versionRange.Max)
+			slog.Error("Database schema version out of range",
+				"actual_version", dbVersionInt,
+				"min_version", versionRange.Min,
+				"max_version", versionRange.Max,
 			)
 			return
 		}
 
 		slog.Info("Database connection fully established",
 			"type", dbType,
-			"schema_version", dbVersion,
+			"schema_version", dbVersionInt,
 			"status", "ready",
 		)
 	})

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -4,7 +4,7 @@
 package database
 
 import (
-	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/kubearchive/kubearchive/pkg/database/fake"
@@ -16,22 +16,34 @@ func TestNewDatabase(t *testing.T) {
 	tests := []struct {
 		name          string
 		schemaVersion string
-		err           error
+		err           string
 	}{
 		{
 			name:          "zero schema version",
 			schemaVersion: "0",
-			err:           fmt.Errorf("expected database schema version '%s', found '0'", CurrentDatabaseSchemaVersion),
+			err:           "database schema version 0 is outside accepted range [4, 4]",
 		},
 		{
 			name:          "current schema version",
-			schemaVersion: CurrentDatabaseSchemaVersion,
-			err:           nil,
+			schemaVersion: "4",
+		},
+		{
+			name:          "version above max",
+			schemaVersion: "5",
+			err:           "database schema version 5 is outside accepted range [4, 4]",
+		},
+		{
+			name:          "non-numeric schema version",
+			schemaVersion: "v9",
+			err:           `invalid database schema version 'v9': expected an integer: strconv.Atoi: parsing "v9": invalid syntax`,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			once = sync.Once{}
+			db = nil
+
 			t.Setenv("DATABASE_KIND", "fake")
 			t.Setenv("DATABASE_DB", "kubearchive")
 			t.Setenv("DATABASE_USER", "kubearchive")
@@ -39,13 +51,14 @@ func TestNewDatabase(t *testing.T) {
 			t.Setenv("DATABASE_URL", "kubearchive")
 			t.Setenv("DATABASE_PORT", "5432")
 
-			db := fake.NewFakeDatabase([]*unstructured.Unstructured{}, []fake.LogUrlRow{}, "jsonPath")
-			db.CurrentSchemaVersion = test.schemaVersion
-			RegisteredDatabases["fake"] = db
+			fakeDB := fake.NewFakeDatabase([]*unstructured.Unstructured{}, []fake.LogUrlRow{}, "jsonPath")
+			fakeDB.CurrentSchemaVersion = test.schemaVersion
+			DatabaseSchemaVersions["fake"] = SchemaVersionRange{Min: 4, Max: 4}
+			RegisteredDatabases["fake"] = fakeDB
 
 			_, err := newDatabase()
-			if test.err != nil {
-				assert.Equal(t, test.err, err)
+			if test.err != "" {
+				assert.EqualError(t, err, test.err)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
Update schema migration job to accept a target version.
Provide a range of schema versions compatible with the codebase.

Assisted by: Claude CLI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1782 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
The schema migration job accepts a target version to do gradual upgrades.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
