### PR TITLE
feat(issue-1936):  Add database connection pool configuration

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,6 +14,7 @@
 ** xref:configuration/global-filters.adoc[Global Filters]
 ** xref:configuration/delayed-deletes.adoc[]
 ** xref:configuration/cache-expiration-time.adoc[Cache Expiration Time]
+** xref:configuration/database-connection-pool.adoc[Database Connection Pool]
 ** xref:configuration/observability.adoc[Observability]
 ** xref:configuration/impersonation.adoc[]
 ** xref:configuration/kubearchive-logs.adoc[]

--- a/docs/modules/ROOT/pages/configuration/database-connection-pool.adoc
+++ b/docs/modules/ROOT/pages/configuration/database-connection-pool.adoc
@@ -1,0 +1,92 @@
+= Database Connection Pool
+
+KubeArchive limits the number of concurrent connections each pod opens to the
+database. This prevents connection exhaustion errors when the application
+receives a high volume of requests.
+
+The following environment variables control connection pool behavior:
+
+* `DATABASE_MAX_OPEN_CONNS`: maximum number of open connections to the database.
+    If not set, the default value is **25**.
+* `DATABASE_MAX_IDLE_CONNS`: maximum number of idle connections kept in the pool.
+    If not set, the default value is **10**.
+* `DATABASE_CONN_MAX_LIFETIME`: maximum time a connection can be reused.
+    If not set, the default value is **5m** (5 minutes).
+* `DATABASE_CONN_MAX_IDLE_TIME`: maximum time a connection can remain idle before being closed.
+    If not set, the default value is **2m** (2 minutes).
+
+Duration values must be parseable by
+link:https://pkg.go.dev/time#ParseDuration[time.ParseDuration]
+(e.g. `5m`, `30s`, `2h`).
+
+[WARNING]
+====
+The `DATABASE_MAX_OPEN_CONNS` value is **per pod**. The total number of
+connections to the database is this value multiplied by the number of pods
+that access the database (by default: 2 API + 1 sink = 3 pods).
+
+Ensure the total does not exceed your database's `max_connections` setting
+(PostgreSQL default: 100).
+====
+
+To modify the connection pool settings, edit or patch the relevant Deployment
+in the `kubearchive` namespace:
+
+[source,yaml]
+----
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: kubearchive-api-server
+        env:
+        - name: DATABASE_MAX_OPEN_CONNS
+          value: "15"
+        - name: DATABASE_MAX_IDLE_CONNS
+          value: "7"
+        - name: DATABASE_CONN_MAX_LIFETIME
+          value: "10m"
+        - name: DATABASE_CONN_MAX_IDLE_TIME
+          value: "3m"
+----
+
+Apply the patch to both deployments that access the database:
+
+[source,bash]
+----
+kubectl patch -n kubearchive deployment kubearchive-api-server --patch-file path/to/patch.yaml
+kubectl patch -n kubearchive deployment kubearchive-sink --patch-file path/to/patch.yaml
+----
+
+[NOTE]
+====
+The same environment variables apply to both `kubearchive-api-server` and
+`kubearchive-sink` since both connect to the database. Ensure you configure
+both deployments consistently.
+====
+
+== Edge Cases
+
+* **Invalid, zero, or negative values**: If an environment variable is set to a
+  non-numeric string, an unparseable duration, zero, or a negative value, the
+  application logs a warning and falls back to the default. Zero is rejected
+  because in Go's `database/sql`, `SetMaxOpenConns(0)` means unlimited
+  connections and `SetConnMaxLifetime(0)` means connections are never recycled.
+
+* **Very high `DATABASE_MAX_OPEN_CONNS`**: Setting a large value (e.g. 1000)
+  effectively disables pool limiting and may exhaust the database's
+  `max_connections` (PostgreSQL default: 100), causing the same connection
+  errors this feature is designed to prevent.
+
+* **Very long `DATABASE_CONN_MAX_LIFETIME` or `DATABASE_CONN_MAX_IDLE_TIME`**:
+  Setting durations too high (e.g. hours or days) can lead to stale
+  connections that are not recycled after a database failover, network
+  interruption, or configuration change. The defaults (5m lifetime, 2m idle)
+  balance connection reuse with timely recovery.
+
+* **`DATABASE_MAX_IDLE_CONNS` greater than `DATABASE_MAX_OPEN_CONNS`**: The
+  idle count is capped internally by Go's `database/sql` to never exceed the
+  max open count. Setting a higher idle value has no effect.

