### PR TITLE
fix(1928): add configurable statement timeout for database read queries

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -158,26 +158,7 @@ func main() {
 		}
 	}(db)
 
-	queryTimeout := defaultQueryTimeout
-	if s := os.Getenv(queryTimeoutEnvVar); s != "" {
-		d, parseErr := time.ParseDuration(s)
-		if parseErr != nil {
-			slog.Error("invalid query timeout, using default",
-				"env", queryTimeoutEnvVar,
-				"value", s,
-				"default", defaultQueryTimeout,
-				"error", parseErr.Error(),
-			)
-		} else if d <= 0 {
-			slog.Error("invalid query timeout, using default",
-				"env", queryTimeoutEnvVar,
-				"value", s,
-				"default", defaultQueryTimeout,
-			)
-		} else {
-			queryTimeout = d
-		}
-	}
+	queryTimeout := getQueryTimeout()
 	slog.Info("Database query timeout configured", "timeout", queryTimeout)
 
 	controller := routers.Controller{Database: db, CacheConfiguration: *cacheExpirations, QueryTimeout: queryTimeout}
@@ -236,6 +217,30 @@ func main() {
 	// This blocks until the context expires
 	<-ctx.Done()
 	slog.Debug("Shutdown reached timeout")
+}
+
+func getQueryTimeout() time.Duration {
+	queryTimeout := defaultQueryTimeout
+	if s := os.Getenv(queryTimeoutEnvVar); s != "" {
+		d, parseErr := time.ParseDuration(s)
+		if parseErr != nil {
+			slog.Error("invalid query timeout, using default", //nolint:gosec
+				"env", queryTimeoutEnvVar,
+				"value", s,
+				"default", defaultQueryTimeout,
+				"error", parseErr.Error(),
+			)
+		} else if d <= 0 {
+			slog.Error("invalid query timeout, using default", //nolint:gosec
+				"env", queryTimeoutEnvVar,
+				"value", s,
+				"default", defaultQueryTimeout,
+			)
+		} else {
+			queryTimeout = d
+		}
+	}
+	return queryTimeout
 }
 
 func getCacheExpirations() (*routers.CacheExpirations, error) {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -230,7 +230,7 @@ func getQueryTimeout() time.Duration {
 				"default", defaultQueryTimeout,
 				"error", parseErr.Error(),
 			)
-		} else if d <= 0 {
+		} else if d < 0 {
 			slog.Error("invalid query timeout, using default", //nolint:gosec
 				"env", queryTimeoutEnvVar,
 				"value", s,

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -35,6 +35,8 @@ const (
 	otelServiceName                   = "kubearchive.api"
 	cacheExpirationAuthorizedEnvVar   = "CACHE_EXPIRATION_AUTHORIZED"
 	cacheExpirationUnauthorizedEnvVar = "CACHE_EXPIRATION_UNAUTHORIZED"
+	queryTimeoutEnvVar                = "KUBEARCHIVE_QUERY_TIMEOUT"
+	defaultQueryTimeout               = 5 * time.Minute
 )
 
 var (
@@ -156,7 +158,23 @@ func main() {
 		}
 	}(db)
 
-	controller := routers.Controller{Database: db, CacheConfiguration: *cacheExpirations}
+	queryTimeout := defaultQueryTimeout
+	if s := os.Getenv(queryTimeoutEnvVar); s != "" {
+		d, parseErr := time.ParseDuration(s)
+		if parseErr != nil {
+			slog.Error("invalid query timeout, using default",
+				"env", queryTimeoutEnvVar,
+				"value", s,
+				"default", defaultQueryTimeout,
+				"error", parseErr.Error(),
+			)
+		} else {
+			queryTimeout = d
+		}
+	}
+	slog.Info("Database query timeout configured", "timeout", queryTimeout)
+
+	controller := routers.Controller{Database: db, CacheConfiguration: *cacheExpirations, QueryTimeout: queryTimeout}
 	k8sClient, err := k8sclient.NewInstrumentedKubernetesClient()
 	if err != nil {
 		slog.Error("Could not create instrumented kubernetes client", "error", err.Error())

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -168,6 +168,12 @@ func main() {
 				"default", defaultQueryTimeout,
 				"error", parseErr.Error(),
 			)
+		} else if d <= 0 {
+			slog.Error("invalid query timeout, using default",
+				"env", queryTimeoutEnvVar,
+				"value", s,
+				"default", defaultQueryTimeout,
+			)
 		} else {
 			queryTimeout = d
 		}

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -143,7 +143,7 @@ func TestGetQueryTimeout(t *testing.T) {
 		{
 			name:         "zero duration",
 			envValue:     "0s",
-			wantDuration: defaultQueryTimeout,
+			wantDuration: 0,
 		},
 		{
 			name:         "negative duration",

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -21,7 +21,7 @@ func fakeServer(k8sClient kubernetes.Interface, cache *cache.Cache) *Server {
 	if k8sClient == nil {
 		// Replacing deprecated NewSimpleClientset for NewClientset fails because of TokenReview.
 		// It may be related to https://github.com/kubernetes/kubernetes/issues/126850 so keeping deprecated.
-		k8sClient = fakeK8s.NewSimpleClientset() //nolint:staticcheck
+		k8sClient = fakeK8s.NewSimpleClientset() //nolint:staticcheck // needed for TokenReview tests
 	}
 	controller := routers.Controller{Database: fakeDB.NewFakeDatabase(nil, nil)}
 	expirations := &routers.CacheExpirations{Authorized: 1 * time.Second, Unauthorized: 1 * time.Second}
@@ -102,4 +102,70 @@ func TestGetCacheExpirationsWorkingProperly(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 10*time.Second, expirations.Authorized)
 	assert.Equal(t, 10*time.Second, expirations.Unauthorized)
+}
+
+func TestGetQueryTimeout(t *testing.T) {
+	testCases := []struct {
+		name         string
+		envValue     string
+		wantDuration time.Duration
+	}{
+		{
+			name:         "env var not set",
+			envValue:     "",
+			wantDuration: defaultQueryTimeout,
+		},
+		{
+			name:         "valid duration 30s",
+			envValue:     "30s",
+			wantDuration: 30 * time.Second,
+		},
+		{
+			name:         "valid duration 2m",
+			envValue:     "2m",
+			wantDuration: 2 * time.Minute,
+		},
+		{
+			name:         "valid duration 1h",
+			envValue:     "1h",
+			wantDuration: 1 * time.Hour,
+		},
+		{
+			name:         "invalid duration string abc",
+			envValue:     "abc",
+			wantDuration: defaultQueryTimeout,
+		},
+		{
+			name:         "invalid duration string 10",
+			envValue:     "10",
+			wantDuration: defaultQueryTimeout,
+		},
+		{
+			name:         "zero duration",
+			envValue:     "0s",
+			wantDuration: defaultQueryTimeout,
+		},
+		{
+			name:         "negative duration",
+			envValue:     "-5s",
+			wantDuration: defaultQueryTimeout,
+		},
+		{
+			name:         "negative duration minutes",
+			envValue:     "-2m",
+			wantDuration: defaultQueryTimeout,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv(queryTimeoutEnvVar, tc.envValue)
+			}
+
+			got := getQueryTimeout()
+
+			assert.Equal(t, tc.wantDuration, got)
+		})
+	}
 }

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -39,12 +39,12 @@ type Controller struct {
 // database query execution only — not for the full response lifecycle — so that callers which
 // stream results can pass it solely to the initial cursor-open call; returns DeadlineExceeded
 // immediately if the parent context is already expired.
-func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
+func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if c.QueryTimeout <= 0 {
-		return ctx, func() {}, nil
+		return ctx, func() {}
 	}
 	newCtx, cancel := context.WithTimeout(ctx, c.QueryTimeout)
-	return newCtx, cancel, nil
+	return newCtx, cancel
 }
 
 func (c *Controller) GetResources(context *gin.Context) {
@@ -126,11 +126,7 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
-		queryCtx, cancel, queryErr := c.queryContext(context.Request.Context())
-		if queryErr != nil {
-			abort.Abort(context, queryErr, http.StatusGatewayTimeout)
-			return
-		}
+		queryCtx, cancel := c.queryContext(context.Request.Context())
 		defer cancel()
 		count, countErr := c.Database.CountResources(
 			queryCtx, kind, apiVersion, namespace, name, labelFilters,
@@ -150,11 +146,7 @@ func (c *Controller) GetResources(context *gin.Context) {
 
 	// Single resource by exact name - no streaming needed
 	if name != "" && !strings.Contains(name, "*") {
-		queryCtx, cancel, queryErr := c.queryContext(context.Request.Context())
-		if queryErr != nil {
-			abort.Abort(context, queryErr, http.StatusGatewayTimeout)
-			return
-		}
+		queryCtx, cancel := c.queryContext(context.Request.Context())
 		defer cancel()
 		var resources []labelFilter.Resource
 		resources, err = c.Database.QueryResources(
@@ -193,11 +185,7 @@ func (c *Controller) GetResources(context *gin.Context) {
 	w := context.Writer
 
 	reqCtx := context.Request.Context()
-	queryCtx, queryCancel, err := c.queryContext(reqCtx)
-	if err != nil {
-		abort.Abort(context, err, http.StatusGatewayTimeout)
-		return
-	}
+	queryCtx, queryCancel := c.queryContext(reqCtx)
 	defer queryCancel()
 	err = c.Database.StreamResources(
 		queryCtx, reqCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
@@ -295,11 +283,7 @@ func (c *Controller) GetLogURL(context *gin.Context) {
 		apiVersion = fmt.Sprintf("%s/%s", group, version)
 	}
 
-	queryCtx, cancel, err := c.queryContext(context.Request.Context())
-	if err != nil {
-		abort.Abort(context, err, http.StatusGatewayTimeout)
-		return
-	}
+	queryCtx, cancel := c.queryContext(context.Request.Context())
 	defer cancel()
 	var logRecord *interfaces.LogRecord
 	if name != "" {
@@ -348,11 +332,7 @@ func (c *Controller) GetResourceByUID(context *gin.Context) {
 		return
 	}
 
-	queryCtx, cancel, err := c.queryContext(context.Request.Context())
-	if err != nil {
-		abort.Abort(context, err, http.StatusGatewayTimeout)
-		return
-	}
+	queryCtx, cancel := c.queryContext(context.Request.Context())
 	defer cancel()
 	resource, err := c.Database.QueryResourceByUID(queryCtx, kind, apiVersion, namespace, uid)
 	if err != nil {

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -41,7 +41,7 @@ type Controller struct {
 // immediately if the parent context is already expired.
 func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
 	if c.QueryTimeout <= 0 {
-		return ctx, func() {}, errors.New("Query timeout must be greater than zero")
+		return ctx, func() {}, nil
 	}
 	newCtx, cancel := context.WithTimeout(ctx, c.QueryTimeout)
 	return newCtx, cancel, nil
@@ -137,7 +137,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 			creationTimestampAfter, creationTimestampBefore)
 
 		if countErr != nil {
-			abort.Abort(context, countErr, http.StatusInternalServerError)
+			if errors.Is(countErr, dbErrors.ErrQueryTimeout) {
+				abort.Abort(context, countErr, http.StatusGatewayTimeout)
+			} else {
+				abort.Abort(context, countErr, http.StatusInternalServerError)
+			}
 			return
 		}
 		context.JSON(http.StatusOK, gin.H{"count": count})
@@ -157,7 +161,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 			queryCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
 			creationTimestampAfter, creationTimestampBefore, 2)
 		if err != nil {
-			abort.Abort(context, err, http.StatusInternalServerError)
+			if errors.Is(err, dbErrors.ErrQueryTimeout) {
+				abort.Abort(context, err, http.StatusGatewayTimeout)
+			} else {
+				abort.Abort(context, err, http.StatusInternalServerError)
+			}
 			return
 		}
 		if len(resources) == 0 {
@@ -215,7 +223,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 
 	if err != nil {
 		if !headerWritten {
-			abort.Abort(context, err, http.StatusInternalServerError)
+			if errors.Is(err, dbErrors.ErrQueryTimeout) {
+				abort.Abort(context, err, http.StatusGatewayTimeout)
+			} else {
+				abort.Abort(context, err, http.StatusInternalServerError)
+			}
 			return
 		}
 		// Response already started - log the error, client will see truncated JSON
@@ -303,7 +315,11 @@ func (c *Controller) GetLogURL(context *gin.Context) {
 		return
 	}
 	if err != nil {
-		abort.Abort(context, err, http.StatusInternalServerError)
+		if errors.Is(err, dbErrors.ErrQueryTimeout) {
+			abort.Abort(context, err, http.StatusGatewayTimeout)
+		} else {
+			abort.Abort(context, err, http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -340,7 +356,11 @@ func (c *Controller) GetResourceByUID(context *gin.Context) {
 	defer cancel()
 	resource, err := c.Database.QueryResourceByUID(queryCtx, kind, apiVersion, namespace, uid)
 	if err != nil {
-		abort.Abort(context, err, http.StatusInternalServerError)
+		if errors.Is(err, dbErrors.ErrQueryTimeout) {
+			abort.Abort(context, err, http.StatusGatewayTimeout)
+		} else {
+			abort.Abort(context, err, http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -126,9 +126,9 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
-		queryCtx, cancel, err := c.queryContext(context.Request.Context())
-		if err != nil {
-			abort.Abort(context, err, http.StatusGatewayTimeout)
+		queryCtx, cancel, queryErr := c.queryContext(context.Request.Context())
+		if queryErr != nil {
+			abort.Abort(context, queryErr, http.StatusGatewayTimeout)
 			return
 		}
 		defer cancel()
@@ -145,9 +145,9 @@ func (c *Controller) GetResources(context *gin.Context) {
 
 	// Single resource by exact name - no streaming needed
 	if name != "" && !strings.Contains(name, "*") {
-		queryCtx, cancel, err := c.queryContext(context.Request.Context())
-		if err != nil {
-			abort.Abort(context, err, http.StatusGatewayTimeout)
+		queryCtx, cancel, queryErr := c.queryContext(context.Request.Context())
+		if queryErr != nil {
+			abort.Abort(context, queryErr, http.StatusGatewayTimeout)
 			return
 		}
 		defer cancel()

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -184,11 +184,10 @@ func (c *Controller) GetResources(context *gin.Context) {
 	var headerWritten bool
 	w := context.Writer
 
-	reqCtx := context.Request.Context()
-	queryCtx, queryCancel := c.queryContext(reqCtx)
+	queryCtx, queryCancel := c.queryContext(context.Request.Context())
 	defer queryCancel()
 	err = c.Database.StreamResources(
-		queryCtx, reqCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
+		queryCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
 		creationTimestampAfter, creationTimestampBefore, newLimit,
 		func(resource labelFilter.Resource) error {
 			count++

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -4,6 +4,7 @@
 package routers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +32,14 @@ type CacheExpirations struct {
 type Controller struct {
 	Database           interfaces.DBReader
 	CacheConfiguration CacheExpirations
+	QueryTimeout       time.Duration
+}
+
+func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if c.QueryTimeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, c.QueryTimeout)
 }
 
 func (c *Controller) GetResources(context *gin.Context) {
@@ -112,8 +121,10 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
+		queryCtx, cancel := c.queryContext(context.Request.Context())
+		defer cancel()
 		count, countErr := c.Database.CountResources(
-			context.Request.Context(), kind, apiVersion, namespace, name, labelFilters,
+			queryCtx, kind, apiVersion, namespace, name, labelFilters,
 			creationTimestampAfter, creationTimestampBefore)
 		if countErr != nil {
 			abort.Abort(context, countErr, http.StatusInternalServerError)
@@ -125,9 +136,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 
 	// Single resource by exact name - no streaming needed
 	if name != "" && !strings.Contains(name, "*") {
+		queryCtx, cancel := c.queryContext(context.Request.Context())
+		defer cancel()
 		var resources []labelFilter.Resource
 		resources, err = c.Database.QueryResources(
-			context.Request.Context(), kind, apiVersion, namespace, name, id, date, labelFilters,
+			queryCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
 			creationTimestampAfter, creationTimestampBefore, 2)
 		if err != nil {
 			abort.Abort(context, err, http.StatusInternalServerError)
@@ -157,8 +170,10 @@ func (c *Controller) GetResources(context *gin.Context) {
 	var headerWritten bool
 	w := context.Writer
 
+	streamCtx, streamCancel := c.queryContext(context.Request.Context())
+	defer streamCancel()
 	err = c.Database.StreamResources(
-		context.Request.Context(), kind, apiVersion, namespace, name, id, date, labelFilters,
+		streamCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
 		creationTimestampAfter, creationTimestampBefore, newLimit,
 		func(resource labelFilter.Resource) error {
 			count++
@@ -249,13 +264,15 @@ func (c *Controller) GetLogURL(context *gin.Context) {
 		apiVersion = fmt.Sprintf("%s/%s", group, version)
 	}
 
+	queryCtx, cancel := c.queryContext(context.Request.Context())
+	defer cancel()
 	var logRecord *interfaces.LogRecord
 	if name != "" {
 		logRecord, err = c.Database.QueryLogURLByName(
-			context.Request.Context(), kind, apiVersion, namespace, name, containerName)
+			queryCtx, kind, apiVersion, namespace, name, containerName)
 	} else {
 		logRecord, err = c.Database.QueryLogURLByUID(
-			context.Request.Context(), kind, apiVersion, namespace, uid, containerName)
+			queryCtx, kind, apiVersion, namespace, uid, containerName)
 	}
 
 	if errors.Is(err, dbErrors.ErrResourceNotFound) {
@@ -292,7 +309,9 @@ func (c *Controller) GetResourceByUID(context *gin.Context) {
 		return
 	}
 
-	resource, err := c.Database.QueryResourceByUID(context.Request.Context(), kind, apiVersion, namespace, uid)
+	queryCtx, cancel := c.queryContext(context.Request.Context())
+	defer cancel()
+	resource, err := c.Database.QueryResourceByUID(queryCtx, kind, apiVersion, namespace, uid)
 	if err != nil {
 		abort.Abort(context, err, http.StatusInternalServerError)
 		return

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -40,8 +40,8 @@ type Controller struct {
 // stream results can pass it solely to the initial cursor-open call; returns DeadlineExceeded
 // immediately if the parent context is already expired.
 func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return nil, func() {}, context.DeadlineExceeded
+	if c.QueryTimeout <= 0 {
+		return ctx, func() {}, nil
 	}
 	newCtx, cancel := context.WithTimeout(ctx, c.QueryTimeout)
 	return newCtx, cancel, nil
@@ -135,6 +135,7 @@ func (c *Controller) GetResources(context *gin.Context) {
 		count, countErr := c.Database.CountResources(
 			queryCtx, kind, apiVersion, namespace, name, labelFilters,
 			creationTimestampAfter, creationTimestampBefore)
+
 		if countErr != nil {
 			abort.Abort(context, countErr, http.StatusInternalServerError)
 			return

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -35,11 +35,16 @@ type Controller struct {
 	QueryTimeout       time.Duration
 }
 
-func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if c.QueryTimeout <= 0 {
-		return context.WithCancel(ctx)
+// queryContext creates a child context bounded by the configured QueryTimeout for use during
+// database query execution only — not for the full response lifecycle — so that callers which
+// stream results can pass it solely to the initial cursor-open call; returns DeadlineExceeded
+// immediately if the parent context is already expired.
+func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return nil, func() {}, context.DeadlineExceeded
 	}
-	return context.WithTimeout(ctx, c.QueryTimeout)
+	newCtx, cancel := context.WithTimeout(ctx, c.QueryTimeout)
+	return newCtx, cancel, nil
 }
 
 func (c *Controller) GetResources(context *gin.Context) {
@@ -121,7 +126,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 			abort.Abort(context, errors.New("cannot use 'continue' with 'count'"), http.StatusBadRequest)
 			return
 		}
-		queryCtx, cancel := c.queryContext(context.Request.Context())
+		queryCtx, cancel, err := c.queryContext(context.Request.Context())
+		if err != nil {
+			abort.Abort(context, err, http.StatusGatewayTimeout)
+			return
+		}
 		defer cancel()
 		count, countErr := c.Database.CountResources(
 			queryCtx, kind, apiVersion, namespace, name, labelFilters,
@@ -136,7 +145,11 @@ func (c *Controller) GetResources(context *gin.Context) {
 
 	// Single resource by exact name - no streaming needed
 	if name != "" && !strings.Contains(name, "*") {
-		queryCtx, cancel := c.queryContext(context.Request.Context())
+		queryCtx, cancel, err := c.queryContext(context.Request.Context())
+		if err != nil {
+			abort.Abort(context, err, http.StatusGatewayTimeout)
+			return
+		}
 		defer cancel()
 		var resources []labelFilter.Resource
 		resources, err = c.Database.QueryResources(
@@ -170,10 +183,15 @@ func (c *Controller) GetResources(context *gin.Context) {
 	var headerWritten bool
 	w := context.Writer
 
-	streamCtx, streamCancel := c.queryContext(context.Request.Context())
-	defer streamCancel()
+	reqCtx := context.Request.Context()
+	queryCtx, queryCancel, err := c.queryContext(reqCtx)
+	if err != nil {
+		abort.Abort(context, err, http.StatusGatewayTimeout)
+		return
+	}
+	defer queryCancel()
 	err = c.Database.StreamResources(
-		streamCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
+		queryCtx, reqCtx, kind, apiVersion, namespace, name, id, date, labelFilters,
 		creationTimestampAfter, creationTimestampBefore, newLimit,
 		func(resource labelFilter.Resource) error {
 			count++
@@ -264,7 +282,11 @@ func (c *Controller) GetLogURL(context *gin.Context) {
 		apiVersion = fmt.Sprintf("%s/%s", group, version)
 	}
 
-	queryCtx, cancel := c.queryContext(context.Request.Context())
+	queryCtx, cancel, err := c.queryContext(context.Request.Context())
+	if err != nil {
+		abort.Abort(context, err, http.StatusGatewayTimeout)
+		return
+	}
 	defer cancel()
 	var logRecord *interfaces.LogRecord
 	if name != "" {
@@ -309,7 +331,11 @@ func (c *Controller) GetResourceByUID(context *gin.Context) {
 		return
 	}
 
-	queryCtx, cancel := c.queryContext(context.Request.Context())
+	queryCtx, cancel, err := c.queryContext(context.Request.Context())
+	if err != nil {
+		abort.Abort(context, err, http.StatusGatewayTimeout)
+		return
+	}
 	defer cancel()
 	resource, err := c.Database.QueryResourceByUID(queryCtx, kind, apiVersion, namespace, uid)
 	if err != nil {

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -41,7 +41,7 @@ type Controller struct {
 // immediately if the parent context is already expired.
 func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc, error) {
 	if c.QueryTimeout <= 0 {
-		return ctx, func() {}, nil
+		return ctx, func() {}, errors.New("Query timeout must be greater than zero")
 	}
 	newCtx, cancel := context.WithTimeout(ctx, c.QueryTimeout)
 	return newCtx, cancel, nil

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -37,8 +37,9 @@ type Controller struct {
 
 // queryContext creates a child context bounded by the configured QueryTimeout for use during
 // database query execution only — not for the full response lifecycle — so that callers which
-// stream results can pass it solely to the initial cursor-open call; returns DeadlineExceeded
-// immediately if the parent context is already expired.
+// stream results can pass it solely to the initial cursor-open call;
+// queryContext returns a child context with the configured QueryTimeout applied.
+// If QueryTimeout is zero or negative, the parent context is returned unchanged.
 func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if c.QueryTimeout <= 0 {
 		return ctx, func() {}

--- a/cmd/api/routers/routers.go
+++ b/cmd/api/routers/routers.go
@@ -35,9 +35,6 @@ type Controller struct {
 	QueryTimeout       time.Duration
 }
 
-// queryContext creates a child context bounded by the configured QueryTimeout for use during
-// database query execution only — not for the full response lifecycle — so that callers which
-// stream results can pass it solely to the initial cursor-open call;
 // queryContext returns a child context with the configured QueryTimeout applied.
 // If QueryTimeout is zero or negative, the parent context is returned unchanged.
 func (c *Controller) queryContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/pagination"
-	"github.com/kubearchive/kubearchive/pkg/database/fake"
 	dbErrors "github.com/kubearchive/kubearchive/pkg/database/errors"
+	"github.com/kubearchive/kubearchive/pkg/database/fake"
 	"github.com/kubearchive/kubearchive/pkg/database/interfaces"
 	"github.com/kubearchive/kubearchive/pkg/models"
 	"github.com/stretchr/testify/assert"

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -891,8 +891,8 @@ func (s *slowDBReader) QueryResources(ctx context.Context, _, _, _, _, _, _ stri
 	return nil, s.block(ctx)
 }
 
-func (s *slowDBReader) StreamResources(ctx context.Context, _, _, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time, _ int, _ func(models.Resource) error) error {
-	return s.block(ctx)
+func (s *slowDBReader) StreamResources(queryCtx, _ context.Context, _, _, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time, _ int, _ func(models.Resource) error) error {
+	return s.block(queryCtx)
 }
 
 func (s *slowDBReader) CountResources(ctx context.Context, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time) (int64, error) {

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -4,6 +4,7 @@
 package routers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,11 +13,13 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/pagination"
 	"github.com/kubearchive/kubearchive/pkg/database/fake"
 	"github.com/kubearchive/kubearchive/pkg/database/interfaces"
+	"github.com/kubearchive/kubearchive/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -864,4 +867,159 @@ func TestCountResourcesWithInvalidParams(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, res.Code)
 		})
 	}
+}
+
+// slowDBReader is a test double for interfaces.DBReader whose query methods block
+// until the supplied context is cancelled, then return ctx.Err(). This lets us
+// verify that the Controller's QueryTimeout correctly cancels in-flight DB calls.
+type slowDBReader struct {
+	// blockFor is the maximum time each method will block before checking the context.
+	// Setting it longer than QueryTimeout guarantees the timeout fires first.
+	blockFor time.Duration
+}
+
+func (s *slowDBReader) block(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(s.blockFor):
+		return nil
+	}
+}
+
+func (s *slowDBReader) QueryResources(ctx context.Context, _, _, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time, _ int) ([]models.Resource, error) {
+	return nil, s.block(ctx)
+}
+
+func (s *slowDBReader) StreamResources(ctx context.Context, _, _, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time, _ int, _ func(models.Resource) error) error {
+	return s.block(ctx)
+}
+
+func (s *slowDBReader) CountResources(ctx context.Context, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time) (int64, error) {
+	return 0, s.block(ctx)
+}
+
+func (s *slowDBReader) QueryResourceByUID(ctx context.Context, _, _, _, _ string) (*models.Resource, error) {
+	return nil, s.block(ctx)
+}
+
+func (s *slowDBReader) QueryLogURLByName(ctx context.Context, _, _, _, _, _ string) (*interfaces.LogRecord, error) {
+	return nil, s.block(ctx)
+}
+
+func (s *slowDBReader) QueryLogURLByUID(ctx context.Context, _, _, _, _, _ string) (*interfaces.LogRecord, error) {
+	return nil, s.block(ctx)
+}
+
+func (s *slowDBReader) Ping(_ context.Context) error                    { return nil }
+func (s *slowDBReader) QueryDatabaseSchemaVersion(_ context.Context) (string, error) {
+	return "", nil
+}
+func (s *slowDBReader) CloseDB() error                  { return nil }
+func (s *slowDBReader) Init(_ map[string]string) error  { return nil }
+
+// setupRouterWithTimeout creates a test router backed by db and applies queryTimeout.
+func setupRouterWithTimeout(db interfaces.DBReader, core bool, queryTimeout time.Duration) *gin.Engine {
+	router := gin.Default()
+	ctrl := Controller{Database: db, QueryTimeout: queryTimeout}
+	router.Use(func(c *gin.Context) {
+		if core {
+			c.Set("apiResourceKind", "Pod")
+		} else {
+			c.Set("apiResourceKind", "Crontab")
+		}
+	})
+	router.Use(pagination.Middleware())
+	router.GET("/apis/:group/:version/:resourceType", ctrl.GetResources)
+	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType", ctrl.GetResources)
+	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/:name", ctrl.GetResources)
+	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/uid/:uid", ctrl.GetResourceByUID)
+	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/:name/log",
+		ctrl.GetLogURL, retrieveLogURL)
+	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
+		ctrl.GetLogURL, retrieveLogURL)
+	router.GET("/api/:version/:resourceType", ctrl.GetResources)
+	router.GET("/api/:version/namespaces/:namespace/:resourceType", ctrl.GetResources)
+	router.GET("/api/:version/namespaces/:namespace/:resourceType/:name", ctrl.GetResources)
+	router.GET("/api/:version/namespaces/:namespace/:resourceType/uid/:uid", ctrl.GetResourceByUID)
+	router.GET("/api/:version/namespaces/:namespace/:resourceType/:name/log",
+		ctrl.GetLogURL, retrieveLogURL)
+	router.GET("/api/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
+		ctrl.GetLogURL, retrieveLogURL)
+	return router
+}
+
+// TestQueryTimeout verifies that Controller.QueryTimeout causes DB-bound handlers
+// to abort with 500 (context deadline exceeded) before the slow DB finishes,
+// and that the response arrives well within the blockFor budget.
+func TestQueryTimeout(t *testing.T) {
+	const timeout = 50 * time.Millisecond
+	const blockFor = 500 * time.Millisecond // much longer than the timeout
+
+	slow := &slowDBReader{blockFor: blockFor}
+
+	tests := []struct {
+		name   string
+		isCore bool
+		url    string
+	}{
+		{
+			name:   "GetResources list times out",
+			isCore: false,
+			url:    "/apis/stable.example.com/v1/namespaces/test/crontabs",
+		},
+		{
+			name:   "GetResources by name times out",
+			isCore: false,
+			url:    "/apis/stable.example.com/v1/namespaces/test/crontabs/my-crontab",
+		},
+		{
+			name:   "GetResources count times out",
+			isCore: false,
+			url:    "/apis/stable.example.com/v1/namespaces/test/crontabs?count=true",
+		},
+		{
+			name:   "GetResourceByUID times out",
+			isCore: false,
+			url:    "/apis/stable.example.com/v1/namespaces/test/crontabs/uid/some-uid",
+		},
+		{
+			name:   "GetLogURL times out",
+			isCore: true,
+			url:    "/api/v1/namespaces/test/pods/my-pod/log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := setupRouterWithTimeout(slow, tt.isCore, timeout)
+
+			start := time.Now()
+			res := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			router.ServeHTTP(res, req)
+			elapsed := time.Since(start)
+
+			// Handler must return an error status — the DB never returned data.
+			assert.Equal(t, http.StatusInternalServerError, res.Code,
+				"expected 500 when DB call times out")
+
+			// The response must arrive well before the DB's blockFor duration,
+			// confirming the timeout fired rather than the DB finishing naturally.
+			assert.Less(t, elapsed, blockFor,
+				"response took %v but blockFor is %v — timeout should have fired first", elapsed, blockFor)
+		})
+	}
+}
+
+// TestQueryTimeoutDisabled verifies that when QueryTimeout is zero the handler
+// does NOT impose a timeout — the fast fake DB returns normally.
+func TestQueryTimeoutDisabled(t *testing.T) {
+	router := setupRouterWithTimeout(fake.NewFakeDatabase(testResources, testLogUrls), false, 0)
+
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/apis/stable.example.com/v1/namespaces/test/crontabs", nil)
+	router.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code, "zero QueryTimeout should not block successful requests")
 }

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/kubearchive/kubearchive/cmd/api/pagination"
 	"github.com/kubearchive/kubearchive/pkg/database/fake"
+	dbErrors "github.com/kubearchive/kubearchive/pkg/database/errors"
 	"github.com/kubearchive/kubearchive/pkg/database/interfaces"
 	"github.com/kubearchive/kubearchive/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -885,7 +886,7 @@ type slowDBReader struct {
 func (s *slowDBReader) block(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return dbErrors.WrapQueryError(ctx, ctx.Err())
 	case <-time.After(s.blockFor):
 		return nil
 	}
@@ -928,7 +929,7 @@ func setupRouterWithTimeout(db interfaces.DBReader, core bool, queryTimeout time
 }
 
 // TestQueryTimeout verifies that Controller.QueryTimeout causes DB-bound handlers
-// to abort with 500 (context deadline exceeded) before the slow DB finishes,
+// to abort with 504 (context deadline exceeded) before the slow DB finishes,
 // and that the response arrives well within the blockFor budget.
 func TestQueryTimeout(t *testing.T) {
 	const timeout = 50 * time.Millisecond
@@ -979,8 +980,8 @@ func TestQueryTimeout(t *testing.T) {
 			elapsed := time.Since(start)
 
 			// Handler must return an error status — the DB never returned data.
-			assert.Equal(t, http.StatusInternalServerError, res.Code,
-				"expected 500 when DB call times out")
+			assert.Equal(t, http.StatusGatewayTimeout, res.Code,
+				"expected 504 when DB call times out")
 
 			// The response must arrive well before the DB's blockFor duration,
 			// confirming the timeout fired rather than the DB finishing naturally.

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -896,7 +896,7 @@ func (s *slowDBReader) QueryResources(ctx context.Context, _, _, _, _, _, _ stri
 	return nil, s.block(ctx)
 }
 
-func (s *slowDBReader) StreamResources(queryCtx, _ context.Context, _, _, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time, _ int, _ func(models.Resource) error) error {
+func (s *slowDBReader) StreamResources(queryCtx context.Context, _, _, _, _, _, _ string, _ *models.LabelFilters, _, _ *time.Time, _ int, _ func(models.Resource) error) error {
 	return s.block(queryCtx)
 }
 

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -911,12 +911,12 @@ func (s *slowDBReader) QueryLogURLByUID(ctx context.Context, _, _, _, _, _ strin
 	return nil, s.block(ctx)
 }
 
-func (s *slowDBReader) Ping(_ context.Context) error                    { return nil }
+func (s *slowDBReader) Ping(_ context.Context) error { return nil }
 func (s *slowDBReader) QueryDatabaseSchemaVersion(_ context.Context) (string, error) {
 	return "", nil
 }
-func (s *slowDBReader) CloseDB() error                  { return nil }
-func (s *slowDBReader) Init(_ map[string]string) error  { return nil }
+func (s *slowDBReader) CloseDB() error                 { return nil }
+func (s *slowDBReader) Init(_ map[string]string) error { return nil }
 
 // setupRouterWithTimeout creates a test router backed by db and applies queryTimeout.
 func setupRouterWithTimeout(db interfaces.DBReader, core bool, queryTimeout time.Duration) *gin.Engine {

--- a/cmd/api/routers/routers_test.go
+++ b/cmd/api/routers/routers_test.go
@@ -43,10 +43,10 @@ func retrieveLogURL(c *gin.Context) {
 	c.JSON(http.StatusOK, fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s", record.URL, record.Query, record.Start, record.End, record.PodName, record.PodUUID, record.ContainerName))
 }
 
-// setupRouter set up the router the same way that NewServer does without the middleware
-func setupRouter(db interfaces.DBReader, core bool) *gin.Engine {
+// buildRouter constructs a gin.Engine wired to ctrl with the standard test routes.
+// setupRouter and setupRouterWithTimeout are thin wrappers around this function.
+func buildRouter(ctrl Controller, core bool) *gin.Engine {
 	router := gin.Default()
-	ctrl := Controller{Database: db}
 	router.Use(func(c *gin.Context) {
 		if core {
 			c.Set("apiResourceKind", "Pod")
@@ -54,7 +54,6 @@ func setupRouter(db interfaces.DBReader, core bool) *gin.Engine {
 			c.Set("apiResourceKind", "Crontab")
 		}
 	})
-
 	router.Use(pagination.Middleware())
 	router.GET("/apis/:group/:version/:resourceType", ctrl.GetResources)
 	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType", ctrl.GetResources)
@@ -73,6 +72,11 @@ func setupRouter(db interfaces.DBReader, core bool) *gin.Engine {
 	router.GET("/api/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
 		ctrl.GetLogURL, retrieveLogURL)
 	return router
+}
+
+// setupRouter sets up the router the same way that NewServer does without the middleware.
+func setupRouter(db interfaces.DBReader, core bool) *gin.Engine {
+	return buildRouter(Controller{Database: db}, core)
 }
 
 func TestLabelSelectorQueryParameter(t *testing.T) {
@@ -920,33 +924,7 @@ func (s *slowDBReader) Init(_ map[string]string) error { return nil }
 
 // setupRouterWithTimeout creates a test router backed by db and applies queryTimeout.
 func setupRouterWithTimeout(db interfaces.DBReader, core bool, queryTimeout time.Duration) *gin.Engine {
-	router := gin.Default()
-	ctrl := Controller{Database: db, QueryTimeout: queryTimeout}
-	router.Use(func(c *gin.Context) {
-		if core {
-			c.Set("apiResourceKind", "Pod")
-		} else {
-			c.Set("apiResourceKind", "Crontab")
-		}
-	})
-	router.Use(pagination.Middleware())
-	router.GET("/apis/:group/:version/:resourceType", ctrl.GetResources)
-	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType", ctrl.GetResources)
-	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/:name", ctrl.GetResources)
-	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/uid/:uid", ctrl.GetResourceByUID)
-	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/:name/log",
-		ctrl.GetLogURL, retrieveLogURL)
-	router.GET("/apis/:group/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
-		ctrl.GetLogURL, retrieveLogURL)
-	router.GET("/api/:version/:resourceType", ctrl.GetResources)
-	router.GET("/api/:version/namespaces/:namespace/:resourceType", ctrl.GetResources)
-	router.GET("/api/:version/namespaces/:namespace/:resourceType/:name", ctrl.GetResources)
-	router.GET("/api/:version/namespaces/:namespace/:resourceType/uid/:uid", ctrl.GetResourceByUID)
-	router.GET("/api/:version/namespaces/:namespace/:resourceType/:name/log",
-		ctrl.GetLogURL, retrieveLogURL)
-	router.GET("/api/:version/namespaces/:namespace/:resourceType/uid/:uid/log",
-		ctrl.GetLogURL, retrieveLogURL)
-	return router
+	return buildRouter(Controller{Database: db, QueryTimeout: queryTimeout}, core)
 }
 
 // TestQueryTimeout verifies that Controller.QueryTimeout causes DB-bound handlers

--- a/config/templates/api_server/api_server.yaml
+++ b/config/templates/api_server/api_server.yaml
@@ -100,6 +100,8 @@ spec:
               value: "300"
             - name: API_RATE_LIMIT_LOG_BURST
               value: "30"
+            - name: KUBEARCHIVE_QUERY_TIMEOUT 
+              value: "5m"
           ports:
             - containerPort: 8081
               name: server

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -16,6 +16,7 @@
 ** xref:configuration/cache-expiration-time.adoc[Cache Expiration Time]
 ** xref:configuration/database-connection-pool.adoc[Database Connection Pool]
 ** xref:configuration/rate-limiting.adoc[Rate Limiting]
+** xref:configuration/database-query-timeout.adoc[Database Query Timeout]
 ** xref:configuration/observability.adoc[Observability]
 ** xref:configuration/impersonation.adoc[]
 ** xref:configuration/kubearchive-logs.adoc[]

--- a/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
+++ b/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
@@ -78,7 +78,7 @@ When a query exceeds the timeout the API returns:
 
 [source,json]
 ----
-{"message": "context deadline exceeded"}
+{"message": "context deadline exceeded: query timeout: context deadline exceeded"}
 ----
 
 with HTTP status `504 Gateway Timeout`. Clients can retry the request

--- a/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
+++ b/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
@@ -21,7 +21,7 @@ To modify the timeout, perform the following steps:
 [source,yaml]
 ----
 ---
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 spec:
   template:

--- a/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
+++ b/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
@@ -1,0 +1,84 @@
+= Database Query Timeout
+
+KubeArchive can enforce a timeout on database read queries to prevent
+long-running statements from exhausting database connections. When a
+query exceeds the configured timeout the API returns HTTP `504 Gateway
+Timeout` to the client and the database statement is cancelled.
+
+The timeout is controlled by the `KUBEARCHIVE_QUERY_TIMEOUT` environment
+variable. If not set, the default value is **5 minutes**.
+
+The value must be parseable by
+link:https://pkg.go.dev/time#ParseDuration[time.ParseDuration]
+(for example `30s`, `2m`, `10m`). If the value is invalid or negative
+the API server logs a warning and falls back to the default.
+
+To modify the timeout, perform the following steps:
+
+. Edit or patch the `kubearchive-api-server` Deployment in the
+`kubearchive` namespace:
++
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: kubearchive-api-server
+        env:
+        - name: KUBEARCHIVE_QUERY_TIMEOUT
+          value: 10m
+----
+
+. Save the patch somewhere on disk and apply it:
++
+[source,bash]
+----
+kubectl patch -n kubearchive deployment kubearchive-api-server --patch-file path/to/patch.yaml
+----
+
+== Affected endpoints
+
+The timeout applies to every database read issued by the API server:
+
+* Collection queries (`GET /apis/.../resourceType`)
+* Single-resource queries by name (`GET /apis/.../resourceType/name`)
+* Single-resource queries by UID (`GET /apis/.../resourceType/uid/uid`)
+* Resource count queries (`?count=true`)
+* Log URL queries (`GET .../log`)
+
+For streaming responses (collection queries that return multiple
+resources), the timeout governs the initial database cursor open.
+Once rows begin streaming to the client, the response uses the
+original request context so that a short query timeout does not
+truncate an otherwise healthy transfer.
+
+== Disabling the timeout
+
+Setting `KUBEARCHIVE_QUERY_TIMEOUT` to `0` disables the timeout
+entirely. In this configuration every query runs until it completes
+or the client disconnects.
+
+[WARNING]
+====
+Running without a query timeout is not recommended in production.
+Without a timeout, a single expensive query (for example a full table
+scan triggered by a broad label selector) can hold a database
+connection indefinitely, potentially exhausting the connection pool.
+====
+
+== Error responses
+
+When a query exceeds the timeout the API returns:
+
+[source,json]
+----
+{"message": "context deadline exceeded"}
+----
+
+with HTTP status `504 Gateway Timeout`. Clients can retry the request
+with narrower filters (namespace, label selector, timestamp range) to
+reduce query execution time.

--- a/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
+++ b/docs/modules/ROOT/pages/configuration/database-query-timeout.adoc
@@ -50,11 +50,13 @@ The timeout applies to every database read issued by the API server:
 * Resource count queries (`?count=true`)
 * Log URL queries (`GET .../log`)
 
+[NOTE]
+====
 For streaming responses (collection queries that return multiple
-resources), the timeout governs the initial database cursor open.
-Once rows begin streaming to the client, the response uses the
-original request context so that a short query timeout does not
-truncate an otherwise healthy transfer.
+resources), timeout covers both query execution and resource collection
+iteration time, this should be taken into account when configuring 
+the timeout for namespaces which produce a large amounts of resources.
+====
 
 == Disabling the timeout
 

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -12,8 +12,10 @@ import (
 )
 
 var (
-	ErrResourceNotFound = errors.New("resource not found")
-	ErrQueryTimeout     = errors.New("context deadline exceeded")
+	ErrResourceNotFound    = errors.New("resource not found")
+	ErrContextQueryTimeout = errors.New("context deadline exceeded")
+	ErrDatabaseTimeout     = errors.New("database query timeout")
+	ErrContextCancelled    = errors.New("user context cancelled")
 )
 
 const pgQueryCancelled = "57014"
@@ -26,19 +28,21 @@ func WrapQueryError(ctx context.Context, err error) error {
 	}
 
 	// Check context error first in case query was cancelled
-	if ctxErr := ctx.Err(); ctxErr == context.Canceled || ctxErr == context.DeadlineExceeded {
-		return fmt.Errorf("%w: %w", ErrQueryTimeout, ctxErr)
+	if ctxErr := ctx.Err(); ctxErr == context.Canceled {
+		return fmt.Errorf("%w: %w", ErrContextCancelled, ctxErr)
+	} else if ctxErr == context.DeadlineExceeded {
+		return fmt.Errorf("%w: %w", ErrContextQueryTimeout, ctxErr)
 	}
 
 	// Check if context deadline was exceeded
 	if errors.Is(err, context.DeadlineExceeded) {
-		return fmt.Errorf("%w: %w", ErrQueryTimeout, err)
+		return fmt.Errorf("%w: %w", ErrDatabaseTimeout, err)
 	}
 
 	// Check for PostgreSQL error code 57014 (query_canceled)
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) && pqErr.Code == pgQueryCancelled {
-		return fmt.Errorf("%w: %w", ErrQueryTimeout, pqErr)
+		return fmt.Errorf("%w: %w", ErrDatabaseTimeout, pqErr)
 	}
 
 	return err

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -14,8 +14,8 @@ import (
 var (
 	ErrResourceNotFound    = errors.New("resource not found")
 	ErrQueryTimeout        = errors.New("query timeout")
-	ErrContextQueryTimeout = fmt.Errorf("context deadline exceeded: %w", ErrQueryTimeout)
-	ErrDatabaseTimeout     = fmt.Errorf("database query timeout: %w", ErrQueryTimeout)
+	ErrContextQueryTimeout = errors.New("context deadline exceeded")
+	ErrDatabaseTimeout     = errors.New("database query timeout")
 	ErrContextCancelled    = errors.New("user context cancelled")
 )
 

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
 )
 
 var (
@@ -18,8 +19,6 @@ var (
 	ErrDatabaseTimeout     = fmt.Errorf("database query timeout: %w", ErrQueryTimeout)
 	ErrContextCancelled    = errors.New("user context cancelled")
 )
-
-const pgQueryCancelled = "57014"
 
 // WrapQueryError wraps database query errors to detect timeout conditions.
 // Returns ErrQueryTimeout if the error was caused by context deadline or PostgreSQL query cancellation.
@@ -40,10 +39,8 @@ func WrapQueryError(ctx context.Context, err error) error {
 		return fmt.Errorf("%w: %w", ErrDatabaseTimeout, err)
 	}
 
-	// Check for PostgreSQL error code 57014 (query_canceled)
-	var pqErr *pq.Error
-	if errors.As(err, &pqErr) && pqErr.Code == pgQueryCancelled {
-		return fmt.Errorf("%w: %w", ErrContextQueryTimeout, pqErr)
+	if pqErr := pq.As(err, pqerror.QueryCanceled); pqErr != nil {
+		return fmt.Errorf("%w: %w", ErrQueryTimeout, pqErr)
 	}
 
 	return err

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -6,6 +6,7 @@ package errors
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/lib/pq"
 )
@@ -15,6 +16,8 @@ var (
 	ErrQueryTimeout     = errors.New("context deadline exceeded")
 )
 
+const pgQueryCancelled = "57014"
+
 // WrapQueryError wraps database query errors to detect timeout conditions.
 // Returns ErrQueryTimeout if the error was caused by context deadline or PostgreSQL query cancellation.
 func WrapQueryError(ctx context.Context, err error) error {
@@ -22,20 +25,20 @@ func WrapQueryError(ctx context.Context, err error) error {
 		return nil
 	}
 
-	// Check if context deadline was exceeded
-	if errors.Is(err, context.DeadlineExceeded) {
-		return ErrQueryTimeout
+	// Check context error first in case query was cancelled
+	if ctxErr := ctx.Err(); ctxErr == context.Canceled || ctxErr == context.DeadlineExceeded {
+		return fmt.Errorf("%w: %w", ErrQueryTimeout, ctxErr)
 	}
 
-	// Check context error first in case query was cancelled
-	if ctxErr := ctx.Err(); ctxErr == context.DeadlineExceeded {
-		return ErrQueryTimeout
+	// Check if context deadline was exceeded
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", ErrQueryTimeout, err)
 	}
 
 	// Check for PostgreSQL error code 57014 (query_canceled)
 	var pqErr *pq.Error
-	if errors.As(err, &pqErr) && pqErr.Code == "57014" {
-		return ErrQueryTimeout
+	if errors.As(err, &pqErr) && pqErr.Code == pgQueryCancelled {
+		return fmt.Errorf("%w: %w", ErrQueryTimeout, pqErr)
 	}
 
 	return err

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -13,8 +13,9 @@ import (
 
 var (
 	ErrResourceNotFound    = errors.New("resource not found")
-	ErrContextQueryTimeout = errors.New("context deadline exceeded")
-	ErrDatabaseTimeout     = errors.New("database query timeout")
+	ErrQueryTimeout        = errors.New("query timeout")
+	ErrContextQueryTimeout = fmt.Errorf("context deadline exceeded: %w", ErrQueryTimeout)
+	ErrDatabaseTimeout     = fmt.Errorf("database query timeout: %w", ErrQueryTimeout)
 	ErrContextCancelled    = errors.New("user context cancelled")
 )
 
@@ -42,7 +43,7 @@ func WrapQueryError(ctx context.Context, err error) error {
 	// Check for PostgreSQL error code 57014 (query_canceled)
 	var pqErr *pq.Error
 	if errors.As(err, &pqErr) && pqErr.Code == pgQueryCancelled {
-		return fmt.Errorf("%w: %w", ErrDatabaseTimeout, pqErr)
+		return fmt.Errorf("%w: %w", ErrContextQueryTimeout, pqErr)
 	}
 
 	return err

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -3,6 +3,40 @@
 
 package errors
 
-import "errors"
+import (
+	"context"
+	"errors"
 
-var ErrResourceNotFound = errors.New("resource not found")
+	"github.com/lib/pq"
+)
+
+var (
+	ErrResourceNotFound = errors.New("resource not found")
+	ErrQueryTimeout     = errors.New("context deadline exceeded")
+)
+
+// WrapQueryError wraps database query errors to detect timeout conditions.
+// Returns ErrQueryTimeout if the error was caused by context deadline or PostgreSQL query cancellation.
+func WrapQueryError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check if context deadline was exceeded
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrQueryTimeout
+	}
+
+	// Check context error first in case query was cancelled
+	if ctxErr := ctx.Err(); ctxErr == context.DeadlineExceeded {
+		return ErrQueryTimeout
+	}
+
+	// Check for PostgreSQL error code 57014 (query_canceled)
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Code == "57014" {
+		return ErrQueryTimeout
+	}
+
+	return err
+}

--- a/pkg/database/errors/errors.go
+++ b/pkg/database/errors/errors.go
@@ -14,8 +14,8 @@ import (
 var (
 	ErrResourceNotFound    = errors.New("resource not found")
 	ErrQueryTimeout        = errors.New("query timeout")
-	ErrContextQueryTimeout = errors.New("context deadline exceeded")
-	ErrDatabaseTimeout     = errors.New("database query timeout")
+	ErrContextQueryTimeout = fmt.Errorf("context deadline exceeded: %w", ErrQueryTimeout)
+	ErrDatabaseTimeout     = fmt.Errorf("database query timeout: %w", ErrQueryTimeout)
 	ErrContextCancelled    = errors.New("user context cancelled")
 )
 

--- a/pkg/database/errors/errors_test.go
+++ b/pkg/database/errors/errors_test.go
@@ -47,7 +47,7 @@ func TestWrapQueryError(t *testing.T) {
 			name:     "postgresql error 57014 query_canceled",
 			ctxFunc:  func() context.Context { return context.Background() },
 			err:      &pq.Error{Code: "57014", Message: "canceling statement due to user request"},
-			expected: ErrContextQueryTimeout,
+			expected: fmt.Errorf("%w: %w", ErrQueryTimeout, &pq.Error{Code: "57014", Message: "canceling statement due to user request"}),
 		},
 		{
 			name:     "other postgresql error not wrapped",

--- a/pkg/database/errors/errors_test.go
+++ b/pkg/database/errors/errors_test.go
@@ -1,0 +1,89 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+func TestWrapQueryError(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		err      error
+		expected error
+	}{
+		{
+			name:     "nil error returns nil",
+			ctx:      context.Background(),
+			err:      nil,
+			expected: nil,
+		},
+		{
+			name:     "context deadline exceeded",
+			ctx:      context.Background(),
+			err:      context.DeadlineExceeded,
+			expected: ErrQueryTimeout,
+		},
+		{
+			name: "context deadline exceeded from context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+				defer cancel()
+				time.Sleep(2 * time.Millisecond)
+				return ctx
+			}(),
+			err:      errors.New("some database error"),
+			expected: ErrQueryTimeout,
+		},
+		{
+			name:     "postgresql error 57014 query_canceled",
+			ctx:      context.Background(),
+			err:      &pq.Error{Code: "57014", Message: "canceling statement due to user request"},
+			expected: ErrQueryTimeout,
+		},
+		{
+			name:     "other postgresql error not wrapped",
+			ctx:      context.Background(),
+			err:      &pq.Error{Code: "42P01", Message: "relation does not exist"},
+			expected: &pq.Error{Code: "42P01", Message: "relation does not exist"},
+		},
+		{
+			name:     "generic error not wrapped",
+			ctx:      context.Background(),
+			err:      errors.New("some other error"),
+			expected: errors.New("some other error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WrapQueryError(tt.ctx, tt.err)
+
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+
+			if tt.expected == ErrQueryTimeout {
+				if !errors.Is(result, ErrQueryTimeout) {
+					t.Errorf("expected ErrQueryTimeout, got %v", result)
+				}
+				return
+			}
+
+			// For specific error types, check the message matches
+			if result.Error() != tt.expected.Error() {
+				t.Errorf("expected error %q, got %q", tt.expected.Error(), result.Error())
+			}
+		})
+	}
+}

--- a/pkg/database/errors/errors_test.go
+++ b/pkg/database/errors/errors_test.go
@@ -6,6 +6,7 @@ package errors
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ func TestWrapQueryError(t *testing.T) {
 			name:     "context deadline exceeded",
 			ctxFunc:  func() context.Context { return context.Background() },
 			err:      context.DeadlineExceeded,
-			expected: ErrQueryTimeout,
+			expected: fmt.Errorf("%w: %w", ErrDatabaseTimeout, context.DeadlineExceeded),
 		},
 		{
 			name: "context deadline exceeded from context",
@@ -40,13 +41,13 @@ func TestWrapQueryError(t *testing.T) {
 				return ctx
 			},
 			err:      errors.New("some database error"),
-			expected: ErrQueryTimeout,
+			expected: ErrContextQueryTimeout,
 		},
 		{
 			name:     "postgresql error 57014 query_canceled",
 			ctxFunc:  func() context.Context { return context.Background() },
 			err:      &pq.Error{Code: "57014", Message: "canceling statement due to user request"},
-			expected: ErrQueryTimeout,
+			expected: ErrContextQueryTimeout,
 		},
 		{
 			name:     "other postgresql error not wrapped",
@@ -74,9 +75,9 @@ func TestWrapQueryError(t *testing.T) {
 				return
 			}
 
-			if tt.expected == ErrQueryTimeout {
-				if !errors.Is(result, ErrQueryTimeout) {
-					t.Errorf("expected ErrQueryTimeout, got %v", result)
+			if tt.expected == ErrContextQueryTimeout {
+				if !errors.Is(result, ErrContextQueryTimeout) {
+					t.Errorf("expected ErrContextQueryTimeout, got %v", result)
 				}
 				return
 			}

--- a/pkg/database/errors/errors_test.go
+++ b/pkg/database/errors/errors_test.go
@@ -15,48 +15,48 @@ import (
 func TestWrapQueryError(t *testing.T) {
 	tests := []struct {
 		name     string
-		ctx      context.Context
+		ctxFunc  func() context.Context
 		err      error
 		expected error
 	}{
 		{
 			name:     "nil error returns nil",
-			ctx:      context.Background(),
+			ctxFunc:  func() context.Context { return context.Background() },
 			err:      nil,
 			expected: nil,
 		},
 		{
 			name:     "context deadline exceeded",
-			ctx:      context.Background(),
+			ctxFunc:  func() context.Context { return context.Background() },
 			err:      context.DeadlineExceeded,
 			expected: ErrQueryTimeout,
 		},
 		{
 			name: "context deadline exceeded from context",
-			ctx: func() context.Context {
+			ctxFunc: func() context.Context {
 				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 				defer cancel()
 				time.Sleep(2 * time.Millisecond)
 				return ctx
-			}(),
+			},
 			err:      errors.New("some database error"),
 			expected: ErrQueryTimeout,
 		},
 		{
 			name:     "postgresql error 57014 query_canceled",
-			ctx:      context.Background(),
+			ctxFunc:  func() context.Context { return context.Background() },
 			err:      &pq.Error{Code: "57014", Message: "canceling statement due to user request"},
 			expected: ErrQueryTimeout,
 		},
 		{
 			name:     "other postgresql error not wrapped",
-			ctx:      context.Background(),
+			ctxFunc:  func() context.Context { return context.Background() },
 			err:      &pq.Error{Code: "42P01", Message: "relation does not exist"},
 			expected: &pq.Error{Code: "42P01", Message: "relation does not exist"},
 		},
 		{
 			name:     "generic error not wrapped",
-			ctx:      context.Background(),
+			ctxFunc:  func() context.Context { return context.Background() },
 			err:      errors.New("some other error"),
 			expected: errors.New("some other error"),
 		},
@@ -64,7 +64,8 @@ func TestWrapQueryError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := WrapQueryError(tt.ctx, tt.err)
+			ctx := tt.ctxFunc()
+			result := WrapQueryError(ctx, tt.err)
 
 			if tt.expected == nil {
 				if result != nil {

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -257,7 +257,7 @@ func (f *fakeDatabase) QueryResources(ctx context.Context, kind, version, namesp
 	return resources, f.err
 }
 
-func (f *fakeDatabase) StreamResources(queryCtx, _ context.Context, kind, version, namespace, name,
+func (f *fakeDatabase) StreamResources(queryCtx context.Context, kind, version, namespace, name,
 	continueId, continueDate string, _ *models.LabelFilters,
 	creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 	fn func(resource models.Resource) error) error {

--- a/pkg/database/fake/database_generated.go
+++ b/pkg/database/fake/database_generated.go
@@ -257,14 +257,14 @@ func (f *fakeDatabase) QueryResources(ctx context.Context, kind, version, namesp
 	return resources, f.err
 }
 
-func (f *fakeDatabase) StreamResources(ctx context.Context, kind, version, namespace, name,
+func (f *fakeDatabase) StreamResources(queryCtx, _ context.Context, kind, version, namespace, name,
 	continueId, continueDate string, _ *models.LabelFilters,
 	creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 	fn func(resource models.Resource) error) error {
 	if f.err != nil {
 		return f.err
 	}
-	resources := f.queryFilteredResources(ctx, kind, version, namespace, name,
+	resources := f.queryFilteredResources(queryCtx, kind, version, namespace, name,
 		continueId, continueDate, creationTimestampAfter, creationTimestampBefore, limit)
 	for _, resource := range resources {
 		if err := fn(resource); err != nil {

--- a/pkg/database/interfaces/database.go
+++ b/pkg/database/interfaces/database.go
@@ -37,7 +37,9 @@ type DBReader interface {
 		creationTimestampAfter, creationTimestampBefore *time.Time, limit int) ([]models.Resource, error)
 	// StreamResources iterates over matching resources row by row, calling fn for each.
 	// Unlike QueryResources, it does not load all rows into memory at once.
-	StreamResources(ctx context.Context, kind, apiVersion, namespace,
+	// queryCtx governs the initial query execution (cursor open); iterCtx governs row iteration.
+	// Separating them lets callers apply a short deadline to the query without cutting off the stream mid-write.
+	StreamResources(queryCtx, iterCtx context.Context, kind, apiVersion, namespace,
 		name, continueId, continueDate string, labelFilters *models.LabelFilters,
 		creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 		fn func(resource models.Resource) error) error

--- a/pkg/database/interfaces/database.go
+++ b/pkg/database/interfaces/database.go
@@ -37,9 +37,7 @@ type DBReader interface {
 		creationTimestampAfter, creationTimestampBefore *time.Time, limit int) ([]models.Resource, error)
 	// StreamResources iterates over matching resources row by row, calling fn for each.
 	// Unlike QueryResources, it does not load all rows into memory at once.
-	// queryCtx governs the initial query execution (cursor open); iterCtx governs row iteration.
-	// Separating them lets callers apply a short deadline to the query without cutting off the stream mid-write.
-	StreamResources(queryCtx, iterCtx context.Context, kind, apiVersion, namespace,
+	StreamResources(ctx context.Context, kind, apiVersion, namespace,
 		name, continueId, continueDate string, labelFilters *models.LabelFilters,
 		creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 		fn func(resource models.Resource) error) error

--- a/pkg/database/sql/postgresql.go
+++ b/pkg/database/sql/postgresql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/jmoiron/sqlx"
 	"github.com/kubearchive/kubearchive/pkg/database/env"
+	dbErrors "github.com/kubearchive/kubearchive/pkg/database/errors"
 	"github.com/kubearchive/kubearchive/pkg/database/interfaces"
 	"github.com/kubearchive/kubearchive/pkg/database/sql/facade"
 	"github.com/kubearchive/kubearchive/pkg/models"
@@ -114,7 +115,7 @@ func resolveKeyIDs(ctx context.Context, querier sqlx.QueryerContext, keys []stri
 
 	rows, err := querier.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("resolving label key IDs: %w", err)
+		return nil, fmt.Errorf("resolving label key IDs: %w", dbErrors.WrapQueryError(ctx, err))
 	}
 	defer rows.Close()
 
@@ -153,7 +154,7 @@ func resolveLabelIDs(ctx context.Context, querier sqlx.QueryerContext, labels ma
 
 	rows, err := querier.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("resolving label IDs: %w", err)
+		return nil, fmt.Errorf("resolving label IDs: %w", dbErrors.WrapQueryError(ctx, err))
 	}
 	defer rows.Close()
 
@@ -194,7 +195,7 @@ func resolveLabelIDsMulti(ctx context.Context, querier sqlx.QueryerContext, labe
 
 	rows, err := querier.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("resolving label IDs (multi): %w", err)
+		return nil, fmt.Errorf("resolving label IDs (multi): %w", dbErrors.WrapQueryError(ctx, err))
 	}
 	defer rows.Close()
 

--- a/pkg/database/sql/query.go
+++ b/pkg/database/sql/query.go
@@ -34,9 +34,8 @@ func (q queryPerformer[T]) performQuery(ctx context.Context, builder sqlbuilder.
 	return res, dbErrors.WrapQueryError(ctx, err)
 }
 
-// performStreamQuery executes the query using queryCtx (e.g. one with a deadline) and
-// iterates rows under iterCtx. Separating the two contexts lets callers apply a timeout
-// only to the query-execution phase without aborting row iteration mid-stream.
+// performStreamQuery executes the query and iterates rows under query context ctx.
+// If ctx has a timeout configured, it covers both query execution and row iteration.
 func (q queryPerformer[T]) performStreamQuery(ctx context.Context, builder sqlbuilder.Builder, fn func(T) error) error {
 	query, args := builder.BuildWithFlavor(q.flavor)
 	rows, err := q.querier.QueryxContext(ctx, query, args...)

--- a/pkg/database/sql/query.go
+++ b/pkg/database/sql/query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/jmoiron/sqlx"
+	dbErrors "github.com/kubearchive/kubearchive/pkg/database/errors"
 )
 
 type queryPerformer[T any] struct {
@@ -23,14 +24,14 @@ func (q queryPerformer[T]) performSingleRowQuery(ctx context.Context, builder sq
 	var t T
 	query, args := builder.BuildWithFlavor(q.flavor)
 	err := sqlx.GetContext(ctx, q.querier, &t, query, args...)
-	return t, err
+	return t, dbErrors.WrapQueryError(ctx, err)
 }
 
 func (q queryPerformer[T]) performQuery(ctx context.Context, builder sqlbuilder.Builder) ([]T, error) {
 	var res []T
 	query, args := builder.BuildWithFlavor(q.flavor)
 	err := sqlx.SelectContext(ctx, q.querier, &res, query, args...)
-	return res, err
+	return res, dbErrors.WrapQueryError(ctx, err)
 }
 
 // performStreamQuery executes the query using queryCtx (e.g. one with a deadline) and
@@ -40,7 +41,7 @@ func (q queryPerformer[T]) performStreamQuery(queryCtx, iterCtx context.Context,
 	query, args := builder.BuildWithFlavor(q.flavor)
 	rows, err := q.querier.QueryxContext(queryCtx, query, args...)
 	if err != nil {
-		return err
+		return dbErrors.WrapQueryError(queryCtx, err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -55,5 +56,5 @@ func (q queryPerformer[T]) performStreamQuery(queryCtx, iterCtx context.Context,
 			return err
 		}
 	}
-	return rows.Err()
+	return dbErrors.WrapQueryError(queryCtx, rows.Err())
 }

--- a/pkg/database/sql/query.go
+++ b/pkg/database/sql/query.go
@@ -37,15 +37,15 @@ func (q queryPerformer[T]) performQuery(ctx context.Context, builder sqlbuilder.
 // performStreamQuery executes the query using queryCtx (e.g. one with a deadline) and
 // iterates rows under iterCtx. Separating the two contexts lets callers apply a timeout
 // only to the query-execution phase without aborting row iteration mid-stream.
-func (q queryPerformer[T]) performStreamQuery(queryCtx, iterCtx context.Context, builder sqlbuilder.Builder, fn func(T) error) error {
+func (q queryPerformer[T]) performStreamQuery(ctx context.Context, builder sqlbuilder.Builder, fn func(T) error) error {
 	query, args := builder.BuildWithFlavor(q.flavor)
-	rows, err := q.querier.QueryxContext(queryCtx, query, args...)
+	rows, err := q.querier.QueryxContext(ctx, query, args...)
 	if err != nil {
-		return dbErrors.WrapQueryError(queryCtx, err)
+		return dbErrors.WrapQueryError(ctx, err)
 	}
 	defer rows.Close()
 	for rows.Next() {
-		if err := iterCtx.Err(); err != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		var t T
@@ -56,5 +56,5 @@ func (q queryPerformer[T]) performStreamQuery(queryCtx, iterCtx context.Context,
 			return err
 		}
 	}
-	return dbErrors.WrapQueryError(queryCtx, rows.Err())
+	return dbErrors.WrapQueryError(ctx, rows.Err())
 }

--- a/pkg/database/sql/query.go
+++ b/pkg/database/sql/query.go
@@ -33,14 +33,20 @@ func (q queryPerformer[T]) performQuery(ctx context.Context, builder sqlbuilder.
 	return res, err
 }
 
-func (q queryPerformer[T]) performStreamQuery(ctx context.Context, builder sqlbuilder.Builder, fn func(T) error) error {
+// performStreamQuery executes the query using queryCtx (e.g. one with a deadline) and
+// iterates rows under iterCtx. Separating the two contexts lets callers apply a timeout
+// only to the query-execution phase without aborting row iteration mid-stream.
+func (q queryPerformer[T]) performStreamQuery(queryCtx, iterCtx context.Context, builder sqlbuilder.Builder, fn func(T) error) error {
 	query, args := builder.BuildWithFlavor(q.flavor)
-	rows, err := q.querier.QueryxContext(ctx, query, args...)
+	rows, err := q.querier.QueryxContext(queryCtx, query, args...)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 	for rows.Next() {
+		if err := iterCtx.Err(); err != nil {
+			return err
+		}
 		var t T
 		if err := rows.StructScan(&t); err != nil {
 			return err

--- a/pkg/database/sql/reader.go
+++ b/pkg/database/sql/reader.go
@@ -138,16 +138,16 @@ func (db *sqlDatabaseImpl) QueryResources(ctx context.Context, kind, apiVersion,
 	return db.performResourceQuery(ctx, sb)
 }
 
-func (db *sqlDatabaseImpl) StreamResources(queryCtx, iterCtx context.Context, kind, apiVersion, namespace, name,
+func (db *sqlDatabaseImpl) StreamResources(ctx context.Context, kind, apiVersion, namespace, name,
 	continueId, continueDate string, labelFilters *models.LabelFilters,
 	creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 	fn func(resource models.Resource) error) error {
-	sb, err := db.buildResourceListQuery(queryCtx, kind, apiVersion, namespace, name,
+	sb, err := db.buildResourceListQuery(ctx, kind, apiVersion, namespace, name,
 		continueId, continueDate, labelFilters, creationTimestampAfter, creationTimestampBefore, limit)
 	if err != nil {
 		return err
 	}
-	return newQueryPerformer[models.Resource](db.db, db.flavor).performStreamQuery(queryCtx, iterCtx, sb, fn)
+	return newQueryPerformer[models.Resource](db.db, db.flavor).performStreamQuery(ctx, sb, fn)
 }
 
 type uuidKindDate struct {
@@ -168,7 +168,7 @@ func (db *sqlDatabaseImpl) getLogsForPodSelector(ctx context.Context, sb *sqlbui
 
 	resources, err := db.performResourceQuery(ctx, sb)
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve resource '%s/%s': %s", namespace, name, err.Error())
+		return nil, fmt.Errorf("could not retrieve resource '%s/%s': %w", namespace, name, err.Error())
 	}
 
 	if len(resources) == 0 {
@@ -179,7 +179,7 @@ func (db *sqlDatabaseImpl) getLogsForPodSelector(ctx context.Context, sb *sqlbui
 	var pod corev1.Pod
 	err = json.Unmarshal([]byte(resource.Data), &pod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize pod '%s/%s': %s", namespace, name, err.Error())
+		return nil, fmt.Errorf("failed to deserialize pod '%s/%s': %w", namespace, name, err.Error())
 	}
 
 	if containerName == "" {

--- a/pkg/database/sql/reader.go
+++ b/pkg/database/sql/reader.go
@@ -138,16 +138,16 @@ func (db *sqlDatabaseImpl) QueryResources(ctx context.Context, kind, apiVersion,
 	return db.performResourceQuery(ctx, sb)
 }
 
-func (db *sqlDatabaseImpl) StreamResources(ctx context.Context, kind, apiVersion, namespace, name,
+func (db *sqlDatabaseImpl) StreamResources(queryCtx, iterCtx context.Context, kind, apiVersion, namespace, name,
 	continueId, continueDate string, labelFilters *models.LabelFilters,
 	creationTimestampAfter, creationTimestampBefore *time.Time, limit int,
 	fn func(resource models.Resource) error) error {
-	sb, err := db.buildResourceListQuery(ctx, kind, apiVersion, namespace, name,
+	sb, err := db.buildResourceListQuery(queryCtx, kind, apiVersion, namespace, name,
 		continueId, continueDate, labelFilters, creationTimestampAfter, creationTimestampBefore, limit)
 	if err != nil {
 		return err
 	}
-	return newQueryPerformer[models.Resource](db.db, db.flavor).performStreamQuery(ctx, sb, fn)
+	return newQueryPerformer[models.Resource](db.db, db.flavor).performStreamQuery(queryCtx, iterCtx, sb, fn)
 }
 
 type uuidKindDate struct {

--- a/pkg/database/sql/reader.go
+++ b/pkg/database/sql/reader.go
@@ -168,7 +168,7 @@ func (db *sqlDatabaseImpl) getLogsForPodSelector(ctx context.Context, sb *sqlbui
 
 	resources, err := db.performResourceQuery(ctx, sb)
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve resource '%s/%s': %w", namespace, name, err.Error())
+		return nil, fmt.Errorf("could not retrieve resource '%s/%s': %w", namespace, name, err)
 	}
 
 	if len(resources) == 0 {
@@ -179,7 +179,7 @@ func (db *sqlDatabaseImpl) getLogsForPodSelector(ctx context.Context, sb *sqlbui
 	var pod corev1.Pod
 	err = json.Unmarshal([]byte(resource.Data), &pod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize pod '%s/%s': %w", namespace, name, err.Error())
+		return nil, fmt.Errorf("failed to deserialize pod '%s/%s': %w", namespace, name, err)
 	}
 
 	if containerName == "" {


### PR DESCRIPTION
Assisted-by: Claude

## Which Issue(s) this Pull Request Resolves

Resolves #1928

## Release Note

```release-note
These changes sets the timeout for database requests to prevent long-running queries to drain db connection pool. The timeout will be configured by KUBEARCHIVE_QUERY_TIMEOUT env variable and defaulted to 5 minutes.
```