### PR TITLE
Fix migration scripts running before downgrade check

### DIFF
--- a/integrations/database/postgresql/main.go
+++ b/integrations/database/postgresql/main.go
@@ -22,6 +22,13 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
+// migrator abstracts the subset of migrate.Migrate used by the orchestration logic.
+type migrator interface {
+	Version() (uint, bool, error)
+	Migrate(version uint) error
+	Steps(n int) error
+}
+
 // scriptEntry represents a shell script to run after a specific migration version.
 type scriptEntry struct {
 	afterVersion uint
@@ -79,25 +86,37 @@ func main() {
 		slog.Info("Target migration version requested", "version", targetVersion)
 	}
 
-	// Run any scripts for the current version before stepping forward.
-	// This handles the case where a previous run applied a migration but
-	// its script was interrupted. Scripts are idempotent so re-running is safe.
-	currentVersion, _, _ := m.Version()
-	if currentVersion != 0 {
-		slog.Info("Checking for scripts on current version", "version", currentVersion) //nolint:gosec // version is a uint from migrate, not user input
-		if err := runScriptsForVersion(scripts, currentVersion); err != nil {
-			panic(err)
-		}
+	if err := stepMigrationsWithScripts(m, scripts, targetVersion, hasTarget); err != nil {
+		panic(err)
 	}
 
+	slog.Info("Migration completed successfully", "duration", time.Since(start))
+}
+
+// stepMigrationsWithScripts orchestrates migrations one step at a time,
+// running interleaved scripts after each migration. On downgrade it skips
+// scripts and delegates directly to Migrate.
+func stepMigrationsWithScripts(m migrator, scripts []scriptEntry, targetVersion uint, hasTarget bool) error {
+	currentVersion, _, _ := m.Version()
+
 	// If the target version is below the current version, migrate down directly.
+	// Skip scripts — they only apply when migrating up.
 	if hasTarget && currentVersion > targetVersion {
 		slog.Info("Migrating down", "from", currentVersion, "to", targetVersion) //nolint:gosec // versions are uints from migrate, not user input
 		if err := m.Migrate(targetVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-			panic(err)
+			return err
 		}
-		slog.Info("Migration completed successfully", "duration", time.Since(start))
-		return
+		return nil
+	}
+
+	// Run any scripts for the current version before stepping forward.
+	// This handles the case where a previous run applied a migration but
+	// its script was interrupted. Scripts are idempotent so re-running is safe.
+	if currentVersion != 0 {
+		slog.Info("Checking for scripts on current version", "version", currentVersion) //nolint:gosec // version is a uint from migrate, not user input
+		if err := runScriptsForVersion(scripts, currentVersion); err != nil {
+			return err
+		}
 	}
 
 	// Step through migrations one at a time, running scripts after each.
@@ -115,17 +134,17 @@ func main() {
 			break
 		}
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		newVersion, _, _ := m.Version()
 		slog.Info("Migration applied", "version", newVersion, "duration", time.Since(stepStart)) //nolint:gosec // version is a uint from migrate, not user input
 		if err := runScriptsForVersion(scripts, newVersion); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
-	slog.Info("Migration completed successfully", "duration", time.Since(start))
+	return nil
 }
 
 // runMigrations applies migrations using the original simple logic (no script interleaving).
@@ -200,13 +219,16 @@ func runScriptsForVersion(scripts []scriptEntry, version uint) error {
 
 		slog.Info("Running script", "script", s.name)
 		scriptStart := time.Now()
-		if err := executeScript(s.path); err != nil {
+		if err := executeScriptFunc(s.path); err != nil {
 			return fmt.Errorf("script %s failed: %w", s.name, err)
 		}
 		slog.Info("Script completed successfully", "script", s.name, "duration", time.Since(scriptStart))
 	}
 	return nil
 }
+
+// executeScriptFunc runs a shell script. It is a variable so tests can replace it.
+var executeScriptFunc = executeScript
 
 // executeScript runs a shell script, streaming its output to stdout/stderr.
 func executeScript(scriptPath string) error {

--- a/integrations/database/postgresql/main_test.go
+++ b/integrations/database/postgresql/main_test.go
@@ -4,10 +4,128 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// mockMigrator records calls for testing stepMigrationsWithScripts.
+type mockMigrator struct {
+	version      uint
+	migrateCalls []uint
+	stepsCalls   int
+	// versions to step through on successive Steps() calls
+	stepVersions []uint
+	stepIndex    int
+}
+
+func (m *mockMigrator) Version() (uint, bool, error) {
+	return m.version, m.version != 0, nil
+}
+
+func (m *mockMigrator) Migrate(version uint) error {
+	m.migrateCalls = append(m.migrateCalls, version)
+	m.version = version
+	return nil
+}
+
+func (m *mockMigrator) Steps(n int) error {
+	m.stepsCalls++
+	if m.stepIndex >= len(m.stepVersions) {
+		return os.ErrNotExist
+	}
+	m.version = m.stepVersions[m.stepIndex]
+	m.stepIndex++
+	return nil
+}
+
+func TestStepMigrationsWithScripts_DowngradeSkipsScripts(t *testing.T) {
+	mock := &mockMigrator{version: 7}
+
+	scriptRan := false
+	scripts := []scriptEntry{
+		{afterVersion: 7, name: "07_08_populate.sh", path: "/fake/07_08_populate.sh"},
+	}
+
+	origExecuteScript := executeScriptFunc
+	executeScriptFunc = func(path string) error {
+		scriptRan = true
+		return nil
+	}
+	defer func() { executeScriptFunc = origExecuteScript }()
+
+	err := stepMigrationsWithScripts(mock, scripts, 5, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if scriptRan {
+		t.Error("scripts should NOT run during downgrade")
+	}
+
+	if len(mock.migrateCalls) != 1 || mock.migrateCalls[0] != 5 {
+		t.Errorf("expected Migrate(5), got %v", mock.migrateCalls)
+	}
+}
+
+func TestStepMigrationsWithScripts_UpgradeRunsScripts(t *testing.T) {
+	mock := &mockMigrator{
+		version:      7,
+		stepVersions: []uint{8},
+	}
+
+	var scriptsRun []string
+	scripts := []scriptEntry{
+		{afterVersion: 7, name: "07_08_populate.sh", path: "/fake/07_08_populate.sh"},
+		{afterVersion: 8, name: "08_09_index.sh", path: "/fake/08_09_index.sh"},
+	}
+
+	origExecuteScript := executeScriptFunc
+	executeScriptFunc = func(path string) error {
+		scriptsRun = append(scriptsRun, path)
+		return nil
+	}
+	defer func() { executeScriptFunc = origExecuteScript }()
+
+	err := stepMigrationsWithScripts(mock, scripts, 9, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"/fake/07_08_populate.sh", "/fake/08_09_index.sh"}
+	if len(scriptsRun) != len(expected) {
+		t.Fatalf("expected scripts %v, got %v", expected, scriptsRun)
+	}
+	for i, e := range expected {
+		if scriptsRun[i] != e {
+			t.Errorf("script[%d]: expected %q, got %q", i, e, scriptsRun[i])
+		}
+	}
+}
+
+func TestStepMigrationsWithScripts_ScriptFailureStopsMigration(t *testing.T) {
+	mock := &mockMigrator{version: 7}
+
+	scripts := []scriptEntry{
+		{afterVersion: 7, name: "07_08_populate.sh", path: "/fake/07_08_populate.sh"},
+	}
+
+	origExecuteScript := executeScriptFunc
+	executeScriptFunc = func(path string) error {
+		return fmt.Errorf("script crashed")
+	}
+	defer func() { executeScriptFunc = origExecuteScript }()
+
+	err := stepMigrationsWithScripts(mock, scripts, 9, true)
+	if err == nil {
+		t.Fatal("expected error from failed script")
+	}
+
+	if mock.stepsCalls != 0 {
+		t.Error("should not have stepped after script failure")
+	}
+}
 
 func TestDiscoverScripts(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Which Issue(s) this Pull Request Resolves

Resolves https://github.com/kubearchive/kubearchive/issues/1876

## Release Note

```release-note
Fixed a bug where migration scripts (e.g. label population) ran unconditionally before checking the migration direction, causing unnecessary work on downgrades.
```

## Notes for Reviewers

The direction check (`currentVersion > targetVersion`) is now evaluated before running interleaved scripts. On downgrade, the code skips directly to `Migrate()` without executing any scripts.

The orchestration logic was extracted from `main()` into `stepMigrationsWithScripts()` behind a `migrator` interface, enabling unit tests with a mock. Three new tests verify:
- Downgrade skips scripts
- Upgrade runs scripts (both resume and post-step)
- Script failure stops migration