### PR TITLE
1927 replace resource label index with covering index

### DIFF
--- a/integrations/database/postgresql/migrations/08_label_resource_constraints.down.sql
+++ b/integrations/database/postgresql/migrations/08_label_resource_constraints.down.sql
@@ -2,4 +2,4 @@ ALTER TABLE resource_label ALTER COLUMN label_id SET STATISTICS -1;
 ALTER TABLE resource_label DROP CONSTRAINT IF EXISTS fk_resource_label_label_id;
 ALTER TABLE label_key_value DROP CONSTRAINT IF EXISTS fk_label_key_value_value_id;
 ALTER TABLE label_key_value DROP CONSTRAINT IF EXISTS fk_label_key_value_key_id;
-DROP INDEX IF EXISTS idx_resource_label_key_value;
+DROP INDEX IF EXISTS idx_resource_label_label_resource;

--- a/integrations/database/postgresql/migrations/08_label_resource_constraints.up.sql
+++ b/integrations/database/postgresql/migrations/08_label_resource_constraints.up.sql
@@ -4,7 +4,7 @@
 -- This runs after the population script has filled all label tables.
 
 -- Index for label lookups (get all resources with a specific label pair)
-CREATE INDEX IF NOT EXISTS idx_resource_label_key_value ON resource_label(label_id);
+CREATE INDEX IF NOT EXISTS idx_resource_label_label_resource ON resource_label(label_id, resource_id);
 
 -- Foreign keys with NOT VALID to avoid scanning/locking referenced tables.
 -- NOT VALID skips validation of existing rows. Future inserts/updates are


### PR DESCRIPTION
Resolves #1927

```release-note
Improved performance of reads with the new DB normalized schema introduced in v1.21. Check how to take advantage of this fix if you have already migrated [here](https://github.com/kubearchive/kubearchive/issues/1927)
```
