### PR TITLE
feat(issue-444): add integration test and docs for database password rotation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,6 +16,7 @@ Install these tools:
 1. [`podman`](https://podman.io/docs/installation)
 1. [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/)
 1. [`yq`](https://github.com/mikefarah/yq/)
+1. [`jq`](https://jqlang.org/download/)
 1. [`migrate`](https://github.com/golang-migrate/migrate)
 
 ## Creating a fork repository

--- a/config/templates/database/database_secret.yaml
+++ b/config/templates/database/database_secret.yaml
@@ -11,10 +11,10 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/part-of: kubearchive
     app.kubernetes.io/version: "${NEXT_VERSION}"
-data:
-  DATABASE_KIND: cG9zdGdyZXNxbA==
-  DATABASE_PORT: "NTQzMg=="
-  DATABASE_URL: "a3ViZWFyY2hpdmUtcncucG9zdGdyZXNxbC5zdmMuY2x1c3Rlci5sb2NhbA=="
-  DATABASE_DB: "a3ViZWFyY2hpdmU="
-  DATABASE_USER: "a3ViZWFyY2hpdmU="
-  DATABASE_PASSWORD: "RGF0IWFiYXNdM1Bhc3MqdzByZA=="  # notsecret
+stringData:
+  DATABASE_KIND: ""
+  DATABASE_PORT: ""
+  DATABASE_URL: ""
+  DATABASE_DB: ""
+  DATABASE_USER: ""
+  DATABASE_PASSWORD: ""

--- a/docs/modules/ROOT/pages/integrations/database.adoc
+++ b/docs/modules/ROOT/pages/integrations/database.adoc
@@ -70,7 +70,7 @@ psql -U admin \ <1>
 
 The `kubearchive-database-credentials` Secret stores the information to connect KubeArchive with the Database.
 
-The default content of this Secret when KubeArchive is installed is:
+The Secret ships with empty values and must be populated before KubeArchive can connect to the database:
 
 [source, yaml]
 ----
@@ -80,17 +80,17 @@ metadata:
   name: kubearchive-database-credentials
   namespace: kubearchive
 stringData:
-  DATABASE_KIND: postgresql
-  DATABASE_PORT: "5432"
-  DATABASE_URL: "kubearchive-rw.postgresql.svc.cluster.local"
-  DATABASE_DB: "kubearchive"
-  DATABASE_USER: "kubearchive"
-  DATABASE_PASSWORD: "Databas3Passw0rd"  # notsecret
+  DATABASE_KIND: ""
+  DATABASE_PORT: ""
+  DATABASE_URL: ""
+  DATABASE_DB: ""
+  DATABASE_USER: ""
+  DATABASE_PASSWORD: ""
 ----
 
-Update the secret with the specific values of your database and
+Populate the secret with the specific values of your database and
 restart the pods accordingly to pick the new values.
-The command for changing the most common values, URL and password, is:
+The command for setting the most common values, URL and password, is:
 
 [source, bash]
 ----

--- a/docs/modules/ROOT/pages/integrations/database.adoc
+++ b/docs/modules/ROOT/pages/integrations/database.adoc
@@ -119,6 +119,49 @@ kubectl rollout -n kubearchive restart deployment kubearchive-sink kubearchive-a
 ----
 ====
 
+=== Password Rotation
+
+To rotate the password of the `kubearchive` database user, follow these steps:
+
+. Change the password on the database side. A database administrator should
+update the `kubearchive` user password. For PostgreSQL:
++
+[source, sql]
+----
+ALTER USER kubearchive WITH PASSWORD 'new-password'; -- <1>
+----
+<1> Replace with the new password.
+
+. Update the `kubearchive-database-credentials` Secret in the `kubearchive` namespace:
++
+[source, bash]
+----
+kubectl patch secret -n kubearchive kubearchive-database-credentials \
+--patch='{"stringData": {
+"DATABASE_PASSWORD": "new-password" <1>
+}}'
+----
+<1> Replace with the new password.
+
+. Rollout restart the KubeArchive deployments that access the database:
++
+[source, bash]
+----
+kubectl rollout -n kubearchive restart deployment kubearchive-sink kubearchive-api-server
+----
+
+. Verify that the deployments are running correctly:
++
+[source, bash]
+----
+kubectl rollout -n kubearchive status deployment kubearchive-sink kubearchive-api-server
+----
+
+[IMPORTANT]
+====
+Both the database password and the Kubernetes Secret must be updated to match.
+If they are out of sync, the KubeArchive components will fail to connect to the database.
+====
 
 == Adding a New Database engine
 

--- a/hack/kubearchive-install.sh
+++ b/hack/kubearchive-install.sh
@@ -11,6 +11,11 @@ set -o xtrace
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${SCRIPT_DIR}/..
 
+if ! command -v jq &> /dev/null; then
+  echo "[ERROR] jq is required but not installed. Please install jq and try again."
+  exit 1
+fi
+
 PODS=$(kubectl -n kubearchive get pods | grep -E -v "NAME|No resources|apiserversource" |& awk '{print $1}')
 
 # Extract the release version
@@ -22,7 +27,49 @@ bash cmd/operator/generate.sh
 bash cmd/installer/generate.sh
 # Delete the migration job if it already exists because Job specs are immutable.
 kubectl -n kubearchive delete job kubearchive-schema-migration --ignore-not-found
-kubectl kustomize config/ | envsubst '$NEXT_VERSION' | ko apply --tags latest-build -f - --base-import-paths
+# Save database credentials before ko apply overwrites the Secret with empty values.
+# xtrace is disabled here to avoid printing credentials to logs.
+{ set +x; } 2>/dev/null
+DB_KIND=$(kubectl get secret -n kubearchive kubearchive-database-credentials \
+  -o jsonpath='{.data.DATABASE_KIND}' 2>/dev/null | base64 --decode || true)
+DB_URL=$(kubectl get secret -n kubearchive kubearchive-database-credentials \
+  -o jsonpath='{.data.DATABASE_URL}' 2>/dev/null | base64 --decode || true)
+DB_PORT=$(kubectl get secret -n kubearchive kubearchive-database-credentials \
+  -o jsonpath='{.data.DATABASE_PORT}' 2>/dev/null | base64 --decode || true)
+DB_DB=$(kubectl get secret -n kubearchive kubearchive-database-credentials \
+  -o jsonpath='{.data.DATABASE_DB}' 2>/dev/null | base64 --decode || true)
+DB_USER=$(kubectl get secret -n kubearchive kubearchive-database-credentials \
+  -o jsonpath='{.data.DATABASE_USER}' 2>/dev/null | base64 --decode || true)
+DB_PASSWORD=$(kubectl get secret -n kubearchive kubearchive-database-credentials \
+  -o jsonpath='{.data.DATABASE_PASSWORD}' 2>/dev/null | base64 --decode || true)
+set -o xtrace
+
+# Run ko apply and capture its exit code without triggering errexit, so that
+# credential restore always runs even if ko apply fails.
+kubectl kustomize config/ | envsubst '$NEXT_VERSION' | ko apply --tags latest-build -f - --base-import-paths || KO_EXIT_CODE=$?
+
+# Restore credentials if they were set before ko apply.
+PATCH_FILE=$(mktemp)
+trap 'rm -f "${PATCH_FILE}"' EXIT
+{ set +x; } 2>/dev/null
+if [ -n "${DB_PASSWORD}" ]; then
+  jq -n \
+    --arg kind "${DB_KIND}" \
+    --arg url "${DB_URL}" \
+    --arg port "${DB_PORT}" \
+    --arg db "${DB_DB}" \
+    --arg user "${DB_USER}" \
+    --arg password "${DB_PASSWORD}" \
+    '{"stringData": {"DATABASE_KIND": $kind, "DATABASE_URL": $url, "DATABASE_PORT": $port, "DATABASE_DB": $db, "DATABASE_USER": $user, "DATABASE_PASSWORD": $password}}' > "${PATCH_FILE}"
+  kubectl patch -n kubearchive secret kubearchive-database-credentials --patch-file "${PATCH_FILE}"
+fi
+unset DB_KIND DB_URL DB_PORT DB_DB DB_USER DB_PASSWORD
+set -o xtrace
+
+# Propagate ko apply failure after credentials have been safely restored.
+if [ -n "${KO_EXIT_CODE:-}" ]; then
+  exit "${KO_EXIT_CODE}"
+fi
 
 kubectl -n kubearchive rollout status deployment --timeout=90s
 

--- a/integrations/database/postgresql/install.sh
+++ b/integrations/database/postgresql/install.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd ${SCRIPT_DIR}
 
+if ! command -v jq &> /dev/null; then
+  echo "[ERROR] jq is required but not installed. Please install jq and try again."
+  exit 1
+fi
+
 # renovate: datasource=github-releases depName=cloudnative-pg packageName=cloudnative-pg/cloudnative-pg
 VERSION=1.24.1
 NAMESPACE="postgresql"
@@ -78,6 +83,23 @@ export NEXT_VERSION="${NEXT_VERSION:-$(cat "${REPO_ROOT}/VERSION")}"
 kubectl create ns kubearchive --dry-run=client -o yaml | kubectl apply -f -
 envsubst '$NEXT_VERSION' < "${REPO_ROOT}/config/templates/database/database_secret.yaml" \
   | kubectl -n kubearchive apply -f -
+
+# Populate the database credentials.
+# The Secret ships with empty values; the actual credentials are set here.
+# The values below match the kubearchive user created in setup.sql.
+echo "[INFO] Patching kubearchive-database-credentials secret..."
+DB_PASSWORD="Dat!abas]3Pass*w0rd" # notsecret - matches setup.sql
+PATCH_FILE=$(mktemp)
+trap 'rm -f "${PATCH_FILE}"' EXIT
+jq -n \
+  --arg kind "postgresql" \
+  --arg url "${SERVICE}.${NAMESPACE}.svc.cluster.local" \
+  --arg port "${REMOTE_PORT}" \
+  --arg db "kubearchive" \
+  --arg user "kubearchive" \
+  --arg password "${DB_PASSWORD}" \
+  '{"stringData": {"DATABASE_KIND": $kind, "DATABASE_URL": $url, "DATABASE_PORT": $port, "DATABASE_DB": $db, "DATABASE_USER": $user, "DATABASE_PASSWORD": $password}}' > "${PATCH_FILE}"
+kubectl patch -n kubearchive secret kubearchive-database-credentials --patch-file "${PATCH_FILE}"
 
 # Build the migration image and deploy the Job
 # ko reads .ko.yaml from the working directory, so run from the repo root.

--- a/test/integration/password_rotation_test.go
+++ b/test/integration/password_rotation_test.go
@@ -1,0 +1,220 @@
+// Copyright KubeArchive Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v5"
+	"github.com/kubearchive/kubearchive/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// TestPasswordRotation verifies that database password rotation works correctly.
+//
+// Prerequisite (external to KubeArchive):
+//   - The database administrator changes the kubearchive user password in PostgreSQL.
+//
+// KubeArchive user procedure:
+//  1. Update the kubearchive-database-credentials Secret with the new password.
+//  2. Rollout restart kubearchive-sink and kubearchive-api-server.
+//  3. Verify the components reconnect successfully with the new credentials.
+func TestPasswordRotation(t *testing.T) {
+	clientset, _ := test.GetKubernetesClient(t)
+	ctx := context.Background()
+
+	secret, err := clientset.CoreV1().Secrets("kubearchive").Get(ctx, "kubearchive-database-credentials", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get kubearchive-database-credentials secret: %v", err)
+	}
+	originalPassword := string(secret.Data["DATABASE_PASSWORD"])
+	t.Logf("Retrieved original database password from Secret")
+
+	newPassword := "Rotated-P@ss-" + test.RandomString()
+
+	// Register cleanup steps as separate t.Cleanup calls so each runs
+	// independently (LIFO order) even if a previous one fails.
+	t.Cleanup(func() {
+		waitForLogMessage(t, "kubearchive-api-server", "Successfully connected to the database")
+	})
+	t.Cleanup(func() {
+		waitForLogMessage(t, "kubearchive-sink", "Successfully connected to the database")
+	})
+	t.Cleanup(func() {
+		scaleRestartDeployment(t, clientset, "kubearchive-api-server")
+	})
+	t.Cleanup(func() {
+		scaleRestartDeployment(t, clientset, "kubearchive-sink")
+	})
+	t.Cleanup(func() {
+		setDatabasePassword(t, clientset, originalPassword)
+	})
+	t.Cleanup(func() {
+		t.Log("Restoring original database password")
+		alterDatabasePassword(t, clientset, originalPassword)
+	})
+
+	// Prerequisite: database administrator changes the password in PostgreSQL
+	t.Log("Prerequisite: changing database password in PostgreSQL")
+	alterDatabasePassword(t, clientset, newPassword)
+
+	// Step 1: update the kubearchive-database-credentials Secret
+	t.Log("Step 1: updating kubearchive-database-credentials Secret")
+	setDatabasePassword(t, clientset, newPassword)
+
+	// Step 2: rollout restart the KubeArchive deployments
+	t.Log("Step 2: restarting kubearchive-sink")
+	scaleRestartDeployment(t, clientset, "kubearchive-sink")
+	t.Log("Step 2: restarting kubearchive-api-server")
+	scaleRestartDeployment(t, clientset, "kubearchive-api-server")
+
+	// Step 3: verify the components reconnect with the new credentials
+	t.Log("Step 3: waiting for sink to connect to the database with the new password")
+	waitForLogMessage(t, "kubearchive-sink", "Successfully connected to the database")
+	t.Log("Step 3: waiting for api-server to connect to the database with the new password")
+	waitForLogMessage(t, "kubearchive-api-server", "Successfully connected to the database")
+}
+
+// alterDatabasePassword changes the kubearchive database user password by
+// executing ALTER USER via psql in the PostgreSQL pod.
+func alterDatabasePassword(t testing.TB, clientset *kubernetes.Clientset, password string) {
+	t.Helper()
+
+	config, err := test.GetKubernetesConfig()
+	if err != nil {
+		t.Fatalf("Failed to get Kubernetes config: %v", err)
+	}
+
+	podName := test.GetPodName(t, clientset, "postgresql", "kubearchive-")
+	if podName == "" {
+		t.Fatal("Could not find PostgreSQL pod in namespace 'postgresql'")
+	}
+
+	escapedPassword := strings.ReplaceAll(password, "'", "''")
+	cmd := []string{"psql", "-U", "postgres", "-c", fmt.Sprintf("ALTER USER kubearchive WITH PASSWORD '%s'", escapedPassword)}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace("postgresql").
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Command: cmd,
+			Stdout:  true,
+			Stderr:  true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		t.Fatalf("Failed to create SPDY executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	execCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err = executor.StreamWithContext(execCtx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Failed to execute ALTER USER: %v, stderr: %s", err, stderr.String())
+	}
+
+	t.Logf("ALTER USER result: %s", strings.TrimSpace(stdout.String()))
+}
+
+// setDatabasePassword updates the DATABASE_PASSWORD in the kubearchive-database-credentials Secret.
+func setDatabasePassword(t testing.TB, clientset *kubernetes.Clientset, password string) {
+	t.Helper()
+	ctx := context.Background()
+
+	secret, err := clientset.CoreV1().Secrets("kubearchive").Get(ctx, "kubearchive-database-credentials", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+
+	secret.Data["DATABASE_PASSWORD"] = []byte(password)
+
+	_, err = clientset.CoreV1().Secrets("kubearchive").Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to update secret: %v", err)
+	}
+
+	// Verify the Secret was updated correctly
+	updated, err := clientset.CoreV1().Secrets("kubearchive").Get(ctx, "kubearchive-database-credentials", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to verify updated secret: %v", err)
+	}
+	if string(updated.Data["DATABASE_PASSWORD"]) != password {
+		t.Fatal("Secret password mismatch after update")
+	}
+	t.Log("Secret updated successfully")
+}
+
+// scaleRestartDeployment restarts a deployment by scaling it to 0 and back
+// to its original replica count, waiting for the old pods to terminate and
+// new pods to be created.
+func scaleRestartDeployment(t testing.TB, clientset *kubernetes.Clientset, deploymentName string) {
+	t.Helper()
+	ctx := context.Background()
+
+	labelSelector := fmt.Sprintf("app=%s", deploymentName)
+
+	scale, err := clientset.AppsV1().Deployments("kubearchive").GetScale(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get scale for %s: %v", deploymentName, err)
+	}
+	originalReplicas := scale.Spec.Replicas
+
+	// Scale to 0
+	scaleCopy := *scale
+	scaleCopy.Spec.Replicas = 0
+	_, err = clientset.AppsV1().Deployments("kubearchive").UpdateScale(ctx, deploymentName, &scaleCopy, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to scale %s to 0: %v", deploymentName, err)
+	}
+	t.Logf("Scaled %s to 0 replicas", deploymentName)
+
+	// Wait for all pods to disappear
+	err = retry.New(retry.Attempts(30), retry.MaxDelay(2*time.Second)).Do(func() error {
+		pods, listErr := clientset.CoreV1().Pods("kubearchive").List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if listErr != nil {
+			return listErr
+		}
+		if len(pods.Items) > 0 {
+			return fmt.Errorf("%s still has %d pod(s)", deploymentName, len(pods.Items))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for %s pods to terminate: %v", deploymentName, err)
+	}
+
+	// Scale back to the original replica count
+	scale, err = clientset.AppsV1().Deployments("kubearchive").GetScale(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get scale for %s: %v", deploymentName, err)
+	}
+	scaleCopy = *scale
+	scaleCopy.Spec.Replicas = originalReplicas
+	_, err = clientset.AppsV1().Deployments("kubearchive").UpdateScale(ctx, deploymentName, &scaleCopy, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to scale %s to %d: %v", deploymentName, originalReplicas, err)
+	}
+	t.Logf("Scaled %s to %d replicas", deploymentName, originalReplicas)
+
+	waitForDeploymentReady(t, deploymentName)
+}

--- a/test/integration/password_rotation_test.go
+++ b/test/integration/password_rotation_test.go
@@ -39,6 +39,9 @@ func TestPasswordRotation(t *testing.T) {
 		t.Fatalf("Failed to get kubearchive-database-credentials secret: %v", err)
 	}
 	originalPassword := string(secret.Data["DATABASE_PASSWORD"])
+	if originalPassword == "" {
+		t.Fatal("kubearchive-database-credentials secret has no DATABASE_PASSWORD set, cannot proceed with password rotation test")
+	}
 	t.Logf("Retrieved original database password from Secret")
 
 	newPassword := "Rotated-P@ss-" + test.RandomString()
@@ -73,7 +76,10 @@ func TestPasswordRotation(t *testing.T) {
 	t.Log("Step 1: updating kubearchive-database-credentials Secret")
 	setDatabasePassword(t, clientset, newPassword)
 
-	// Step 2: rollout restart the KubeArchive deployments
+	// Step 2: rollout restart the KubeArchive deployments.
+	// scaleRestartDeployment scales to zero first, guaranteeing entirely new pods with fresh logs.
+	// This makes the waitForLogMessage assertion in Step 3 unambiguous. If the restart strategy
+	// is ever changed to a rolling restart, a SinceTime filter must be added to waitForLogMessage.
 	t.Log("Step 2: restarting kubearchive-sink")
 	scaleRestartDeployment(t, clientset, "kubearchive-sink")
 	t.Log("Step 2: restarting kubearchive-api-server")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please read our contributor guidelines:
https://kubearchive.github.io/kubearchive/main/contributors/guide.html
-->

## Which Issue(s) this Pull Request Resolves
<!-- Please make sure to create an issue you can link to and mention it here
to automatically close it. If this PR covers part of the work, instead of
"Resolves #", use "Related to #"

Usage: `Resolves #<issue number>`, or `Resolves (paste link of issue)`.

If the issue resolve more than one issue, repeat the verb: `Resolves #<issue number>, resolves #<issue number>`
-->

Resolves #444 , resolves #1826

## Release Note
<!--
If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other KubeArchive contributors.
If this change has no user-visible impact, leave the code block as is.

See
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_writing_release_notes
for guidelines on how to write Release Notes.
-->

```release-note
issue-444: Add integration test and documentation for database password rotation. Validates rotating the kubearchive database user password by updating the Secret and restarting the deployments. Documents the step-by-step procedure in the database integrations page.

issue-1826: Remove placeholder values from kubearchive-database-credentials Secret. The Secret now ships with empty values to prevent false credential leak alerts. Credentials are populated at install time by the PostgreSQL integration script.
```

## Notes for Reviewers
<!--
Leave notes for the reviewers if you want to point their attention to some
specific place.
-->
This PR addresses two issues:
issue-444: Database password rotation
Adds an integration test that validates the full password rotation procedure: changing the database user password in PostgreSQL, updating the kubearchive-database-credentials Secret, and rolling out the affected deployments.
Adds a "Password Rotation" section to the database integrations documentation with step-by-step instructions.

issue-1826: Remove placeholder values from kubearchive-database-credentials Secret
The Secret now ships with empty values instead of placeholder credentials, matching the pattern used by kubearchive-logging.
The postgresql/install.sh script patches the Secret with real credentials after creation.
The Secret is removed from the kustomize manifest so ko apply never overwrites it.

Assisted-by: Cursor (Claude Opus 4.6 High).
<!--
Please label this pull request according to what type of issue you are addressing.
For reference on required PR/issue labels, read here:
https://kubearchive.github.io/kubearchive/main/contributors/release.html#_pull_request_labels

The labels from the linked issues are copied, but make sure at least one of the following labels
are in place after creating the issue:
kind/bug
kind/documentation
kind/feature

Optionally add one or more of the following kinds if applicable:
kind/breaking
-->
