### PR TITLE
Fix CLI next page command issues

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -506,7 +506,8 @@ func (o *GetOptions) printPaginationMessage(resources []*ResourceWithAvailabilit
 
 	// Add before timestamp (set to just before the oldest resource's timestamp to avoid including it)
 	// Subtract 1 nanosecond to ensure we don't include the same resource again
-	beforeTimestamp := oldestTimestamp.Add(-1 * time.Nanosecond)
+	// Use UTC to match how Kubernetes stores creation timestamps, ensuring correct string comparison in the DB
+	beforeTimestamp := oldestTimestamp.Add(-1 * time.Nanosecond).UTC()
 	nextCmd.WriteString(fmt.Sprintf(" --before %s", beforeTimestamp.Format(time.RFC3339Nano)))
 
 	// Add after timestamp if originally provided

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -823,8 +823,14 @@ func TestRun(t *testing.T) {
 
 				// Normalize dynamic timestamps in pagination commands for predictable testing
 				if strings.Contains(actualOutput, "--before") {
+					// Verify the --before timestamp is in UTC (ends with Z)
+					re := regexp.MustCompile(`--before (\S+)`)
+					matches := re.FindStringSubmatch(actualOutput)
+					if len(matches) == 2 {
+						assert.True(t, strings.HasSuffix(matches[1], "Z"),
+							"pagination --before timestamp should be in UTC (ending with Z), got: %s", matches[1])
+					}
 					// Replace dynamic timestamp with placeholder for comparison
-					re := regexp.MustCompile(`--before \S+`)
 					actualOutput = re.ReplaceAllString(actualOutput, "--before <timestamp-placeholder>")
 				}
 

--- a/pkg/cmd/retriever.go
+++ b/pkg/cmd/retriever.go
@@ -306,7 +306,9 @@ func (opts *KARetrieverOptions) GetNamespace() (string, error) {
 	return "", fmt.Errorf("unable to retrieve namespace from kubeconfig context")
 }
 
-// ResolveResourceSpec resolves a resource specification using Kubernetes discovery API
+// ResolveResourceSpec resolves a resource specification using Kubernetes discovery API.
+// Supported formats: resource, resource.group, resource.version.group
+// Groups may contain dots (e.g., tekton.dev), so parsing joins remaining parts accordingly.
 func (opts *KARetrieverOptions) ResolveResourceSpec(resourceSpec string) (*ResourceInfo, error) {
 	parts := strings.Split(resourceSpec, ".")
 
@@ -314,23 +316,21 @@ func (opts *KARetrieverOptions) ResolveResourceSpec(resourceSpec string) (*Resou
 		return nil, fmt.Errorf("resource name cannot be empty")
 	}
 
-	if len(parts) > 3 {
-		return nil, fmt.Errorf("invalid resource specification format: %s", resourceSpec)
-	}
-
 	resourceName := parts[0]
 	var requestedVersion, requestedGroup string
 
-	switch len(parts) {
-	case 1:
-		// resource only - need to discover both version and group
-	case 2:
-		// resource.group - need to discover the version for the group
-		requestedGroup = parts[1]
-	case 3:
-		// resource.version.group - everything specified
-		requestedVersion = parts[1]
-		requestedGroup = parts[2]
+	if len(parts) > 1 {
+		// Check if the second part looks like a version (starts with 'v' followed by a digit)
+		if len(parts[1]) >= 2 && parts[1][0] == 'v' && parts[1][1] >= '0' && parts[1][1] <= '9' {
+			// resource.version or resource.version.group (group may contain dots)
+			requestedVersion = parts[1]
+			if len(parts) > 2 {
+				requestedGroup = strings.Join(parts[2:], ".")
+			}
+		} else {
+			// resource.group (group may contain dots)
+			requestedGroup = strings.Join(parts[1:], ".")
+		}
 	}
 
 	// Find the resource using discovery

--- a/pkg/cmd/retriever_test.go
+++ b/pkg/cmd/retriever_test.go
@@ -79,6 +79,16 @@ func newMockDiscoveryClient() *MockDiscoveryClient {
 						Version:      "v1",
 					},
 				},
+				{
+					Name: "tekton.dev",
+					Versions: []metav1.GroupVersionForDiscovery{
+						{GroupVersion: "tekton.dev/v1", Version: "v1"},
+					},
+					PreferredVersion: metav1.GroupVersionForDiscovery{
+						GroupVersion: "tekton.dev/v1",
+						Version:      "v1",
+					},
+				},
 			},
 		},
 		serverResources: map[string]*metav1.APIResourceList{
@@ -145,6 +155,17 @@ func newMockDiscoveryClient() *MockDiscoveryClient {
 						SingularName: "job",
 						Namespaced:   true,
 						Kind:         "Job",
+					},
+				},
+			},
+			"tekton.dev/v1": {
+				GroupVersion: "tekton.dev/v1",
+				APIResources: []metav1.APIResource{
+					{
+						Name:         "pipelineruns",
+						SingularName: "pipelinerun",
+						Namespaced:   true,
+						Kind:         "PipelineRun",
 					},
 				},
 			},
@@ -670,16 +691,42 @@ func TestResolveResourceSpec(t *testing.T) {
 			expectedKind:     "Deployment",
 		},
 		{
+			name:             "dotted group - plural with group",
+			resourceSpec:     "pipelineruns.tekton.dev",
+			expectedResource: "pipelineruns",
+			expectedVersion:  "v1",
+			expectedGroup:    "tekton.dev",
+			expectedKind:     "PipelineRun",
+		},
+		{
+			name:             "dotted group - singular with group",
+			resourceSpec:     "pipelinerun.tekton.dev",
+			expectedResource: "pipelineruns",
+			expectedVersion:  "v1",
+			expectedGroup:    "tekton.dev",
+			expectedKind:     "PipelineRun",
+		},
+		{
+			name:             "dotted group - plural with version and group",
+			resourceSpec:     "pipelineruns.v1.tekton.dev",
+			expectedResource: "pipelineruns",
+			expectedVersion:  "v1",
+			expectedGroup:    "tekton.dev",
+			expectedKind:     "PipelineRun",
+		},
+		{
+			name:             "dotted group - singular with version and group",
+			resourceSpec:     "pipelinerun.v1.tekton.dev",
+			expectedResource: "pipelineruns",
+			expectedVersion:  "v1",
+			expectedGroup:    "tekton.dev",
+			expectedKind:     "PipelineRun",
+		},
+		{
 			name:          "empty resource",
 			resourceSpec:  "",
 			expectError:   true,
 			errorContains: "resource name cannot be empty",
-		},
-		{
-			name:          "too many parts",
-			resourceSpec:  "pods.v1.core.extra",
-			expectError:   true,
-			errorContains: "invalid resource specification format",
 		},
 		{
 			name:          "resource not found",


### PR DESCRIPTION
Ensure --before is on UTC
Fix problems with full resource
format when the group include a dot

Assisted by: Claude CLI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1793 , resolves #1797 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Fix next page message bugs: before is now on UTC to prevent overlapping between pages and large format for resources with a dot in the group are supported
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
