### PR TITLE
Add server-side resource count endpoint

### DIFF
--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -4,7 +4,6 @@
 package routers
 
 import (
-	stdctx "context"
 	"errors"
 	"fmt"
 	"io"
@@ -113,10 +112,8 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
-		countCtx, cancel := stdctx.WithTimeout(context.Request.Context(), 30*time.Second)
-		defer cancel()
 		count, err := c.Database.CountResources(
-			countCtx, kind, apiVersion, namespace, name, labelFilters,
+			context.Request.Context(), kind, apiVersion, namespace, name, labelFilters,
 			creationTimestampAfter, creationTimestampBefore)
 		if err != nil {
 			abort.Abort(context, err, http.StatusInternalServerError)

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -112,11 +112,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
-		count, countErr := c.Database.CountResources(
+		count, err := c.Database.CountResources(
 			context.Request.Context(), kind, apiVersion, namespace, name, labelFilters,
 			creationTimestampAfter, creationTimestampBefore)
-		if countErr != nil {
-			abort.Abort(context, countErr, http.StatusInternalServerError)
+		if err != nil {
+			abort.Abort(context, err, http.StatusInternalServerError)
 			return
 		}
 		context.JSON(http.StatusOK, gin.H{"count": count})

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -4,6 +4,7 @@
 package routers
 
 import (
+	stdctx "context"
 	"errors"
 	"fmt"
 	"io"
@@ -112,8 +113,10 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
+		countCtx, cancel := stdctx.WithTimeout(context.Request.Context(), 30*time.Second)
+		defer cancel()
 		count, err := c.Database.CountResources(
-			context.Request.Context(), kind, apiVersion, namespace, name, labelFilters,
+			countCtx, kind, apiVersion, namespace, name, labelFilters,
 			creationTimestampAfter, creationTimestampBefore)
 		if err != nil {
 			abort.Abort(context, err, http.StatusInternalServerError)

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -102,6 +102,27 @@ func (c *Controller) GetResources(context *gin.Context) {
 		apiVersion = fmt.Sprintf("%s/%s", group, version)
 	}
 
+	// Count-only request
+	if context.Query("count") == "true" {
+		if context.Query("limit") != "" {
+			abort.Abort(context, errors.New("cannot use 'limit' with 'count'"), http.StatusBadRequest)
+			return
+		}
+		if context.Query("continue") != "" {
+			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
+			return
+		}
+		count, countErr := c.Database.CountResources(
+			context.Request.Context(), kind, apiVersion, namespace, name, labelFilters,
+			creationTimestampAfter, creationTimestampBefore)
+		if countErr != nil {
+			abort.Abort(context, countErr, http.StatusInternalServerError)
+			return
+		}
+		context.JSON(http.StatusOK, gin.H{"count": count})
+		return
+	}
+
 	// Single resource by exact name - no streaming needed
 	if name != "" && !strings.Contains(name, "*") {
 		var resources []labelFilter.Resource

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -112,11 +112,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
-		count, err := c.Database.CountResources(
+		count, countErr := c.Database.CountResources(
 			context.Request.Context(), kind, apiVersion, namespace, name, labelFilters,
 			creationTimestampAfter, creationTimestampBefore)
-		if err != nil {
-			abort.Abort(context, err, http.StatusInternalServerError)
+		if countErr != nil {
+			abort.Abort(context, countErr, http.StatusInternalServerError)
 			return
 		}
 		context.JSON(http.StatusOK, gin.H{"count": count})

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -778,3 +778,83 @@ func TestTimestampValidationErrorMessages(t *testing.T) {
 		})
 	}
 }
+
+func TestCountResources(t *testing.T) {
+	tests := []struct {
+		name          string
+		api           string
+		isCore        bool
+		expectedCode  int
+		expectedCount int64
+	}{
+		{
+			name:          "count non-core resources",
+			api:           "/apis/stable.example.com/v1/namespaces/test/crontabs?count=true",
+			isCore:        false,
+			expectedCode:  http.StatusOK,
+			expectedCount: int64(len(nonCoreResources)),
+		},
+		{
+			name:          "count core resources",
+			api:           "/api/v1/namespaces/test/pods?count=true",
+			isCore:        true,
+			expectedCode:  http.StatusOK,
+			expectedCount: int64(len(coreResources)),
+		},
+		{
+			name:          "count with no matching resources",
+			api:           "/apis/stable.example.com/v1/namespaces/nonexistent/crontabs?count=true",
+			isCore:        false,
+			expectedCode:  http.StatusOK,
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := setupRouter(fake.NewFakeDatabase(testResources, testLogUrls), tt.isCore)
+			res := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.api, nil)
+			router.ServeHTTP(res, req)
+
+			assert.Equal(t, tt.expectedCode, res.Code)
+			var response map[string]int64
+			err := json.NewDecoder(res.Body).Decode(&response)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedCount, response["count"])
+		})
+	}
+}
+
+func TestCountResourcesWithError(t *testing.T) {
+	router := setupRouter(fake.NewFakeDatabaseWithError(errors.New("database error")), false)
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespaces/test/crontabs?count=true", nil)
+	router.ServeHTTP(res, req)
+	assert.Equal(t, http.StatusInternalServerError, res.Code)
+}
+
+func TestCountResourcesWithInvalidParams(t *testing.T) {
+	router := setupRouter(fake.NewFakeDatabase(testResources, testLogUrls), false)
+	tests := []struct {
+		name string
+		api  string
+	}{
+		{
+			name: "count with limit",
+			api:  "/apis/stable.example.com/v1/namespaces/test/crontabs?count=true&limit=10",
+		},
+		{
+			name: "count with continue",
+			api:  "/apis/stable.example.com/v1/namespaces/test/crontabs?count=true&continue=MSAyMDI1LTAxLTAxVDAwOjAwOjAwWg==",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.api, nil)
+			router.ServeHTTP(res, req)
+			assert.Equal(t, http.StatusBadRequest, res.Code)
+		})
+	}
+}

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -808,6 +808,13 @@ func TestCountResources(t *testing.T) {
 			expectedCode:  http.StatusOK,
 			expectedCount: 0,
 		},
+		{
+			name:          "count with label selector",
+			api:           "/apis/stable.example.com/v1/namespaces/test/crontabs?count=true&labelSelector=app%3Dtest",
+			isCore:        false,
+			expectedCode:  http.StatusOK,
+			expectedCount: int64(len(nonCoreResources)),
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/modules/ROOT/pages/cli/usage.adoc
+++ b/docs/modules/ROOT/pages/cli/usage.adoc
@@ -74,6 +74,22 @@ For example, `pods`, `pod`, `po` resolve to the Pod resource.
 |Include resources from KubeArchive
 |`true`
 
+|`--count`
+|Print only the count of matching resources (KubeArchive only)
+|`false`
+
+|`--limit`
+|Maximum number of resources to return
+|`100`
+
+|`--after`
+|Only return resources created after this timestamp (RFC3339 format)
+|(none)
+
+|`--before`
+|Only return resources created before this timestamp (RFC3339 format)
+|(none)
+
 |===
 
 [NOTE]
@@ -104,6 +120,12 @@ kubectl ka get pods --in-cluster
 
 # Get only archived resources (no cluster query)
 kubectl ka get pods --archived
+
+# Count archived pods matching a label selector
+kubectl ka get pods -l app=nginx --archived --count
+
+# Count archived pods created in the last 30 days
+kubectl ka get pods --after 2023-06-01T00:00:00Z --archived --count
 ----
 
 [NOTE]
@@ -117,6 +139,12 @@ The command deduplicates resources with the same UID from both sources and shows
 You cannot use label selectors (`-l`) together with specifying a resource name. Use either a label selector to filter
 multiple resources (`kubectl ka get pods -l app=nginx`) OR specify a specific resource name
 (`kubectl ka get pod nginx-pod`), but not both.
+====
+
+[NOTE]
+====
+The `--count` flag only works with KubeArchive (`--archived`) and cannot be combined with `--limit` or a specific resource name.
+It prints a single integer to stdout, making it suitable for use in scripts: `COUNT=$(kubectl ka get pods --archived --count)`.
 ====
 
 [TIP]

--- a/docs/modules/ROOT/pages/reference/api.adoc
+++ b/docs/modules/ROOT/pages/reference/api.adoc
@@ -47,13 +47,14 @@ Examples:
 
 Parameters allowed:
 
-* `limit`: defaults to 100. Not higher than 1000. Limits the number of entries returned.
+* `limit`: defaults to 100. Not higher than 1000. Limits the number of entries returned. Cannot be used with `count`.
 * `continue`: token to access the next page of the pagination. Retrieve it at `.metadata.continue`
-of the returned `List` resource. An empty string if there are no more pages remaining.
+of the returned `List` resource. An empty string if there are no more pages remaining. Cannot be used with `count`.
 * `labelSelector`: allows filtering resources based on label filtering.
 * `creationTimestampAfter`: filters resources created after the specified timestamp (RFC3339 format, e.g., `2023-01-01T12:00:00Z`).
 * `creationTimestampBefore`: filters resources created before the specified timestamp (RFC3339 format, e.g., `2023-12-31T23:59:59Z`).
 * `name`: allows filtering resources by name with wildcard support (see Name Filtering section below).
+* `count`: when set to `true`, returns the count of matching resources instead of the resources themselves. Cannot be used with `limit` or `continue`.
 
 === Timestamp Filters
 
@@ -171,6 +172,34 @@ Examples:
 - Cannot specify both path name parameter and query name parameter (returns 400 Bad Request)
 - Wildcard characters (*) are not allowed in path parameters, use query parameters instead (returns 400 Bad Request)
 ====
+
+=== Resource Count
+
+The `count` parameter returns the number of matching resources instead of the resources themselves.
+The response is a JSON object with a single `count` field:
+
+[source,json]
+----
+{"count": 5610}
+----
+
+All filters (`labelSelector`, `creationTimestampAfter`, `creationTimestampBefore`, `name`) can be
+combined with `count`. Pagination parameters (`limit`, `continue`) cannot be used with `count`
+and will return a 400 Bad Request error.
+
+Examples:
+
+[source,text]
+----
+/api/v1/namespaces/default/pods?count=true <1>
+/api/v1/namespaces/default/pods?count=true&labelSelector=app%3Dnginx <2>
+/api/v1/namespaces/default/pods?count=true&creationTimestampAfter=2023-01-01T00:00:00Z <3>
+/api/v1/namespaces/default/pods?count=true&creationTimestampAfter=2023-01-01T00:00:00Z&creationTimestampBefore=2023-12-31T23:59:59Z <4>
+----
+<1> Count all pods in the default namespace
+<2> Count pods matching a label selector
+<3> Count pods created after a specific date
+<4> Count pods created within a date range
 
 == Individual Resources
 

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -148,6 +148,20 @@ func (o *GetOptions) buildKubeArchiveQueryParams() url.Values {
 	return params
 }
 
+func (o *GetOptions) handleCountResponse(bodyBytes []byte, apiErr *APIError) error {
+	if apiErr != nil {
+		return apiErr
+	}
+	var countResponse struct {
+		Count int64 `json:"count"`
+	}
+	if err := json.Unmarshal(bodyBytes, &countResponse); err != nil {
+		return fmt.Errorf("error parsing count response: %w", err)
+	}
+	fmt.Fprintf(o.Out, "%d\n", countResponse.Count)
+	return nil
+}
+
 func (o *GetOptions) Complete(flags *pflag.FlagSet, args []string) error {
 	err := o.CompleteRetriever()
 	if err != nil {
@@ -392,23 +406,8 @@ func (o *GetOptions) Run() error {
 			}
 		}
 
-		// Handle count requests as a distinct branch
 		if o.Count {
-			if apiErr != nil {
-				if apiErr.StatusCode == http.StatusNotFound {
-					fmt.Fprintf(o.Out, "0\n")
-					return nil
-				}
-				return apiErr
-			}
-			var countResponse struct {
-				Count int64 `json:"count"`
-			}
-			if err := json.Unmarshal(bodyBytes, &countResponse); err != nil {
-				return fmt.Errorf("error parsing count response: %w", err)
-			}
-			fmt.Fprintf(o.Out, "%d\n", countResponse.Count)
-			return nil
+			return o.handleCountResponse(bodyBytes, apiErr)
 		}
 
 		if apiErr != nil {

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -26,6 +26,7 @@ type GetOptions struct {
 	genericiooptions.IOStreams
 	KARetrieverCommand
 	AllNamespaces          bool
+	Count                  bool
 	APIPath                string
 	ResourceInfo           *ResourceInfo
 	Name                   string
@@ -102,6 +103,7 @@ func NewGetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().BoolVar(&o.Count, "count", false, "Only print the count of matching resources (KubeArchive only).")
 	cmd.Flags().StringVarP(&o.LabelSelector, "selector", "l", o.LabelSelector, "Selector (label query) to filter on, supports '=', '==', '!=', 'in', 'notin'.(e.g. -l key1=value1,key2=value2,key3 in (value3)). Matching objects must satisfy all of the specified label constraints.")
 	cmd.Flags().BoolVar(&o.InCluster, "in-cluster", true, "Include resources from the Kubernetes cluster.")
 	cmd.Flags().BoolVar(&o.Archived, "archived", true, "Include resources from KubeArchive.")
@@ -131,7 +133,11 @@ func (o *GetOptions) buildKubeArchiveQueryParams() url.Values {
 	}
 
 	// Add KubeArchive-specific parameters
-	params.Set("limit", fmt.Sprintf("%d", o.Limit))
+	if o.Count {
+		params.Set("count", "true")
+	} else {
+		params.Set("limit", fmt.Sprintf("%d", o.Limit))
+	}
 	if !o.After.IsZero() {
 		params.Set("creationTimestampAfter", o.After.Format(time.RFC3339))
 	}
@@ -167,6 +173,20 @@ func (o *GetOptions) Complete(flags *pflag.FlagSet, args []string) error {
 	}
 	if flags.Changed("in-cluster") && o.InCluster {
 		o.Archived = false
+	}
+
+	// --count only works with KubeArchive (Kubernetes API doesn't support server-side counting)
+	if o.Count {
+		if o.Name != "" {
+			return fmt.Errorf("cannot use --count with a specific resource name")
+		}
+		if !o.Archived {
+			return fmt.Errorf("--count requires --archived (Kubernetes API does not support server-side counting)")
+		}
+		if flags.Changed("limit") {
+			return fmt.Errorf("cannot use --count with --limit")
+		}
+		o.InCluster = false
 	}
 
 	// Validate limit
@@ -370,6 +390,28 @@ func (o *GetOptions) Run() error {
 				strings.Contains(apiErr.Message, "authentication failed") {
 				return fmt.Errorf("KubeArchive authentication required: %s", apiErr.Message)
 			}
+		}
+
+		// Handle count requests as a distinct branch
+		if o.Count {
+			if apiErr != nil {
+				if apiErr.StatusCode == http.StatusNotFound {
+					fmt.Fprintf(o.Out, "0\n")
+					return nil
+				}
+				return apiErr
+			}
+			var countResponse struct {
+				Count int64 `json:"count"`
+			}
+			if err := json.Unmarshal(bodyBytes, &countResponse); err != nil {
+				return fmt.Errorf("error parsing count response: %w", err)
+			}
+			fmt.Fprintf(o.Out, "%d\n", countResponse.Count)
+			return nil
+		}
+
+		if apiErr != nil {
 			// If we have k8s resources, continue with those regardless of the error type
 			if len(sortedResources) > 0 {
 				kubearchiveNotFound = true

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -467,9 +467,9 @@ func TestGetComplete(t *testing.T) {
 			expectArchived:  false,
 		},
 		{
-			name:          "count with archived",
-			args:          []string{"pods"},
-			flags:         []string{"--count", "--archived"},
+			name:  "count with archived",
+			args:  []string{"pods"},
+			flags: []string{"--count", "--archived"},
 			resourceInfo: &ResourceInfo{
 				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
 			},

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -439,6 +439,44 @@ func TestGetComplete(t *testing.T) {
 			expectInCluster: true,
 			expectArchived:  true,
 		},
+		{
+			name:            "count with limit",
+			args:            []string{"pods"},
+			flags:           []string{"--count", "--limit=10", "--archived"},
+			expectError:     true,
+			errorContains:   "cannot use --count with --limit",
+			expectInCluster: false,
+			expectArchived:  true,
+		},
+		{
+			name:            "count with name",
+			args:            []string{"pods", "my-pod"},
+			flags:           []string{"--count", "--archived"},
+			expectError:     true,
+			errorContains:   "cannot use --count with a specific resource name",
+			expectInCluster: false,
+			expectArchived:  true,
+		},
+		{
+			name:            "count without archived",
+			args:            []string{"pods"},
+			flags:           []string{"--count", "--in-cluster"},
+			expectError:     true,
+			errorContains:   "--count requires --archived",
+			expectInCluster: true,
+			expectArchived:  false,
+		},
+		{
+			name:          "count with archived",
+			args:          []string{"pods"},
+			flags:         []string{"--count", "--archived"},
+			resourceInfo: &ResourceInfo{
+				Resource: "pods", Version: "v1", Group: "", GroupVersion: "v1", Kind: "Pod", Namespaced: true,
+			},
+			expectedApiPath: "/api/v1/namespaces/default/pods",
+			expectInCluster: false,
+			expectArchived:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -452,6 +490,7 @@ func TestGetComplete(t *testing.T) {
 			cmd := &cobra.Command{}
 			cmd.Flags().BoolVar(&options.InCluster, "in-cluster", true, "")
 			cmd.Flags().BoolVar(&options.Archived, "archived", true, "")
+			cmd.Flags().BoolVar(&options.Count, "count", false, "")
 			cmd.Flags().IntVar(&options.Limit, "limit", 100, "")
 			cmd.Flags().TimeVar(&options.After, "after", time.Time{}, []string{time.RFC3339}, "")
 			cmd.Flags().TimeVar(&options.Before, "before", time.Now().Add(1*time.Hour), []string{time.RFC3339}, "")

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -238,6 +238,17 @@ func (f *fakeDatabase) queryFilteredResources(ctx context.Context, kind, version
 	return resources
 }
 
+func (f *fakeDatabase) CountResources(ctx context.Context, kind, version, namespace, name string,
+	_ *models.LabelFilters,
+	creationTimestampAfter, creationTimestampBefore *time.Time) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	resources := f.queryFilteredResources(ctx, kind, version, namespace, name,
+		"", "", creationTimestampAfter, creationTimestampBefore, 0)
+	return int64(len(resources)), nil
+}
+
 func (f *fakeDatabase) QueryResources(ctx context.Context, kind, version, namespace, name,
 	continueId, continueDate string, _ *models.LabelFilters,
 	creationTimestampAfter, creationTimestampBefore *time.Time, limit int) ([]models.Resource, error) {

--- a/pkg/database/interfaces/database.go
+++ b/pkg/database/interfaces/database.go
@@ -41,6 +41,9 @@ type DBReader interface {
 		name, continueId, continueDate string, labelFilters *models.LabelFilters,
 		creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 		fn func(resource models.Resource) error) error
+	CountResources(ctx context.Context, kind, apiVersion, namespace, name string,
+		labelFilters *models.LabelFilters,
+		creationTimestampAfter, creationTimestampBefore *time.Time) (int64, error)
 	QueryResourceByUID(ctx context.Context, kind, apiVersion, namespace, uid string) (*models.Resource, error)
 	QueryLogURLByName(ctx context.Context, kind, apiVersion, namespace, name, containerName string) (*LogRecord, error)
 	QueryLogURLByUID(ctx context.Context, kind, apiVersion, namespace, uid, containerName string) (*LogRecord, error)

--- a/pkg/database/sql/facade/selector.go
+++ b/pkg/database/sql/facade/selector.go
@@ -8,6 +8,7 @@ import "github.com/huandu/go-sqlbuilder"
 // DBSelector encapsulates all the selector functions that must be implemented by the drivers
 type DBSelector interface {
 	ResourceSelector() *sqlbuilder.SelectBuilder
+	ResourceCountSelector() *sqlbuilder.SelectBuilder
 	UUIDResourceSelector() *sqlbuilder.SelectBuilder
 	OwnedResourceSelector() *sqlbuilder.SelectBuilder
 	UrlFromResourceSelector() *sqlbuilder.SelectBuilder
@@ -18,6 +19,11 @@ type DBSelector interface {
 // PartialDBSelectorImpl implements partially the DBSelector interface
 // with the default selectors with non-specific DBMS functions
 type PartialDBSelectorImpl struct{}
+
+func (PartialDBSelectorImpl) ResourceCountSelector() *sqlbuilder.SelectBuilder {
+	sb := sqlbuilder.NewSelectBuilder()
+	return sb.Select("COUNT(*)").From("resource")
+}
 
 func (PartialDBSelectorImpl) UUIDResourceSelector() *sqlbuilder.SelectBuilder {
 	sb := sqlbuilder.NewSelectBuilder()

--- a/pkg/database/sql/reader.go
+++ b/pkg/database/sql/reader.go
@@ -43,32 +43,30 @@ func (db *sqlDatabaseImpl) QueryResourceByUID(ctx context.Context, kind, apiVers
 	return &resources[0], nil
 }
 
-// buildResourceListQuery builds the SQL select query for listing resources.
-// This is shared between QueryResources and StreamResources.
-func (db *sqlDatabaseImpl) buildResourceListQuery(ctx context.Context, kind, apiVersion, namespace, name,
-	continueId, continueDate string, labelFilters *models.LabelFilters,
-	creationTimestampAfter, creationTimestampBefore *time.Time, limit int) (*sqlbuilder.SelectBuilder, error) {
-	sb := db.selector.ResourceSelector()
+// applyResourceFilters applies common filters (kind, namespace, name, timestamps, labels)
+// to a select builder. Returns true if the query is a list/wildcard query (not an exact name lookup).
+func (db *sqlDatabaseImpl) applyResourceFilters(ctx context.Context, sb *sqlbuilder.SelectBuilder,
+	kind, apiVersion, namespace, name string, labelFilters *models.LabelFilters,
+	creationTimestampAfter, creationTimestampBefore *time.Time) (bool, error) {
 	sb.Where(db.filter.KindApiVersionFilter(sb.Cond, kind, apiVersion))
 	if namespace != "" {
 		sb.Where(db.filter.NamespaceFilter(sb.Cond, namespace))
 	}
 
-	isWildcardQuery := false
+	isListQuery := false
 	if name != "" {
 		if strings.Contains(name, "*") {
 			sqlPattern := strings.ReplaceAll(name, "*", "%")
 			sb.Where(db.filter.NameWildcardFilter(sb.Cond, sqlPattern))
-			isWildcardQuery = true
+			isListQuery = true
 		} else {
 			sb.Where(db.filter.NameFilter(sb.Cond, name))
 		}
+	} else {
+		isListQuery = true
 	}
 
-	if name == "" || isWildcardQuery {
-		if continueId != "" && continueDate != "" {
-			sb.Where(db.filter.CreationTSAndIDFilter(sb.Cond, continueDate, continueId))
-		}
+	if isListQuery {
 		if creationTimestampAfter != nil {
 			sb.Where(db.filter.CreationTimestampAfterFilter(sb.Cond, *creationTimestampAfter))
 		}
@@ -77,13 +75,57 @@ func (db *sqlDatabaseImpl) buildResourceListQuery(ctx context.Context, kind, api
 		}
 		if !labelFilters.IsEmpty() {
 			if err := db.filter.ApplyLabelFilters(ctx, db.db, sb, labelFilters); err != nil {
-				return nil, err
+				return false, err
 			}
+		}
+	}
+
+	return isListQuery, nil
+}
+
+// buildResourceListQuery builds the SQL select query for listing resources.
+// This is shared between QueryResources and StreamResources.
+func (db *sqlDatabaseImpl) buildResourceListQuery(ctx context.Context, kind, apiVersion, namespace, name,
+	continueId, continueDate string, labelFilters *models.LabelFilters,
+	creationTimestampAfter, creationTimestampBefore *time.Time, limit int) (*sqlbuilder.SelectBuilder, error) {
+	sb := db.selector.ResourceSelector()
+	isListQuery, err := db.applyResourceFilters(ctx, sb, kind, apiVersion, namespace, name,
+		labelFilters, creationTimestampAfter, creationTimestampBefore)
+	if err != nil {
+		return nil, err
+	}
+	if isListQuery {
+		if continueId != "" && continueDate != "" {
+			sb.Where(db.filter.CreationTSAndIDFilter(sb.Cond, continueDate, continueId))
 		}
 		sb = db.sorter.CreationTSAndIDSorter(sb)
 		sb.Limit(limit)
 	}
 	return sb, nil
+}
+
+// buildResourceCountQuery builds the SQL count query for counting matching resources.
+func (db *sqlDatabaseImpl) buildResourceCountQuery(ctx context.Context, kind, apiVersion, namespace, name string,
+	labelFilters *models.LabelFilters,
+	creationTimestampAfter, creationTimestampBefore *time.Time) (*sqlbuilder.SelectBuilder, error) {
+	sb := db.selector.ResourceCountSelector()
+	_, err := db.applyResourceFilters(ctx, sb, kind, apiVersion, namespace, name,
+		labelFilters, creationTimestampAfter, creationTimestampBefore)
+	if err != nil {
+		return nil, err
+	}
+	return sb, nil
+}
+
+func (db *sqlDatabaseImpl) CountResources(ctx context.Context, kind, apiVersion, namespace, name string,
+	labelFilters *models.LabelFilters,
+	creationTimestampAfter, creationTimestampBefore *time.Time) (int64, error) {
+	sb, err := db.buildResourceCountQuery(ctx, kind, apiVersion, namespace, name,
+		labelFilters, creationTimestampAfter, creationTimestampBefore)
+	if err != nil {
+		return 0, err
+	}
+	return newQueryPerformer[int64](db.db, db.flavor).performSingleRowQuery(ctx, sb)
 }
 
 func (db *sqlDatabaseImpl) QueryResources(ctx context.Context, kind, apiVersion, namespace, name,

--- a/pkg/database/sql/reader.go
+++ b/pkg/database/sql/reader.go
@@ -44,7 +44,8 @@ func (db *sqlDatabaseImpl) QueryResourceByUID(ctx context.Context, kind, apiVers
 }
 
 // applyResourceFilters applies common filters (kind, namespace, name, timestamps, labels)
-// to a select builder. Returns true if the query is a list/wildcard query (not an exact name lookup).
+// to a select builder. Returns true if the query targets multiple resources (list or wildcard),
+// false for an exact single-resource lookup.
 func (db *sqlDatabaseImpl) applyResourceFilters(ctx context.Context, sb *sqlbuilder.SelectBuilder,
 	kind, apiVersion, namespace, name string, labelFilters *models.LabelFilters,
 	creationTimestampAfter, creationTimestampBefore *time.Time) (bool, error) {
@@ -66,17 +67,15 @@ func (db *sqlDatabaseImpl) applyResourceFilters(ctx context.Context, sb *sqlbuil
 		isListQuery = true
 	}
 
-	if isListQuery {
-		if creationTimestampAfter != nil {
-			sb.Where(db.filter.CreationTimestampAfterFilter(sb.Cond, *creationTimestampAfter))
-		}
-		if creationTimestampBefore != nil {
-			sb.Where(db.filter.CreationTimestampBeforeFilter(sb.Cond, *creationTimestampBefore))
-		}
-		if !labelFilters.IsEmpty() {
-			if err := db.filter.ApplyLabelFilters(ctx, db.db, sb, labelFilters); err != nil {
-				return false, err
-			}
+	if creationTimestampAfter != nil {
+		sb.Where(db.filter.CreationTimestampAfterFilter(sb.Cond, *creationTimestampAfter))
+	}
+	if creationTimestampBefore != nil {
+		sb.Where(db.filter.CreationTimestampBeforeFilter(sb.Cond, *creationTimestampBefore))
+	}
+	if !labelFilters.IsEmpty() {
+		if err := db.filter.ApplyLabelFilters(ctx, db.db, sb, labelFilters); err != nil {
+			return false, err
 		}
 	}
 

--- a/pkg/database/sql/reader_test.go
+++ b/pkg/database/sql/reader_test.go
@@ -999,3 +999,141 @@ func TestQueryResourceByUID(t *testing.T) {
 		})
 	}
 }
+
+func TestCountResources(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := tt.database.getFilter()
+			sb := tt.database.getSelector().ResourceCountSelector()
+			sb.Where(
+				filter.KindApiVersionFilter(sb.Cond, podKind, podApiVersion),
+				filter.NamespaceFilter(sb.Cond, namespace),
+			)
+			query, args := sb.BuildWithFlavor(tt.database.getFlavor())
+
+			for _, ttt := range subtests {
+				t.Run(ttt.name, func(t *testing.T) {
+					db, mock := NewMock()
+					tt.database.setConn(sqlx.NewDb(db, "sqlmock"))
+
+					rows := sqlmock.NewRows([]string{"count"})
+					if ttt.data {
+						rows.AddRow(int64(42))
+					} else {
+						rows.AddRow(int64(0))
+					}
+					mock.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(sliceOfAny2sliceOfValue(args)...).WillReturnRows(rows)
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+					defer cancel()
+
+					count, err := tt.database.CountResources(ctx, podKind, version, namespace,
+						"", &models.LabelFilters{}, nil, nil)
+					assert.NoError(t, err)
+					if ttt.data {
+						assert.Equal(t, int64(42), count)
+					} else {
+						assert.Equal(t, int64(0), count)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCountResourcesWithoutNamespace(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := tt.database.getFilter()
+			sb := tt.database.getSelector().ResourceCountSelector()
+			sb.Where(
+				filter.KindApiVersionFilter(sb.Cond, podKind, podApiVersion),
+			)
+			query, args := sb.BuildWithFlavor(tt.database.getFlavor())
+
+			db, mock := NewMock()
+			tt.database.setConn(sqlx.NewDb(db, "sqlmock"))
+
+			rows := sqlmock.NewRows([]string{"count"})
+			rows.AddRow(int64(10))
+			mock.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(sliceOfAny2sliceOfValue(args)...).WillReturnRows(rows)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			count, err := tt.database.CountResources(ctx, podKind, version, "",
+				"", &models.LabelFilters{}, nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(10), count)
+		})
+	}
+}
+
+func TestCountResourcesWithTimestampFilters(t *testing.T) {
+	timestampTests := []struct {
+		name                    string
+		creationTimestampAfter  *time.Time
+		creationTimestampBefore *time.Time
+	}{
+		{
+			name: "creationTimestampAfter only",
+			creationTimestampAfter: func() *time.Time {
+				t := time.Date(2023, 6, 1, 12, 0, 0, 0, time.UTC)
+				return &t
+			}(),
+		},
+		{
+			name: "creationTimestampBefore only",
+			creationTimestampBefore: func() *time.Time {
+				t := time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC)
+				return &t
+			}(),
+		},
+		{
+			name: "both timestamp filters",
+			creationTimestampAfter: func() *time.Time {
+				t := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+				return &t
+			}(),
+			creationTimestampBefore: func() *time.Time {
+				t := time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC)
+				return &t
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		for _, timestampTest := range timestampTests {
+			t.Run(fmt.Sprintf("%s %s", tt.name, timestampTest.name), func(t *testing.T) {
+				filter := tt.database.getFilter()
+				sb := tt.database.getSelector().ResourceCountSelector()
+				sb.Where(filter.KindApiVersionFilter(sb.Cond, podKind, podApiVersion))
+
+				if timestampTest.creationTimestampAfter != nil {
+					sb.Where(filter.CreationTimestampAfterFilter(sb.Cond, *timestampTest.creationTimestampAfter))
+				}
+				if timestampTest.creationTimestampBefore != nil {
+					sb.Where(filter.CreationTimestampBeforeFilter(sb.Cond, *timestampTest.creationTimestampBefore))
+				}
+
+				query, args := sb.BuildWithFlavor(tt.database.getFlavor())
+				assert.Contains(t, query, "creationTimestamp")
+
+				db, mock := NewMock()
+				tt.database.setConn(sqlx.NewDb(db, "sqlmock"))
+
+				rows := sqlmock.NewRows([]string{"count"})
+				rows.AddRow(int64(5))
+				mock.ExpectQuery(regexp.QuoteMeta(query)).WithArgs(sliceOfAny2sliceOfValue(args)...).WillReturnRows(rows)
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancel()
+
+				count, err := tt.database.CountResources(ctx, podKind, podApiVersion, "", "",
+					&models.LabelFilters{}, timestampTest.creationTimestampAfter, timestampTest.creationTimestampBefore)
+				assert.NoError(t, err)
+				assert.Equal(t, int64(5), count)
+			})
+		}
+	}
+}

--- a/test/integration/count_test.go
+++ b/test/integration/count_test.go
@@ -1,0 +1,147 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v5"
+	"github.com/kubearchive/kubearchive/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type countResponse struct {
+	Count int64 `json:"count"`
+}
+
+func TestCount(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaceName,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "fedora",
+					Command: []string{"sleep", "1"},
+					Image:   "quay.io/fedora/fedora-minimal:latest",
+				},
+			},
+		},
+	}
+
+	expectedCount := 5
+	for i := range expectedCount {
+		pod.SetName("count-pod-" + strconv.Itoa(i))
+		_, err := clientset.CoreV1().Pods(namespaceName).Create(context.Background(), pod, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	port := test.PortForwardApiServer(t, clientset)
+
+	// Wait for all pods to be archived
+	listURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods", port, namespaceName)
+	err := retry.New(retry.Attempts(240), retry.MaxDelay(4*time.Second)).Do(func() error {
+		list, getUrlErr := test.GetUrl(t, token.Status.Token, listURL, map[string][]string{})
+		if getUrlErr != nil {
+			t.Fatal(getUrlErr)
+		}
+		if len(list.Items) >= expectedCount {
+			return nil
+		}
+		return errors.New("waiting for pods to be archived")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test count endpoint
+	countURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods?count=true", port, namespaceName)
+	body, getUrlErr := test.GetRawUrl(t, token.Status.Token, countURL, map[string][]string{})
+	if getUrlErr != nil {
+		t.Fatal(getUrlErr)
+	}
+
+	var result countResponse
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int64(expectedCount), result.Count)
+}
+
+func TestCountWithNoResources(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	port := test.PortForwardApiServer(t, clientset)
+
+	countURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods?count=true", port, namespaceName)
+	body, getUrlErr := test.GetRawUrl(t, token.Status.Token, countURL, map[string][]string{})
+	if getUrlErr != nil {
+		t.Fatal(getUrlErr)
+	}
+
+	var result countResponse
+	err := json.Unmarshal(body, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int64(0), result.Count)
+}
+
+func TestCountRejectsLimitParam(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	port := test.PortForwardApiServer(t, clientset)
+
+	countURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods?count=true&limit=10", port, namespaceName)
+	_, getUrlErr := test.GetRawUrl(t, token.Status.Token, countURL, map[string][]string{})
+	assert.Error(t, getUrlErr)
+	assert.Contains(t, getUrlErr.Error(), "400")
+}
+
+func TestCountRejectsContinueParam(t *testing.T) {
+	t.Parallel()
+
+	clientset, _ := test.GetKubernetesClient(t)
+	namespaceName, token := test.CreateTestNamespace(t, false)
+
+	test.CreateKAC(t, "testdata/kac-with-resources.yaml", namespaceName)
+
+	port := test.PortForwardApiServer(t, clientset)
+
+	countURL := fmt.Sprintf("https://localhost:%s/api/v1/namespaces/%s/pods?count=true&continue=MSAyMDI1LTAxLTAxVDAwOjAwOjAwWg==", port, namespaceName)
+	_, getUrlErr := test.GetRawUrl(t, token.Status.Token, countURL, map[string][]string{})
+	assert.Error(t, getUrlErr)
+	assert.Contains(t, getUrlErr.Error(), "400")
+}

--- a/test/main.go
+++ b/test/main.go
@@ -265,6 +265,11 @@ func GetUrl(t testing.TB, token string, url string, extraHeaders map[string][]st
 	return &data, nil
 }
 
+// GetRawUrl makes an authenticated GET request and returns the raw response body.
+func GetRawUrl(t testing.TB, token string, url string, extraHeaders map[string][]string) ([]byte, error) {
+	return getUrl(t, token, url, extraHeaders)
+}
+
 func GetLogs(t testing.TB, token string, url string) ([]byte, error) {
 	return getUrl(t, token, url, map[string][]string{})
 }


### PR DESCRIPTION
Add a `?count=true` query parameter to the API server and a `--count` flag to the kubectl-ka CLI. When used, the API executes SELECT COUNT(*) instead of fetching full resource data, returning {"count": N}.

This avoids transferring and deserializing all resource data when only the count is needed. All existing filters (labelSelector, timestamp range, namespace, kind) apply unchanged.

## Issue
https://github.com/kubearchive/kubearchive/issues/1829

## Release Note

```release-note
Adds a `count` query parameter to the API and a `--count` flag to the CLI that return the number of matching resources without fetching full resource data. All existing filters (label selectors, timestamp ranges, namespace) apply to count queries.
```

## Notes for Reviewers
This adds server-side counting to avoid the cost of fetching and deserializing full resource data just to get a count. The implementation reuses the
  existing filter pipeline (label selectors, timestamp ranges, namespace/kind scoping) but executes SELECT COUNT(*) instead of SELECT data.

  Key files to review:
  - `pkg/database/sql/reader.go` — `buildResourceCountQuery` and `CountResources` (core logic)
  - `cmd/api/routers/routers.go` — `?count=true` handling in `GetResources`
  - `pkg/cmd/get.go` — `--count` CLI flag and response parsing

  And the PR should be labeled kind/feature.

