### PR TITLE
Make 07_08 migration script resumable

### DIFF
--- a/integrations/database/postgresql/migrations/07_08_populate_label_tables.sh
+++ b/integrations/database/postgresql/migrations/07_08_populate_label_tables.sh
@@ -45,6 +45,16 @@ fi
 
 log "Resource ID range: ${MIN_ID} to ${MAX_ID}"
 
+# Check if a previous run made partial progress by looking at the highest
+# resource_id already recorded in resource_label.
+# shellcheck disable=SC2086
+RESUME_ID=$(psql ${PSQL_OPTS} -c "SELECT COALESCE(MAX(resource_id), 0) FROM resource_label;")
+
+if [ "${RESUME_ID}" -gt "${MIN_ID}" ]; then
+    log "Resuming from resource ID ${RESUME_ID} (previous progress detected)"
+    MIN_ID="${RESUME_ID}"
+fi
+
 # ============================================================================
 # Single-pass batched population of all label tables.
 #


### PR DESCRIPTION
## Which Issue(s) this Pull Request Resolves

Resolves https://github.com/kubearchive/kubearchive/issues/1875

## Release Note

```release-note
The 07_08 label population migration script is now resumable. If interrupted, it resumes from where it left off instead of restarting from the beginning.
```

## Notes for Reviewers

The batch loop in `07_08_populate_label_tables.sh` now checks `MAX(resource_id)` in `resource_label` before starting. If a previous run made partial progress, it resumes from that point instead of restarting from the beginning. `ON CONFLICT DO NOTHING` handles any overlap from re-scanning the tail end of the last batch.