### PR TITLE
1858 Performance tests fail fix

### DIFF
--- a/test/performance/locustfile.py
+++ b/test/performance/locustfile.py
@@ -6,8 +6,8 @@ from string import Template
 from uuid import uuid4
 from pathlib import Path
 from locust import HttpUser, task
-from cloudevents.http import CloudEvent
-from cloudevents.conversion import to_binary
+from cloudevents.v1.http import CloudEvent
+from cloudevents.v1.conversion import to_binary
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 

--- a/test/performance/requirements.txt
+++ b/test/performance/requirements.txt
@@ -1,2 +1,2 @@
 locust
-cloudevents
+cloudevents>=2

--- a/test/performance/requirements.txt
+++ b/test/performance/requirements.txt
@@ -1,2 +1,2 @@
 locust
-cloudevents<2
+cloudevents

--- a/test/performance/requirements.txt
+++ b/test/performance/requirements.txt
@@ -1,2 +1,2 @@
 locust
-cloudevents
+cloudevents<2

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -38,7 +38,7 @@ sleep 30
 kubectl port-forward -n kubearchive svc/kubearchive-sink 8082:80 &
 SINK_FORWARD_PID=$!
 # This step will take 10 minutes to run. To check if it's still running do: `ps aux | grep locust | grep -v grep`
-./venv/bin/locust -f ${SCRIPT_DIR}/locustfile.py --headless --users 2 -r 2 -t 600s -H https://localhost:8081 --only-summary --processes -1 CreatePods --csv perf-results/create &> perf-results/create.txt
+./venv/bin/locust -f ${SCRIPT_DIR}/locustfile.py --headless --users 2 -r 2 -t 600s -H https://localhost:8081 --only-summary --processes -1 CreatePods --csv perf-results/create |& tee perf-results/create.txt
 kill $SINK_FORWARD_PID
 sleep 30
 END=$(date +%s)
@@ -52,7 +52,7 @@ START=$(date +%s)
 sleep 30
 kubectl port-forward -n kubearchive svc/kubearchive-api-server 8081:8081 &
 SINK_FORWARD_PID=$!
-./venv/bin/locust -f ${SCRIPT_DIR}/locustfile.py --headless --users 2 -r 2 -t 600s -H https://localhost:8081 --only-summary --processes -1 GetPods --csv perf-results/get &> perf-results/get.txt
+./venv/bin/locust -f ${SCRIPT_DIR}/locustfile.py --headless --users 2 -r 2 -t 600s -H https://localhost:8081 --only-summary --processes -1 GetPods --csv perf-results/get |& tee perf-results/get.txt
 kill $SINK_FORWARD_PID
 sleep 30
 END=$(date +%s)


### PR DESCRIPTION
Resolves #1858

```release-note
Fixes ModuleNotFoundError: No module named 'cloudevents.http' for Locust performance test framework
```

## Notes for Reviewers
The latest performance tests are failing on Locust call:

```
+ sleep 30
+ SINK_FORWARD_PID=22169
+ kubectl port-forward -n kubearchive svc/kubearchive-sink 8082:80
+ ./venv/bin/locust -f /home/runner/work/kubearchive/kubearchive/test/performance/locustfile.py --headless --users 2 -r 2 -t 600s -H https://localhost:8081 --only-summary --processes -1 CreatePods --csv perf-results/create
Forwarding from 127.0.0.1:8082 -> 8080
Forwarding from [::1]:8082 -> 8080
Error: Process completed with exit code 1.
```
Which appeared to be caused by the following error:

```
Error: Exit code 1
     Traceback (most recent call last):
       File "<string>", line 1, in <module>
         from cloudevents.v1 import CloudEvent; from cloudevents.v1.conversion import to_binary; print('v1 compat imports work')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ImportError: cannot import name 'CloudEvent' from 'cloudevents.v1' (/tmp/locust-test/lib64/python3.14/site-packages/cloudevents/v1/__init__.py)
```

This fixes the CloudEvent version requirement.