--- a/pkg/database/env/environment.go
+++ b/pkg/database/env/environment.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 )
 
 const (
@@ -18,9 +19,24 @@ const (
 	DbPasswordEnvVar string = "DATABASE_PASSWORD" // nosec G101 not a password
 	DbHostEnvVar     string = "DATABASE_URL"
 	DbPortEnvVar     string = "DATABASE_PORT"
+
+	DbMaxOpenConnsEnvVar    string = "DATABASE_MAX_OPEN_CONNS"
+	DbMaxIdleConnsEnvVar    string = "DATABASE_MAX_IDLE_CONNS"
+	DbConnMaxLifetimeEnvVar string = "DATABASE_CONN_MAX_LIFETIME"
+	DbConnMaxIdleTimeEnvVar string = "DATABASE_CONN_MAX_IDLE_TIME"
+
+	// WARNING: These defaults assume a typical deployment of 2 API pods + 1 sink pod
+	// (3 pods × 25 connections = 75 total). If you override these via environment variables,
+	// ensure the total across all pods does not exceed your database's max_connections setting
+	// (PostgreSQL default: 100, max: 262,143).
+	DbDefaultMaxOpenConns    = 25
+	DbDefaultMaxIdleConns    = 10
+	DbDefaultConnMaxLifetime = 5 * time.Minute
+	DbDefaultConnMaxIdleTime = 2 * time.Minute
 )
 
 var DbEnvVars = [...]string{DbKindEnvVar, DbNameEnvVar, DbUserEnvVar, DbPasswordEnvVar, DbHostEnvVar, DbPortEnvVar}
+var DbPoolConnEnvVars = [...]string{DbMaxOpenConnsEnvVar, DbMaxIdleConnsEnvVar, DbConnMaxLifetimeEnvVar, DbConnMaxIdleTimeEnvVar}
 
 // Reads database connection info from the environment variables and returns a map of variable name to value.
 func NewDatabaseEnvironment() (map[string]string, error) {
@@ -34,9 +50,16 @@ func NewDatabaseEnvironment() (map[string]string, error) {
 			err = errors.Join(err, fmt.Errorf(dbConnectionErrStr, name))
 		}
 	}
-	if err == nil {
-		return env, nil
-	} else {
+	if err != nil {
 		return nil, err
 	}
+
+	for _, name := range DbPoolConnEnvVars {
+		value, exists := os.LookupEnv(name)
+		if exists {
+			env[name] = value
+		}
+	}
+
+	return env, nil
 }

--- a/pkg/database/sql/connection.go
+++ b/pkg/database/sql/connection.go
@@ -6,16 +6,18 @@ package sql
 import (
 	"database/sql"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/XSAM/otelsql"
 	"github.com/avast/retry-go/v5"
 	"github.com/jmoiron/sqlx"
+	"github.com/kubearchive/kubearchive/pkg/database/env"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-func establishConnection(driver, connectionString string) (*sqlx.DB, error) {
+func establishConnection(driver, connectionString string, dbEnv map[string]string) (*sqlx.DB, error) {
 	slog.Info("Establishing database connection")
 	configs := []retry.Option{
 		retry.Attempts(10),
@@ -39,12 +41,15 @@ func establishConnection(driver, connectionString string) (*sqlx.DB, error) {
 		return nil, errRetry
 	}
 
+	slog.Info("Successfully connected to the database")
+
+	configureConnectionPool(conn, dbEnv)
+
 	_, err = otelsql.RegisterDBStatsMetrics(conn, otelsql.WithAttributes(semconv.DBSystemKey.String(driver)))
 	if err != nil {
 		slog.Error("Unable to instrument the DB properly", "error", err.Error())
 		return nil, err
 	}
-	slog.Info("Successfully connected to the database")
 
 	// Extract connection info for logging
 	connectionInfo := extractConnectionInfo(driver, connectionString)
@@ -57,6 +62,63 @@ func establishConnection(driver, connectionString string) (*sqlx.DB, error) {
 		"ssl_mode", connectionInfo.sslMode,
 	)
 	return sqlx.NewDb(conn, driver), nil
+}
+
+func configureConnectionPool(db *sql.DB, dbEnv map[string]string) {
+	maxOpenConns := getEnvInt(dbEnv, env.DbMaxOpenConnsEnvVar, env.DbDefaultMaxOpenConns)
+	maxIdleConns := getEnvInt(dbEnv, env.DbMaxIdleConnsEnvVar, env.DbDefaultMaxIdleConns)
+	connMaxLifetime := getEnvDuration(dbEnv, env.DbConnMaxLifetimeEnvVar, env.DbDefaultConnMaxLifetime)
+	connMaxIdleTime := getEnvDuration(dbEnv, env.DbConnMaxIdleTimeEnvVar, env.DbDefaultConnMaxIdleTime)
+
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetConnMaxLifetime(connMaxLifetime)
+	db.SetConnMaxIdleTime(connMaxIdleTime)
+
+	slog.Info("Database connection pool configured",
+		"max_open_conns", maxOpenConns,
+		"max_idle_conns", maxIdleConns,
+		"conn_max_lifetime", connMaxLifetime,
+		"conn_max_idle_time", connMaxIdleTime,
+	)
+}
+
+func getEnvInt(dbEnv map[string]string, key string, defaultValue int) int {
+	val, exists := dbEnv[key]
+	if !exists || val == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.Atoi(val)
+	if err != nil {
+		slog.Warn("Invalid integer value for environment variable, using default",
+			"key", key, "value", val, "default", defaultValue)
+		return defaultValue
+	}
+	if parsed <= 0 {
+		slog.Warn("Zero or negative value for environment variable is not allowed, using default",
+			"key", key, "value", parsed, "default", defaultValue)
+		return defaultValue
+	}
+	return parsed
+}
+
+func getEnvDuration(dbEnv map[string]string, key string, defaultValue time.Duration) time.Duration {
+	val, exists := dbEnv[key]
+	if !exists || val == "" {
+		return defaultValue
+	}
+	parsed, err := time.ParseDuration(val)
+	if err != nil {
+		slog.Warn("Invalid duration value for environment variable, using default",
+			"key", key, "value", val, "default", defaultValue)
+		return defaultValue
+	}
+	if parsed <= 0 {
+		slog.Warn("Zero or negative duration for environment variable is not allowed, using default",
+			"key", key, "value", parsed, "default", defaultValue)
+		return defaultValue
+	}
+	return parsed
 }
 
 // connectionInfo holds parsed connection details for logging

--- a/pkg/database/sql/connection_test.go
+++ b/pkg/database/sql/connection_test.go
@@ -6,6 +6,7 @@ package sql
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractConnectionInfo(t *testing.T) {
@@ -102,5 +103,137 @@ func TestExtractConnectionInfoEdgeCases(t *testing.T) {
 	result = extractConnectionInfo("postgres", longString)
 	if result.user != "test" {
 		t.Errorf("Expected 'test' user for long connection string, got %s", result.user)
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue int
+		expected     int
+	}{
+		{
+			name:         "env not set returns default",
+			setEnv:       false,
+			defaultValue: 10,
+			expected:     10,
+		},
+		{
+			name:         "valid integer value",
+			envValue:     "20",
+			setEnv:       true,
+			defaultValue: 10,
+			expected:     20,
+		},
+		{
+			name:         "invalid integer value returns default",
+			envValue:     "not-a-number",
+			setEnv:       true,
+			defaultValue: 10,
+			expected:     10,
+		},
+		{
+			name:         "empty string returns default",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: 10,
+			expected:     10,
+		},
+		{
+			name:         "zero returns default",
+			envValue:     "0",
+			setEnv:       true,
+			defaultValue: 10,
+			expected:     10,
+		},
+		{
+			name:         "negative number returns default",
+			envValue:     "-10",
+			setEnv:       true,
+			defaultValue: 10,
+			expected:     10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := "TEST_GET_ENV_INT"
+			envMap := make(map[string]string)
+			if tt.setEnv {
+				envMap[key] = tt.envValue
+			}
+			got := getEnvInt(envMap, key, tt.defaultValue)
+			if got != tt.expected {
+				t.Errorf("getEnvInt() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetEnvDuration(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue time.Duration
+		expected     time.Duration
+	}{
+		{
+			name:         "env not set returns default",
+			setEnv:       false,
+			defaultValue: 5 * time.Minute,
+			expected:     5 * time.Minute,
+		},
+		{
+			name:         "valid duration value",
+			envValue:     "10m",
+			setEnv:       true,
+			defaultValue: 5 * time.Minute,
+			expected:     10 * time.Minute,
+		},
+		{
+			name:         "valid duration in seconds",
+			envValue:     "30s",
+			setEnv:       true,
+			defaultValue: 5 * time.Minute,
+			expected:     30 * time.Second,
+		},
+		{
+			name:         "invalid duration returns default",
+			envValue:     "not-a-duration",
+			setEnv:       true,
+			defaultValue: 5 * time.Minute,
+			expected:     5 * time.Minute,
+		},
+		{
+			name:         "empty string returns default",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: 5 * time.Minute,
+			expected:     5 * time.Minute,
+		},
+		{
+			name:         "negative duration returns default",
+			envValue:     "-5m",
+			setEnv:       true,
+			defaultValue: 5 * time.Minute,
+			expected:     5 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := "TEST_GET_ENV_DURATION"
+			envMap := make(map[string]string)
+			if tt.setEnv {
+				envMap[key] = tt.envValue
+			}
+			got := getEnvDuration(envMap, key, tt.defaultValue)
+			if got != tt.expected {
+				t.Errorf("getEnvDuration() = %v, want %v", got, tt.expected)
+			}
+		})
 	}
 }

--- a/pkg/database/sql/database.go
+++ b/pkg/database/sql/database.go
@@ -38,7 +38,7 @@ type sqlDatabaseImpl struct {
 }
 
 func (db *sqlDatabaseImpl) Init(env map[string]string) error {
-	conn, err := establishConnection(db.creator.GetDriverName(), db.creator.GetConnectionString(env))
+	conn, err := establishConnection(db.creator.GetDriverName(), db.creator.GetConnectionString(env), env)
 	if err != nil {
 		return err
 	}

--- a/test/integration/connection_pool_test.go
+++ b/test/integration/connection_pool_test.go
@@ -1,0 +1,231 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v5"
+	"github.com/kubearchive/kubearchive/pkg/database/env"
+	"github.com/kubearchive/kubearchive/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var dbDeployments = []string{"kubearchive-api-server", "kubearchive-sink"}
+
+func TestConnectionPoolDefaults(t *testing.T) {
+
+	for _, deployment := range dbDeployments {
+		t.Run(deployment, func(t *testing.T) {
+			logs, err := test.GetPodLogs(t, "kubearchive", deployment)
+			if err != nil {
+				t.Fatalf("Failed to get %s logs: %v", deployment, err)
+			}
+
+			expectedLog := "Database connection pool configured"
+			if !strings.Contains(logs, expectedLog) {
+				t.Fatalf("Expected log message %q not found in %s logs", expectedLog, deployment)
+			}
+
+			if !strings.Contains(logs, fmt.Sprintf("max_open_conns=%d", env.DbDefaultMaxOpenConns)) {
+				t.Errorf("Expected default max_open_conns=%d in logs", env.DbDefaultMaxOpenConns)
+			}
+			if !strings.Contains(logs, fmt.Sprintf("max_idle_conns=%d", env.DbDefaultMaxIdleConns)) {
+				t.Errorf("Expected default max_idle_conns=%d in logs", env.DbDefaultMaxIdleConns)
+			}
+			if !strings.Contains(logs, fmt.Sprintf("conn_max_lifetime=%s", env.DbDefaultConnMaxLifetime)) {
+				t.Errorf("Expected default conn_max_lifetime=%s in logs", env.DbDefaultConnMaxLifetime)
+			}
+			if !strings.Contains(logs, fmt.Sprintf("conn_max_idle_time=%s", env.DbDefaultConnMaxIdleTime)) {
+				t.Errorf("Expected default conn_max_idle_time=%s in logs", env.DbDefaultConnMaxIdleTime)
+			}
+		})
+	}
+}
+
+func TestConnectionPoolCustomValues(t *testing.T) {
+	clientset, _ := test.GetKubernetesClient(t)
+
+	saveAndRestoreDeploymentEnvs(t, clientset)
+
+	customEnvVars := map[string]string{
+		"DATABASE_MAX_OPEN_CONNS":     "15",
+		"DATABASE_MAX_IDLE_CONNS":     "7",
+		"DATABASE_CONN_MAX_LIFETIME":  "10m",
+		"DATABASE_CONN_MAX_IDLE_TIME": "3m",
+	}
+
+	for _, name := range dbDeployments {
+		setDeploymentEnvVar(t, clientset, name, customEnvVars)
+		waitForDeploymentReady(t, name)
+	}
+
+	for _, name := range dbDeployments {
+		t.Run(name, func(t *testing.T) {
+			logs := waitForLogMessage(t, name, "max_open_conns=15")
+
+			if !strings.Contains(logs, "max_idle_conns=7") {
+				t.Error("Expected max_idle_conns=7 in logs")
+			}
+			if !strings.Contains(logs, "conn_max_lifetime=10m0s") {
+				t.Error("Expected conn_max_lifetime=10m0s in logs")
+			}
+			if !strings.Contains(logs, "conn_max_idle_time=3m0s") {
+				t.Error("Expected conn_max_idle_time=3m0s in logs")
+			}
+		})
+	}
+}
+
+func TestConnectionPoolRejectsInvalidValues(t *testing.T) {
+	clientset, _ := test.GetKubernetesClient(t)
+
+	saveAndRestoreDeploymentEnvs(t, clientset)
+
+	invalidEnvVars := map[string]string{
+		"DATABASE_MAX_OPEN_CONNS": "-10",
+	}
+
+	for _, name := range dbDeployments {
+		setDeploymentEnvVar(t, clientset, name, invalidEnvVars)
+		waitForDeploymentReady(t, name)
+	}
+
+	for _, name := range dbDeployments {
+		t.Run(name, func(t *testing.T) {
+			logs := waitForLogMessage(t, name, "Zero or negative value for environment variable is not allowed")
+
+			if !strings.Contains(logs, fmt.Sprintf("max_open_conns=%d", env.DbDefaultMaxOpenConns)) {
+				t.Errorf("Expected fallback to default max_open_conns=%d in logs", env.DbDefaultMaxOpenConns)
+			}
+		})
+	}
+}
+
+// saveAndRestoreDeploymentEnvs saves the current env vars for all DB deployments
+// and registers a t.Cleanup that restores them when the test finishes.
+func saveAndRestoreDeploymentEnvs(t testing.TB, clientset *kubernetes.Clientset) {
+	t.Helper()
+	ctx := context.Background()
+
+	originalEnvs := make(map[string][]corev1.EnvVar)
+	for _, name := range dbDeployments {
+		dep, err := clientset.AppsV1().Deployments("kubearchive").Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get deployment %s: %v", name, err)
+		}
+		originalEnvs[name] = dep.Spec.Template.Spec.Containers[0].Env
+	}
+
+	t.Cleanup(func() {
+		t.Log("Restoring original environment variables")
+		for _, name := range dbDeployments {
+			dep, cleanupErr := clientset.AppsV1().Deployments("kubearchive").Get(ctx, name, metav1.GetOptions{})
+			if cleanupErr != nil {
+				t.Logf("Failed to get deployment %s for cleanup: %v", name, cleanupErr)
+				continue
+			}
+			dep.Spec.Template.Spec.Containers[0].Env = originalEnvs[name]
+			_, cleanupErr = clientset.AppsV1().Deployments("kubearchive").Update(ctx, dep, metav1.UpdateOptions{})
+			if cleanupErr != nil {
+				t.Logf("Failed to restore deployment %s: %v", name, cleanupErr)
+				continue
+			}
+			waitForDeploymentReady(t, name)
+		}
+	})
+}
+
+func setDeploymentEnvVar(t testing.TB, clientset *kubernetes.Clientset, deploymentName string, envVars map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+
+	deployment, err := clientset.AppsV1().Deployments("kubearchive").Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get deployment %s: %v", deploymentName, err)
+	}
+
+	container := &deployment.Spec.Template.Spec.Containers[0]
+	for key, value := range envVars {
+		found := false
+		for i, env := range container.Env {
+			if env.Name == key {
+				container.Env[i].Value = value
+				found = true
+				break
+			}
+		}
+		if !found {
+			container.Env = append(container.Env, corev1.EnvVar{Name: key, Value: value})
+		}
+	}
+
+	_, err = clientset.AppsV1().Deployments("kubearchive").Update(ctx, deployment, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update deployment %s: %v", deploymentName, err)
+	}
+}
+
+func waitForLogMessage(t testing.TB, deploymentName string, expectedMsg string) string {
+	t.Helper()
+	var logs string
+	err := retry.New(retry.Attempts(20), retry.MaxDelay(3*time.Second)).Do(func() error {
+		var logErr error
+		logs, logErr = test.GetPodLogs(t, "kubearchive", deploymentName)
+		if logErr != nil {
+			return logErr
+		}
+		if !strings.Contains(logs, expectedMsg) {
+			return fmt.Errorf("expected %q not found in %s logs yet", expectedMsg, deploymentName)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for %q in %s logs: %v", expectedMsg, deploymentName, err)
+	}
+	return logs
+}
+
+func waitForDeploymentReady(t testing.TB, deploymentName string) {
+	t.Helper()
+	clientset, _ := test.GetKubernetesClient(t)
+	ctx := context.Background()
+
+	// Get the deployment's current generation to wait for the rollout to complete
+	deployment, err := clientset.AppsV1().Deployments("kubearchive").Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get deployment %s: %v", deploymentName, err)
+	}
+	expectedGeneration := deployment.Generation
+
+	retryErr := retry.New(retry.Attempts(60), retry.MaxDelay(3*time.Second)).Do(func() error {
+		dep, retryErr := clientset.AppsV1().Deployments("kubearchive").Get(ctx, deploymentName, metav1.GetOptions{})
+		if retryErr != nil {
+			return retryErr
+		}
+		if dep.Status.ObservedGeneration < expectedGeneration {
+			return fmt.Errorf("deployment %s rollout not observed yet", deploymentName)
+		}
+		if dep.Status.UpdatedReplicas < *dep.Spec.Replicas {
+			return fmt.Errorf("deployment %s waiting for updated replicas", deploymentName)
+		}
+		if dep.Status.AvailableReplicas < *dep.Spec.Replicas {
+			return fmt.Errorf("deployment %s waiting for available replicas", deploymentName)
+		}
+		if dep.Status.UnavailableReplicas > 0 {
+			return fmt.Errorf("deployment %s has unavailable replicas", deploymentName)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		t.Fatalf("Timed out waiting for deployment %s to be ready: %v", deploymentName, retryErr)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #1936 

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
- Added database connection pool configuration to prevent connection exhaustion.
- Each pod now limits open connections (default: 10) and idle connections (default: 5).
- Configurable via environment variables:
DATABASE_MAX_OPEN_CONNS
DATABASE_MAX_IDLE_CONNS 
DATABASE_CONN_MAX_LIFETIME
DATABASE_CONN_MAX_IDLE_TIME

```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Assisted-by: Cursor (Claude Opus 4.6 High).
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
