### PR TITLE
Use namespaced query in connectivity test

### DIFF
--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -29,7 +29,7 @@ type MockConnectivityTester struct {
 }
 
 // TestKubeArchiveConnectivity mocks the connectivity test
-func (m *MockConnectivityTester) TestKubeArchiveConnectivity(host string, tlsInsecure bool, token string, caData []byte) error {
+func (m *MockConnectivityTester) TestKubeArchiveConnectivity(host string, tlsInsecure bool, namespace string, token string, caData []byte) error {
 	if m.shouldFail {
 		if m.failError != nil {
 			return m.failError

--- a/pkg/cmd/config/connectivity.go
+++ b/pkg/cmd/config/connectivity.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"k8s.io/client-go/rest"
@@ -14,7 +15,7 @@ import (
 
 // ConnectivityTester defines the interface for testing KubeArchive connectivity.
 type ConnectivityTester interface {
-	TestKubeArchiveConnectivity(host string, tlsInsecure bool, token string, caData []byte) error
+	TestKubeArchiveConnectivity(host string, tlsInsecure bool, namespace string, token string, caData []byte) error
 	TestKubeArchiveLivezEndpoint(host string, tlsInsecure bool, caData []byte) error
 }
 
@@ -22,7 +23,7 @@ type ConnectivityTester interface {
 type DefaultConnectivityTester struct{}
 
 // TestKubeArchiveConnectivity calls the real connectivity test function
-func (d *DefaultConnectivityTester) TestKubeArchiveConnectivity(host string, tlsInsecure bool, token string, caData []byte) error {
+func (d *DefaultConnectivityTester) TestKubeArchiveConnectivity(host string, tlsInsecure bool, namespace string, token string, caData []byte) error {
 	// Create REST config with the provided parameters
 	restConfig := &rest.Config{
 		Host: host,
@@ -45,9 +46,11 @@ func (d *DefaultConnectivityTester) TestKubeArchiveConnectivity(host string, tls
 		return fmt.Errorf("failed to create HTTP client: %w", err)
 	}
 
-	// Test the /api/v1/pods?limit=1 endpoint
+	if namespace == "" {
+		namespace = "default"
+	}
 	base := strings.TrimRight(host, "/")
-	req, err := http.NewRequest(http.MethodGet, base+"/api/v1/pods?limit=1", nil)
+	req, err := http.NewRequest(http.MethodGet, base+"/api/v1/namespaces/"+url.PathEscape(namespace)+"/pods?limit=1", nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/pkg/cmd/config/connectivity_test.go
+++ b/pkg/cmd/config/connectivity_test.go
@@ -1,0 +1,47 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectivityUsesNamespacedEndpoint(t *testing.T) {
+	var requestedPath string
+	var requestedQuery string
+	var authHeader string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		requestedQuery = r.URL.RawQuery
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tester := &DefaultConnectivityTester{}
+	err := tester.TestKubeArchiveConnectivity(server.URL, true, "test-namespace", "fake-token", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/namespaces/test-namespace/pods", requestedPath)
+	assert.Equal(t, "limit=1", requestedQuery)
+	assert.Equal(t, "Bearer fake-token", authHeader)
+}
+
+func TestConnectivityDefaultsToDefaultNamespace(t *testing.T) {
+	var requestedPath string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tester := &DefaultConnectivityTester{}
+	err := tester.TestKubeArchiveConnectivity(server.URL, true, "", "fake-token", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/namespaces/default/pods", requestedPath)
+}

--- a/pkg/cmd/config/interactive.go
+++ b/pkg/cmd/config/interactive.go
@@ -338,7 +338,7 @@ func (is *InteractiveSetup) getTokenForKubeArchive(host string) (string, error) 
 		token = k8sConfig.BearerToken
 	}
 
-	if is.discoverer.connectivityTester.TestKubeArchiveConnectivity(host, true, token, nil) == nil {
+	if is.discoverer.connectivityTester.TestKubeArchiveConnectivity(host, true, is.namespace, token, nil) == nil {
 		return "", nil // empty token is returned for kubectl token
 	}
 

--- a/pkg/cmd/config_set.go
+++ b/pkg/cmd/config_set.go
@@ -253,7 +253,11 @@ func (o *SetOptions) setToken(clusterConfig *config.ClusterConfig, token string)
 
 	// Test token against KubeArchive API if host is configured
 	if clusterConfig.Host != "" {
-		if err := o.tester.TestKubeArchiveConnectivity(clusterConfig.Host, true, token, nil); err != nil {
+		ns, errNs := o.GetNamespace()
+		if errNs != nil {
+			ns = "default"
+		}
+		if err := o.tester.TestKubeArchiveConnectivity(clusterConfig.Host, true, ns, token, nil); err != nil {
 			return fmt.Errorf("token validation failed: %w", err)
 		}
 	}

--- a/pkg/cmd/retriever.go
+++ b/pkg/cmd/retriever.go
@@ -187,12 +187,15 @@ func (opts *KARetrieverOptions) CompleteRetriever() error {
 func (opts *KARetrieverOptions) testConnectivity() error {
 	if opts.host == "" {
 		return fmt.Errorf("no host provided")
-	} else if opts.token == "" {
-		return fmt.Errorf("no token provided")
-	} else if err := opts.connectivityTester.TestKubeArchiveConnectivity(opts.host, opts.tlsInsecure, opts.token, opts.certData); err != nil {
-		return err
 	}
-	return nil
+	if opts.token == "" {
+		return fmt.Errorf("no token provided")
+	}
+	ns, errNs := opts.GetNamespace()
+	if errNs != nil {
+		ns = "default"
+	}
+	return opts.connectivityTester.TestKubeArchiveConnectivity(opts.host, opts.tlsInsecure, ns, opts.token, opts.certData)
 }
 
 // AddRetrieverFlags adds all archive-related flags to the given flag set


### PR DESCRIPTION
## Which Issue(s) this Pull Request Resolves

Resolves #1894

## Release Note

```release-note
Fixed `oc ka config setup` connectivity check timing out on large clusters by using a namespaced query instead of a cluster-scoped one.
```

## Summary

- Change `TestKubeArchiveConnectivity` to use `/api/v1/namespaces/{ns}/pods?limit=1` instead of `/api/v1/pods?limit=1`
- The cluster-scoped query caused ~16min response times on large clusters because it couldn't efficiently use the composite index (`kind, api_version, namespace, creationTimestamp, id`)
- All callers updated to pass a namespace, falling back to `"default"` when unavailable

## Test plan

- [x] New unit tests verify namespaced URL is constructed correctly
- [x] New unit test verifies empty namespace falls back to `"default"`
- [x] All existing tests pass (100+ tests in `pkg/cmd/...`)
- [x] Manual test: `oc ka config setup` on stone-stg-rh01 completes auth check instantly (was timing out at ~16min)

## Notes for Reviewers

The fix scopes the connectivity check to a single namespace instead of querying all pods cluster-wide, which allows PostgreSQL to use the composite index efficiently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)