### PR TITLE
Add temporary index on resource.updated_at for label backfill

### DIFF
--- a/integrations/database/postgresql/migrations/09_10_create_updated_at_index.sh
+++ b/integrations/database/postgresql/migrations/09_10_create_updated_at_index.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright KubeArchive Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Create a temporary index on resource.updated_at to speed up the label
+# backfill in migration 10. The index is dropped later in migration 11.
+#
+# This runs as a shell script (not a .sql migration) because
+# CREATE INDEX CONCURRENTLY cannot execute inside a transaction, and
+# golang-migrate wraps multi-statement .sql files in a transaction.
+#
+# Required environment variables:
+#   DATABASE_URL      - PostgreSQL host
+#   DATABASE_PORT     - PostgreSQL port
+#   DATABASE_DB       - Database name
+#   DATABASE_USER     - Database user
+#   DATABASE_PASSWORD - Database password
+
+set -euo pipefail
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*"; }
+
+PGPASSWORD="${DATABASE_PASSWORD}"; export PGPASSWORD
+
+PSQL_OPTS="-h ${DATABASE_URL} -p ${DATABASE_PORT} -U ${DATABASE_USER} -d ${DATABASE_DB}"
+
+log "Creating index on resource.updated_at..."
+
+# Drop any invalid index left by a previously failed CONCURRENTLY build,
+# otherwise IF NOT EXISTS would match the invalid index and skip creation.
+# shellcheck disable=SC2086
+psql ${PSQL_OPTS} -t -A -c "
+  SELECT 1 FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid
+  WHERE c.relname = 'idx_resource_updated_at' AND NOT i.indisvalid;
+" | grep -q 1 && {
+  log "Dropping invalid index idx_resource_updated_at from a previous failed run..."
+  # shellcheck disable=SC2086
+  psql ${PSQL_OPTS} -c "DROP INDEX IF EXISTS idx_resource_updated_at;"
+}
+
+# shellcheck disable=SC2086
+psql ${PSQL_OPTS} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_resource_updated_at ON resource (updated_at);"
+
+log "Index idx_resource_updated_at created."

--- a/integrations/database/postgresql/migrations/09_10_create_updated_at_index.sh
+++ b/integrations/database/postgresql/migrations/09_10_create_updated_at_index.sh
@@ -29,14 +29,16 @@ log "Creating index on resource.updated_at..."
 # Drop any invalid index left by a previously failed CONCURRENTLY build,
 # otherwise IF NOT EXISTS would match the invalid index and skip creation.
 # shellcheck disable=SC2086
-psql ${PSQL_OPTS} -t -A -c "
-  SELECT 1 FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid
+INVALID=$(psql ${PSQL_OPTS} -t -A -c "
+  SELECT count(*) FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid
   WHERE c.relname = 'idx_resource_updated_at' AND NOT i.indisvalid;
-" | grep -q 1 && {
+")
+
+if [ "${INVALID:-0}" -gt 0 ]; then
   log "Dropping invalid index idx_resource_updated_at from a previous failed run..."
   # shellcheck disable=SC2086
   psql ${PSQL_OPTS} -c "DROP INDEX IF EXISTS idx_resource_updated_at;"
-}
+fi
 
 # shellcheck disable=SC2086
 psql ${PSQL_OPTS} -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_resource_updated_at ON resource (updated_at);"

--- a/integrations/database/postgresql/migrations/11_drop_gin_index.up.sql
+++ b/integrations/database/postgresql/migrations/11_drop_gin_index.up.sql
@@ -1,3 +1,6 @@
 -- Drop the legacy GIN index on JSONB labels; queries now use normalized tables.
 -- This takes ACCESS EXCLUSIVE lock on resource but is instant.
 DROP INDEX IF EXISTS idx_json_labels;
+
+-- Drop the temporary index created by 09_10_create_updated_at_index.sh
+DROP INDEX IF EXISTS idx_resource_updated_at;


### PR DESCRIPTION
## Which Issue(s) this Pull Request Resolves

Resolves #1903

## Release Note

```release-note
Improved performance of the label backfill migration (10) on large databases by creating a temporary index on resource.updated_at before the backfill runs.
```

## Notes for Reviewers

The label backfill migration (10) filters on `resource.updated_at` without an index, causing full sequential scans on large databases. This PR adds:

- `09_10_create_updated_at_index.sh`: creates a B-tree index concurrently before migration 10 runs, following the same shell script pattern as `07_08_populate_label_tables.sh`
- A `DROP INDEX` in `11_drop_gin_index.up.sql` to clean up the temporary index after the backfill

The script also handles the PostgreSQL edge case where a failed `CREATE INDEX CONCURRENTLY` leaves an invalid index behind.