### PR TITLE
Make database schema version range configurable via env vars

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"strconv"
 	"sync"
 
@@ -100,6 +101,19 @@ func newDatabase() (interfaces.Database, error) {
 			err = fmt.Errorf("no schema version range defined for database type '%s'", dbType)
 			slog.Error("No schema version range defined", "type", dbType)
 			return
+		}
+
+		if minStr := os.Getenv("SCHEMA_MIN_VERSION"); minStr != "" {
+			if v, errParse := strconv.Atoi(minStr); errParse == nil {
+				versionRange.Min = v
+				slog.Info("Schema min version overridden by environment", "min", v)
+			}
+		}
+		if maxStr := os.Getenv("SCHEMA_MAX_VERSION"); maxStr != "" {
+			if v, errParse := strconv.Atoi(maxStr); errParse == nil {
+				versionRange.Max = v
+				slog.Info("Schema max version overridden by environment", "max", v)
+			}
 		}
 
 		dbVersionInt, errParse := strconv.Atoi(dbVersion)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -16,6 +16,7 @@ func TestNewDatabase(t *testing.T) {
 	tests := []struct {
 		name          string
 		schemaVersion string
+		envVars       map[string]string
 		err           string
 	}{
 		{
@@ -37,6 +38,27 @@ func TestNewDatabase(t *testing.T) {
 			schemaVersion: "v9",
 			err:           `invalid database schema version 'v9': expected an integer: strconv.Atoi: parsing "v9": invalid syntax`,
 		},
+		{
+			name:          "env var overrides min",
+			schemaVersion: "2",
+			envVars:       map[string]string{"SCHEMA_MIN_VERSION": "2"},
+		},
+		{
+			name:          "env var overrides max",
+			schemaVersion: "6",
+			envVars:       map[string]string{"SCHEMA_MAX_VERSION": "6"},
+		},
+		{
+			name:          "env var narrows range (reject)",
+			schemaVersion: "4",
+			envVars:       map[string]string{"SCHEMA_MAX_VERSION": "3"},
+			err:           "database schema version 4 is outside accepted range [4, 3]",
+		},
+		{
+			name:          "invalid env var ignored",
+			schemaVersion: "4",
+			envVars:       map[string]string{"SCHEMA_MIN_VERSION": "abc"},
+		},
 	}
 
 	for _, test := range tests {
@@ -50,6 +72,10 @@ func TestNewDatabase(t *testing.T) {
 			t.Setenv("DATABASE_PASSWORD", "kubearchive")
 			t.Setenv("DATABASE_URL", "kubearchive")
 			t.Setenv("DATABASE_PORT", "5432")
+
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
 
 			fakeDB := fake.NewFakeDatabase([]*unstructured.Unstructured{}, []fake.LogUrlRow{})
 			fakeDB.CurrentSchemaVersion = test.schemaVersion


### PR DESCRIPTION
## Which Issue(s) this Pull Request Resolves

Resolves https://github.com/kubearchive/kubearchive/issues/1874

## Release Note

```release-note
The database schema version compatibility range can now be overridden via `SCHEMA_MIN_VERSION` and `SCHEMA_MAX_VERSION` environment variables. This allows deployers to widen the accepted range during long-running migrations, preventing api-server and sink pods from rejecting compatible in-progress schema versions.
```

## Notes for Reviewers

After looking up the hardcoded `DatabaseSchemaVersions` range, the code now checks for `SCHEMA_MIN_VERSION` and `SCHEMA_MAX_VERSION` env vars and overrides the min/max accordingly. Invalid values are silently ignored (falls back to hardcoded defaults). Each override is logged individually.

Four new test cases cover: overriding min, overriding max, narrowing the range (rejection), and invalid env var (fallback).