### PR TITLE
Add Codecov coverage upload to unit test workflow

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,3 +18,13 @@ coverage:
 comment:
   layout: "reach,diff,flags,files,footer"
   require_changes: true
+
+flags:
+  unit-tests:
+    carryforward: true
+
+ignore:
+  - "test/**"
+  - "hack/**"
+  - "config/**"
+  - "**/zz_generated*.go"

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  id-token: write
 jobs:
   gotest:
     name: "Golang testing"
@@ -35,4 +36,11 @@ jobs:
       - name: Test Go code
         run: |
           export KUBEBUILDER_ASSETS=${PWD}/`cmd/operator/bin/setup-envtest use --bin-dir cmd/operator/bin -p path`
-          go test -v ./...
+          go test -v -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.out
+          fail_ci_if_error: false


### PR DESCRIPTION
Adds Codecov unit test coverage upload to the go_test workflow.

- Adds '-coverprofile' flag to 'go test' to generate coverage.out
- Uploads to app.codecov.io via OIDC (no token needed)
- Uses 'unit-tests' flag for categorization
- Updates .codecov.yml with flags config and ignore patterns

Resolves #1972 

May require a Codecov admin to enable GitHub OIDC for this repo in the Codecov UI https://app.codecov.io/github/kubearchive
