### PR TITLE
Support pagination in logging integration

### DIFF
--- a/cmd/api/logging/logging.go
+++ b/cmd/api/logging/logging.go
@@ -45,12 +45,35 @@ type ProviderConfig struct {
 
 // ApiEndpoint defines how to query a logging backend
 type ApiEndpoint struct {
-	Reverse  bool                   `yaml:"reverse"`
-	Path     string                 `yaml:"path"`
-	Method   string                 `yaml:"method"`
-	Params   map[string]interface{} `yaml:"params"`
-	Body     map[string]interface{} `yaml:"body"`
-	JsonPath string                 `yaml:"json-path"`
+	Reverse    bool                   `yaml:"reverse"`
+	Path       string                 `yaml:"path"`
+	Method     string                 `yaml:"method"`
+	Params     map[string]interface{} `yaml:"params"`
+	Body       map[string]interface{} `yaml:"body"`
+	JsonPath   string                 `yaml:"json-path"`
+	Pagination *PaginationConfig      `yaml:"pagination"`
+	Timeout    string                 `yaml:"timeout"` // Request timeout as a duration string (e.g. "60s", "5m"). Defaults to 60s.
+}
+
+const defaultRequestTimeout = 60 * time.Second
+
+// PaginationConfig defines how to paginate through a logging backend's responses.
+type PaginationConfig struct {
+	NextCursor      string `yaml:"next-cursor"`      // JSONPath to extract cursor values from the response (last match is used)
+	Param           string `yaml:"param"`            // Query parameter to update with the cursor value
+	CursorIncrement int64  `yaml:"cursor-increment"` // Optional increment to apply to integer cursor values
+}
+
+// requestTimeout returns the parsed timeout duration, falling back to the default.
+func (e *ApiEndpoint) requestTimeout() time.Duration {
+	if e.Timeout == "" {
+		return defaultRequestTimeout
+	}
+	d, err := time.ParseDuration(e.Timeout)
+	if err != nil {
+		return defaultRequestTimeout
+	}
+	return d
 }
 
 // validate checks that mandatory fields are set and applies defaults.
@@ -63,6 +86,19 @@ func (e *ApiEndpoint) validate(providerURL, endpointType string) error {
 	}
 	if e.JsonPath == "" {
 		e.JsonPath = "$."
+	}
+	if e.Timeout != "" {
+		if _, err := time.ParseDuration(e.Timeout); err != nil {
+			return fmt.Errorf("provider '%s' endpoint '%s': invalid timeout '%s': %w", providerURL, endpointType, e.Timeout, err)
+		}
+	}
+	if e.Pagination != nil {
+		if e.Pagination.NextCursor == "" {
+			return fmt.Errorf("provider '%s' endpoint '%s' pagination: next-cursor is required", providerURL, endpointType)
+		}
+		if e.Pagination.Param == "" {
+			return fmt.Errorf("provider '%s' endpoint '%s' pagination: param is required", providerURL, endpointType)
+		}
 	}
 	return nil
 }
@@ -334,17 +370,13 @@ func streamLogs(c *gin.Context, reader *bufio.Reader, jsonPathParser jp.Expr, re
 			}
 			return
 		}
