### PR TITLE
Handle new return value from otelsql.RegisterDBStatsMetrics

### DIFF
--- a/pkg/database/sql/connection.go
+++ b/pkg/database/sql/connection.go
@@ -39,7 +39,7 @@ func establishConnection(driver, connectionString string) (*sqlx.DB, error) {
 		return nil, errRetry
 	}
 
-	err = otelsql.RegisterDBStatsMetrics(conn, otelsql.WithAttributes(semconv.DBSystemKey.String(driver)))
+	_, err = otelsql.RegisterDBStatsMetrics(conn, otelsql.WithAttributes(semconv.DBSystemKey.String(driver)))
 	if err != nil {
 		slog.Error("Unable to instrument the DB properly", "error", err.Error())
 		return nil, err


### PR DESCRIPTION
## Summary
- Since otelsql v0.41.0, `RegisterDBStatsMetrics` returns `(metric.Registration, error)` instead of just `error`
- The dependency was already bumped to v0.42.0 on main by Renovate (#1838), but the code was not updated to handle the new signature
- This applies the same fix from #1740 rebased on current main

## Which Issue(s) this Pull Request Resolves

Resolves #1739

Supersedes #1740

## Release Note

```release-note
NONE
```

## Notes for Reviewers

Same fix as #1740 by @ggallen, rebased onto current main (which already has otelsql v0.42.0 via #1838). The go.mod/go.sum changes from #1740 are no longer needed since the dependency bump is already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)