### PR TITLE
docs: use absolute KUBEBUILDER_ASSETS path in test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Container images are built with `ko` (`.ko.yaml`). There is no Makefile.
 Unit tests require envtest binaries for operator controllers:
 
 ```bash
-export KUBEBUILDER_ASSETS=$(cmd/operator/bin/setup-envtest use --bin-dir cmd/operator/bin -p path)
+export KUBEBUILDER_ASSETS=${PWD}/$(cmd/operator/bin/setup-envtest use --bin-dir cmd/operator/bin -p path)
 go test ./...
 ```
 


### PR DESCRIPTION
setup-envtest emits a repo-relative path, but go test runs each package's test binary from its own source directory, so a relative KUBEBUILDER_ASSETS cannot locate the envtest binaries. Prefix with ${PWD} to match CI.
