### PR TITLE
feat(KAR-887): Exclude Fullsend bot actors from CI workflows

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     name: assign and unassign reviewers
     runs-on: ubuntu-latest
-    if: github.actor != 'kubearchive-renovate[bot]'
+    if: github.actor != 'kubearchive-renovate[bot]' && !startsWith(github.actor, 'fullsend-ai-')
     steps:
       - name: Assign reviewers by label
         id: assign-reviewers

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     name: Check if required labels are assigned to the PR
-    if: github.actor != 'kubearchive-renovate[bot]'
+    if: github.actor != 'kubearchive-renovate[bot]' && !startsWith(github.actor, 'fullsend-ai-')
     steps:
       - name: Check labels
         id: check-labels

--- a/.github/workflows/copy-labels.yml
+++ b/.github/workflows/copy-labels.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     name: Copy labels from linked issues
-    if: github.actor != 'kubearchive-renovate[bot]'
+    if: github.actor != 'kubearchive-renovate[bot]' && !startsWith(github.actor, 'fullsend-ai-')
     steps:
       - name: Copy labels
         id: copy-labels
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     name: Add assignee to the PR
-    if: github.actor != 'kubearchive-renovate[bot]'
+    if: github.actor != 'kubearchive-renovate[bot]' && !startsWith(github.actor, 'fullsend-ai-')
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
@@ -57,7 +57,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     name: Check issue linked to PR
-    if: github.actor != 'kubearchive-renovate[bot]'
+    if: github.actor != 'kubearchive-renovate[bot]' && !startsWith(github.actor, 'fullsend-ai-')
     steps:
       - name: Get linked issues
         id: get-linked-issues


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Related to #KAR-887

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
NONE
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
Part of the Fullsend installation on kubearchive/kubearchive. Fullsend deploys AI agents that open and interact with PRs automatically. This PR excludes those bot actors from CI workflows that are not relevant to automated PRs, preventing unnecessary failures and noisy assignments.
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