-		for _, parsedLine := range parsedLines {
-			if !logsReturned {
-				setLogResponseHeaders(c, record)
-				c.Status(http.StatusOK)
-				logsReturned = true
-			}
-			if _, err := fmt.Fprintln(c.Writer, parsedLine); err != nil { // #nosec G705 -- Content-Type is text/plain
-				slog.ErrorContext(c.Request.Context(), "error writing log line", "error", err)
-				return
-			}
-			c.Writer.Flush()
+		if len(parsedLines) > 0 && !logsReturned {
+			setLogResponseHeaders(c, record)
+			c.Status(http.StatusOK)
+			logsReturned = true
+		}
+		if !writeLogLines(c, parsedLines) {
+			return
 		}
 		if readErr == io.EOF {
 			break
@@ -364,7 +396,7 @@ func LogRetrieval() gin.HandlerFunc {
 	client := http.Client{
 		Transport: otelhttp.NewTransport(&http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}), // #nosec G402
-		Timeout: 60 * time.Second,
+		// No global timeout — per-request timeouts are applied via context using the endpoint's Timeout config.
 	}
 
 	return func(c *gin.Context) {
@@ -466,14 +498,45 @@ func LogRetrieval() gin.HandlerFunc {
 			return
 		}
 
+		// Parse the jsonPath
+		var jsonPathParser jp.Expr
+		if endpoint.JsonPath != "" {
+			var errJP error
+			jsonPathParser, errJP = jp.ParseString(endpoint.JsonPath)
+			if errJP != nil {
+				abort.Abort(c, fmt.Errorf("invalid jsonPath %s: %w", endpoint.JsonPath, errJP), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		tailLinesInt, _ := strconv.Atoi(tailLines)
+
+		// If pagination is configured and we're not tailing or reversing, use paginated streaming
+		if endpoint.Pagination != nil {
+			if tailLinesInt > 0 {
+				slog.Warn("pagination is configured but will be ignored because tailLines is set", "mode", mode, "tailLines", tailLines)
+			} else if endpoint.Reverse {
+				slog.Warn("pagination is configured but will be ignored because reverse is enabled", "mode", mode)
+			} else if legacyFullURL != "" {
+				slog.Warn("pagination is configured but will be ignored for legacy full URLs", "mode", mode)
+			} else {
+				streamPaginatedLogs(c, &client, endpoint, record, extraVars, headers, jsonPathParser, mode)
+				return
+			}
+		}
+
+		// Non-paginated: build and execute a single request
+		reqCtx, reqCancel := context.WithTimeout(c.Request.Context(), endpoint.requestTimeout())
+		defer reqCancel()
+
 		var request *http.Request
 		var errReq error
 		if legacyFullURL != "" {
 			// Legacy full URL: use it as-is instead of interpolating variables
 			// deepcode ignore Server-Side Request Forgery (SSRF): URL comes from the database, originally written by admin-configured sink
-			request, errReq = http.NewRequestWithContext(c.Request.Context(), http.MethodGet, legacyFullURL, nil)
+			request, errReq = http.NewRequestWithContext(reqCtx, http.MethodGet, legacyFullURL, nil)
 		} else {
-			request, errReq = buildProviderRequest(c.Request.Context(), endpoint, record, extraVars)
+			request, errReq = buildProviderRequest(reqCtx, endpoint, record, extraVars)
 		}
 		if errReq != nil {
 			abort.Abort(c, errReq, http.StatusInternalServerError)
@@ -510,25 +573,196 @@ func LogRetrieval() gin.HandlerFunc {
 			return
 		}
 
-		// Parse the jsonPath
-		var jsonPathParser jp.Expr
-		if endpoint.JsonPath != "" {
-			var errJP error
-			jsonPathParser, errJP = jp.ParseString(endpoint.JsonPath)
-			if errJP != nil {
-				abort.Abort(c, fmt.Errorf("invalid jsonPath %s: %w", endpoint.JsonPath, errJP), http.StatusInternalServerError)
-				return
-			}
-		}
-
 		reader := bufio.NewReader(response.Body)
-		tailLinesInt, _ := strconv.Atoi(tailLines)
 
 		if tailLinesInt > 0 || endpoint.Reverse {
 			writeBufferedLogs(c, reader, jsonPathParser, record, requestURL, mode, endpoint.Reverse, tailLinesInt)
 		} else {
 			streamLogs(c, reader, jsonPathParser, record, requestURL, mode)
 		}
+	}
+}
+
+// entriesToStrings converts JSONPath results ([]interface{}) to a slice of non-empty strings.
+func entriesToStrings(entries []interface{}) []string {
+	var results []string
+	for _, entry := range entries {
+		s, ok := entry.(string)
+		if !ok {
+			s = fmt.Sprintf("%v", entry)
+		}
+		if s != "" {
+			results = append(results, s)
+		}
+	}
+	return results
+}
+
+// writeLogLines writes string log lines to the gin response writer and flushes.
+// Returns false if a write error occurred and the caller should stop.
+func writeLogLines(c *gin.Context, lines []string) bool {
+	if len(lines) == 0 {
+		return true
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(c.Writer, line); err != nil { // #nosec G705 -- Content-Type is text/plain
+			slog.ErrorContext(c.Request.Context(), "error writing log line", "error", err)
+			return false
+		}
+	}
+	c.Writer.Flush()
+	return true
+}
+
+// streamPaginatedLogs retrieves logs from a backend that requires pagination.
+// It makes repeated requests, advancing a cursor parameter between pages, and
+// streams each page's entries to the client. Pagination stops when no entries
+// are returned or the cursor stops advancing.
+func streamPaginatedLogs(c *gin.Context, client *http.Client, endpoint *ApiEndpoint, record *interfaces.LogRecord, extraVars map[string]string, providerHeaders map[string]string, jsonPathParser jp.Expr, mode string) {
+	pagination := endpoint.Pagination
+	cursorParser, err := jp.ParseString(pagination.NextCursor)
+	if err != nil {
+		abort.Abort(c, fmt.Errorf("invalid pagination cursor jsonPath %s: %w", pagination.NextCursor, err), http.StatusInternalServerError)
+		return
+	}
+
+	logsReturned := false
+	var lastCursor string
+	timeout := endpoint.requestTimeout()
+
+	for {
+		reqCtx, reqCancel := context.WithTimeout(c.Request.Context(), timeout)
+		request, errReq := buildProviderRequest(reqCtx, endpoint, record, extraVars)
+		if errReq != nil {
+			reqCancel()
+			if logsReturned {
+				slog.ErrorContext(c.Request.Context(), "error building paginated request", "error", errReq)
+			} else {
+				abort.Abort(c, errReq, http.StatusInternalServerError)
+			}
+			return
+		}
+
+		// Override cursor param for subsequent pages
+		if lastCursor != "" {
+			q := request.URL.Query()
+			q.Set(pagination.Param, lastCursor)
+			request.URL.RawQuery = q.Encode()
+		}
+
+		for key, value := range providerHeaders {
+			request.Header.Set(key, value)
+		}
+
+		requestURL := request.URL.String()
+		slog.Info("Sending paginated request to log provider", // #nosec G706 -- URL comes from admin config
+			"request_url", requestURL,
+			"mode", mode,
+			"cursor", lastCursor,
+		)
+
+		response, errReq := client.Do(request) // #nosec G704 -- URL is built from admin-configured LOG_URL and endpoint paths
+		if errReq != nil {
+			reqCancel()
+			if logsReturned {
+				slog.ErrorContext(c.Request.Context(), "error executing paginated request", "error", errReq)
+			} else {
+				abort.Abort(c, errReq, http.StatusInternalServerError)
+			}
+			return
+		}
+
+		body, errRead := io.ReadAll(response.Body)
+		response.Body.Close()
+		reqCancel()
+		if errRead != nil {
+			if logsReturned {
+				slog.ErrorContext(c.Request.Context(), "error reading paginated response", "error", errRead)
+			} else {
+				abort.Abort(c, errRead, http.StatusInternalServerError)
+			}
+			return
+		}
+
+		if response.StatusCode != http.StatusOK {
+			truncatedBody := body
+			if len(truncatedBody) > 1024 {
+				truncatedBody = truncatedBody[:1024]
+			}
+			errMsg := fmt.Errorf("error response: %d - %s", response.StatusCode, truncatedBody)
+			if logsReturned {
+				slog.ErrorContext(c.Request.Context(), "error status in paginated response", "error", errMsg)
+			} else {
+				abort.Abort(c, errMsg, response.StatusCode)
+			}
+			return
+		}
+
+		// Parse the full JSON response
+		parsed, errParse := oj.Parse(body)
+		if errParse != nil {
+			if logsReturned {
+				slog.ErrorContext(c.Request.Context(), "error parsing paginated response JSON", "error", errParse)
+			} else {
+				abort.Abort(c, errParse, http.StatusInternalServerError)
+			}
+			return
+		}
+
+		// Extract log entries
+		lines := entriesToStrings(jsonPathParser.Get(parsed))
+		if len(lines) == 0 {
+			break
+		}
+
+		// Stream entries to client
+		if !logsReturned {
+			setLogResponseHeaders(c, record)
+			c.Status(http.StatusOK)
+			logsReturned = true
+		}
+
+		if !writeLogLines(c, lines) {
+			return
+		}
+
+		slog.Info("Paginated page streamed",
+			"entries", len(lines),
+			"mode", mode,
+		)
+
+		// Extract cursor for next page.
+		// When the response contains multiple streams (e.g. Loki's result[*]),
+		// timestamps are interleaved across streams. We must use the maximum
+		// cursor value to avoid re-fetching entries from earlier streams.
+		cursorResults := cursorParser.Get(parsed)
+		if len(cursorResults) == 0 {
+			break
+		}
+
+		cursor := fmt.Sprintf("%v", cursorResults[0])
+		for _, cr := range cursorResults[1:] {
+			s := fmt.Sprintf("%v", cr)
+			if s > cursor {
+				cursor = s
+			}
+		}
+		if cursor == "" || cursor == lastCursor {
+			break
+		}
+
+		// Apply cursor increment if configured (e.g., +1ns for Loki's inclusive start)
+		if pagination.CursorIncrement != 0 {
+			if cursorInt, errParseInt := strconv.ParseInt(cursor, 10, 64); errParseInt == nil {
+				cursor = strconv.FormatInt(cursorInt+pagination.CursorIncrement, 10)
+			}
+		}
+
+		lastCursor = cursor
+	}
+
+	if !logsReturned {
+		abortNoLogsFound(c, record, "", mode)
 	}
 }
 
@@ -562,15 +796,5 @@ func parseLine(line []byte, jsonPathParser jp.Expr) ([]string, error) {
 		return nil, errJson
 	}
 
-	var results []string
-	for _, res := range jsonPathParser.Get(jsonLine) {
-		s, ok := res.(string)
-		if !ok {
-			s = fmt.Sprintf("%v", res)
-		}
-		if s != "" {
-			results = append(results, s)
-		}
-	}
-	return results, nil
+	return entriesToStrings(jsonPathParser.Get(jsonLine)), nil
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -156,11 +156,11 @@ func main() {
 	httpServer := http.Server{
 		Addr:    "0.0.0.0:8081",
 		Handler: server.router.Handler(),
-		// We do not accept bodies yet, because we are read-only, so we set a
-		// small timeout for headers and complete request. This prevents the
-		// SlowLoris attack (see Wikipedia) by closing open connections fast
+		// ReadHeaderTimeout prevents SlowLoris attacks by closing connections
+		// that take too long to send headers. We intentionally do NOT set
+		// ReadTimeout because it cancels the request context, which would
+		// kill long-running streaming responses (e.g. paginated log retrieval).
 		ReadHeaderTimeout: 2 * time.Second,
-		ReadTimeout:       2 * time.Second,
 	}
 
 	go func() {

--- a/integrations/logging/loki/patch-logging-reader-configmap.yaml
+++ b/integrations/logging/loki/patch-logging-reader-configmap.yaml
@@ -22,9 +22,14 @@ data:
         reverse: false
         path: /loki/api/v1/query_range
         method: GET
+        timeout: 1m
         params:
           query: ${QUERY}
           start: ${START}
-          limit: 10000
+          limit: 300
           direction: forward
         json-path: "$.data.result[*].values[*][1]"
+        pagination:
+          next-cursor: "$.data.result[*].values[*][0]"
+          param: start
+          cursor-increment: 1

--- a/test/integration/logging_test.go
+++ b/test/integration/logging_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubearchive/kubearchive/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -704,6 +705,90 @@ func TestLogTailing(t *testing.T) {
 			})
 			require.NoError(t, retryErr)
 		})
+	}
+}
+
+func TestLargeLogRetrieval(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	port := test.PortForwardApiServer(t, clientset)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	expectedLines := 500000
+	// Create a job that generates 500K log lines using flog with no delay
+	jobName := fmt.Sprintf("large-log-%s", test.RandomString())
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespaceName,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "flog",
+							Command: []string{"flog", "-n", fmt.Sprintf("%d", expectedLines), "-d", "0"},
+							Image:   "quay.io/kubearchive/mingrammer/flog",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := clientset.BatchV1().Jobs(namespaceName).Create(context.Background(), job, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the job to complete before attempting log retrieval
+	test.WaitForJob(t, clientset, namespaceName, jobName)
+	t.Log("Job completed, waiting for logs to be ingested...")
+
+	url := fmt.Sprintf("https://localhost:%s/apis/batch/v1/namespaces/%s/jobs/%s/log", port, namespaceName, jobName)
+	retryErr := retry.New(retry.Attempts(120), retry.MaxDelay(5*time.Second)).Do(func() error {
+		body, err := test.GetLogs(t, token.Status.Token, url)
+		if err != nil {
+			return err
+		}
+
+		if len(body) == 0 {
+			return errors.New("could not retrieve the pod log")
+		}
+
+		bodyString := string(body)
+		lines := strings.Split(strings.TrimSpace(bodyString), "\n")
+		t.Logf("Retrieved %d log lines (%d bytes)", len(lines), len(body))
+		if len(lines) > expectedLines {
+			// More lines than expected — likely duplicates at pagination boundaries.
+			// No point retrying, fail immediately with diagnostics.
+			seen := make(map[string]int, len(lines))
+			for _, line := range lines {
+				seen[line]++
+			}
+			duplicateCount := 0
+			for line, count := range seen {
+				if count > 1 {
+					duplicateCount += count - 1
+					if duplicateCount <= 10 {
+						t.Logf("Duplicate line (%dx): %.100s", count, line)
+					}
+				}
+			}
+			t.Fatalf("Expected %d lines, got %d (unique: %d, duplicates: %d)", expectedLines, len(lines), len(seen), duplicateCount)
+		}
+		if len(lines) != expectedLines {
+			return fmt.Errorf("expected %d lines, got %d", expectedLines, len(lines))
+		}
+		return nil
+	})
+
+	if retryErr != nil {
+		t.Fatal(retryErr)
 	}
 }
 


### PR DESCRIPTION
Assisted by: Claude CLI

<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1802 <!-- , resolves # -->

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
Added support for pagination in logging integration
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->

I've also added the timeout as part of the configurable things in the LOG_PROVIDERS file.
Also, I've tuned the limit per page to 300 because on development environment this was a good number that retrieved the logs within ms. Increasing it to 400 started to timeout.

<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
